### PR TITLE
wn-32, 33: tests, checks, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Right now the repo has:
 - **`ingest/`** – Reserved for data ingest pipelines (FIRMS, weather, terrain, etc.).
 - **`infra/`** – Docker Compose and infra docs for running the full stack locally.
 
-If you want the deep product/ML vision and original longform overview, see `docs/WILDFIRE_NOWCAST_101.md`. For a full from-scratch setup (prerequisites, `.env`, `make` workflows) see [`docs/SETUP.md`](docs/SETUP.md). For navigation to all docs, start at [`docs/README.md`](docs/README.md).
+If you want the deep product/ML vision and original longform overview, see `docs/WILDFIRE_NOWCAST_101.md`. For grid/terrain conventions and alignment guarantees, see [`docs/terrain_grid.md`](docs/terrain_grid.md) (and `docs/grid_choice.md`). For a full from-scratch setup (prerequisites, `.env`, `make` workflows) see [`docs/SETUP.md`](docs/SETUP.md). For navigation to all docs, start at [`docs/README.md`](docs/README.md).
 
 ---
 

--- a/api/core/grid.py
+++ b/api/core/grid.py
@@ -10,6 +10,10 @@ Conventions (analysis order)
   cell **edges**. Coordinate outputs (`grid_coords`, `index_to_latlon`,
   `window_coords`) return **cell centers**.
 
+Contributor docs
+- See `docs/grid_choice.md` (why EPSG:4326 @ 0.01°) and `docs/terrain_grid.md`
+  (full grid + terrain alignment contract, pitfalls, usage recipes).
+
 Note on GeoTIFFs
 GeoTIFF rasters are commonly stored “north-up” where row 0 corresponds to the
 northernmost pixels (i.e., latitude decreases with increasing row index).

--- a/api/terrain/validate.py
+++ b/api/terrain/validate.py
@@ -1,0 +1,161 @@
+"""Terrain/grid validation helpers (fail fast on misalignment).
+
+These checks are intentionally strict and low-level: they validate that rasters are
+on the exact same CRS/resolution/extent as the `GridSpec` used for indexing.
+
+Why
+- The grid stack is easy to silently misconfigure (CRS mismatch, off-by-one extent,
+  wrong origin edge, subtle resampling).
+- These validators catch that early, before incorrect (i, j) indexing leaks into ML/UI.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import rasterio
+from rasterio.crs import CRS
+
+from api.core.grid import GridSpec
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _maybe_raise(messages: Iterable[str], *, strict: bool) -> None:
+    msgs = [m for m in messages if m]
+    if not msgs:
+        return
+    joined = "; ".join(msgs)
+    if strict:
+        raise ValueError(joined)
+    LOGGER.warning("%s", joined)
+
+
+def validate_raster_matches_grid(
+    raster_path: str | Path,
+    grid: GridSpec,
+    *,
+    strict: bool = True,
+) -> None:
+    """Validate a single north-up GeoTIFF matches the provided `GridSpec`.
+
+    Checks
+    - CRS equals `grid.crs`
+    - Pixel size equals `grid.cell_size_deg` (within a tiny tolerance)
+    - Width/height equal `grid.n_lon` / `grid.n_lat`
+    - Bounds/extents match the grid origin edges and size
+    - Transform is north-up (no rotation/shear)
+    """
+
+    path = Path(raster_path)
+    if not path.exists():
+        _maybe_raise([f"Raster not found: {path}"], strict=strict)
+        return
+
+    atol = 1e-9
+    atol_rot = 1e-12
+    with rasterio.open(path) as src:
+        expected_crs = CRS.from_string(grid.crs)
+        src_crs = src.crs
+        msgs: list[str] = []
+
+        if src_crs is None:
+            msgs.append(f"{path.name}: missing CRS (expected {grid.crs})")
+        elif src_crs != expected_crs:
+            msgs.append(f"{path.name}: CRS mismatch (got {src_crs}, expected {expected_crs})")
+
+        # North-up (no rotation/shear).
+        t = src.transform
+        if not (abs(t.b) < atol_rot and abs(t.d) < atol_rot):
+            msgs.append(f"{path.name}: transform has rotation/shear (transform={t})")
+
+        cell_x = float(abs(t.a))
+        cell_y = float(abs(t.e))
+        if not np.isclose(cell_x, cell_y, rtol=0.0, atol=atol_rot):
+            msgs.append(f"{path.name}: non-square pixels (x={cell_x}, y={cell_y})")
+        if not np.isclose(cell_x, float(grid.cell_size_deg), rtol=0.0, atol=atol):
+            msgs.append(
+                f"{path.name}: cell_size_deg mismatch (got {cell_x}, expected {grid.cell_size_deg})"
+            )
+
+        if int(src.width) != int(grid.n_lon):
+            msgs.append(f"{path.name}: width mismatch (got {src.width}, expected {grid.n_lon})")
+        if int(src.height) != int(grid.n_lat):
+            msgs.append(f"{path.name}: height mismatch (got {src.height}, expected {grid.n_lat})")
+
+        # Bounds must match origin edges + extent (half-open grid extent).
+        left, bottom, right, top = map(float, src.bounds)
+        exp_left = float(grid.origin_lon)
+        exp_bottom = float(grid.origin_lat)
+        exp_right = float(grid.origin_lon + grid.n_lon * grid.cell_size_deg)
+        exp_top = float(grid.origin_lat + grid.n_lat * grid.cell_size_deg)
+
+        if not np.isclose(left, exp_left, rtol=0.0, atol=atol):
+            msgs.append(f"{path.name}: left bound mismatch (got {left}, expected {exp_left})")
+        if not np.isclose(bottom, exp_bottom, rtol=0.0, atol=atol):
+            msgs.append(f"{path.name}: bottom bound mismatch (got {bottom}, expected {exp_bottom})")
+        if not np.isclose(right, exp_right, rtol=0.0, atol=atol):
+            msgs.append(f"{path.name}: right bound mismatch (got {right}, expected {exp_right})")
+        if not np.isclose(top, exp_top, rtol=0.0, atol=atol):
+            msgs.append(f"{path.name}: top bound mismatch (got {top}, expected {exp_top})")
+
+        # Transform edges should also match (redundant but produces clearer errors).
+        if not np.isclose(float(t.c), exp_left, rtol=0.0, atol=atol):
+            msgs.append(f"{path.name}: transform.c (west) mismatch (got {t.c}, expected {exp_left})")
+        if not np.isclose(float(t.f), exp_top, rtol=0.0, atol=atol):
+            msgs.append(f"{path.name}: transform.f (north) mismatch (got {t.f}, expected {exp_top})")
+
+        _maybe_raise(msgs, strict=strict)
+
+
+def validate_terrain_stack(
+    dem_path: str | Path | None,
+    slope_path: str | Path,
+    aspect_path: str | Path,
+    grid: GridSpec,
+    *,
+    strict: bool = True,
+) -> None:
+    """Validate DEM/slope/aspect rasters match each other and the `GridSpec`.
+
+    - Always validates slope + aspect.
+    - Validates DEM too when `dem_path` is provided.
+    """
+
+    paths: list[Path] = [Path(slope_path), Path(aspect_path)]
+    if dem_path is not None:
+        paths.append(Path(dem_path))
+
+    # First: each matches the grid contract.
+    for p in paths:
+        validate_raster_matches_grid(p, grid, strict=strict)
+
+    # Second: pairwise exact alignment (CRS/transform/shape/bounds).
+    # This is mostly redundant if grid validation passes, but gives clearer messages
+    # when a caller passes the wrong grid.
+    def _sig(p: Path) -> tuple[str | None, tuple[float, float, float, float, float, float], int, int, tuple[float, float, float, float]]:
+        with rasterio.open(p) as src:
+            crs_str = src.crs.to_string() if src.crs is not None else None
+            t = src.transform
+            transform_6 = (float(t.a), float(t.b), float(t.c), float(t.d), float(t.e), float(t.f))
+            b = src.bounds
+            bounds_4 = (float(b.left), float(b.bottom), float(b.right), float(b.top))
+            return crs_str, transform_6, int(src.width), int(src.height), bounds_4
+
+    msgs: list[str] = []
+    existing = [p for p in paths if p.exists()]
+    if len(existing) >= 2:
+        base = existing[0]
+        base_sig = _sig(base)
+        for other in existing[1:]:
+            other_sig = _sig(other)
+            if other_sig != base_sig:
+                msgs.append(
+                    f"{other.name}: raster does not exactly match {base.name} "
+                    f"(got={other_sig}, expected={base_sig})"
+                )
+    _maybe_raise(msgs, strict=strict)
+

--- a/api/tests/test_grid.py
+++ b/api/tests/test_grid.py
@@ -1,6 +1,24 @@
 import numpy as np
 
-from api.core.grid import GridSpec, bbox_to_window, grid_coords, index_to_latlon, latlon_to_index, window_coords
+from api.core.grid import (
+    DEFAULT_CELL_SIZE_DEG,
+    DEFAULT_CRS,
+    GridSpec,
+    bbox_to_window,
+    grid_bounds,
+    grid_coords,
+    index_to_latlon,
+    latlon_to_index,
+    window_coords,
+)
+
+
+def test_grid_defaults_match_docs():
+    assert DEFAULT_CRS == "EPSG:4326"
+    assert DEFAULT_CELL_SIZE_DEG == 0.01
+    grid = GridSpec()
+    assert grid.crs == "EPSG:4326"
+    assert grid.cell_size_deg == 0.01
 
 
 def test_roundtrip_index_latlon_index():
@@ -50,5 +68,34 @@ def test_grid_coords_match_window_coords_full_extent():
     lat2, lon2 = window_coords(grid, 0, grid.n_lat, 0, grid.n_lon)
     assert np.allclose(lat, lat2)
     assert np.allclose(lon, lon2)
+
+
+def test_boundary_behavior_max_edges_are_out_of_bounds_for_points():
+    grid = GridSpec.from_bbox(lat_min=10.0, lat_max=11.0, lon_min=20.0, lon_max=21.0)
+    min_lon, min_lat, max_lon, max_lat = grid_bounds(grid)
+
+    # Min edges: inclusive (floor -> 0)
+    i0, j0 = latlon_to_index(grid, min_lat, min_lon)
+    assert int(i0) == 0
+    assert int(j0) == 0
+
+    # Max edges: out-of-bounds (half-open extent)
+    i1, j1 = latlon_to_index(grid, max_lat, max_lon)
+    assert int(i1) == grid.n_lat
+    assert int(j1) == grid.n_lon
+
+    # Mixed edges behave deterministically
+    i2, j2 = latlon_to_index(grid, max_lat, min_lon)
+    assert int(i2) == grid.n_lat
+    assert int(j2) == 0
+
+
+def test_bbox_to_window_max_edge_is_full_extent_window():
+    grid = GridSpec.from_bbox(lat_min=10.0, lat_max=11.0, lon_min=20.0, lon_max=21.0)
+    min_lon, min_lat, max_lon, max_lat = grid_bounds(grid)
+
+    # Full extent window should return [0:n] exactly even when bbox equals max edges.
+    i0, i1, j0, j1 = bbox_to_window(grid, min_lon, min_lat, max_lon, max_lat, clip=True)
+    assert (i0, i1, j0, j1) == (0, grid.n_lat, 0, grid.n_lon)
 
 

--- a/api/tests/test_terrain_alignment.py
+++ b/api/tests/test_terrain_alignment.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import from_origin
+
+from api.core.grid import GridSpec
+from api.terrain.features_math import compute_slope_aspect
+from api.terrain.validate import validate_raster_matches_grid, validate_terrain_stack
+
+
+def _repo_root() -> Path:
+    # api/tests/ -> api/ -> repo root
+    return Path(__file__).resolve().parents[2]
+
+
+def _grid_from_raster(path: Path) -> GridSpec:
+    with rasterio.open(path) as src:
+        if src.crs is None:
+            raise AssertionError(f"{path} missing CRS")
+        cell = float(abs(src.transform.a))
+        left, bottom, right, top = map(float, src.bounds)
+        # origin_lat/lon are southern/western *edges* in this project.
+        return GridSpec(
+            crs=src.crs.to_string(),
+            cell_size_deg=cell,
+            origin_lat=bottom,
+            origin_lon=left,
+            n_lat=int(src.height),
+            n_lon=int(src.width),
+        )
+
+
+def test_sample_rasters_align_to_grid_contract():
+    root = _repo_root()
+    dem = root / "data" / "dem" / "smoke_grid" / "dem_smoke_grid_epsg4326_0p01deg.tif"
+    slope = root / "data" / "terrain" / "smoke_grid" / "slope_smoke_grid_epsg4326_0p01deg.tif"
+    aspect = root / "data" / "terrain" / "smoke_grid" / "aspect_smoke_grid_epsg4326_0p01deg.tif"
+
+    assert dem.exists()
+    assert slope.exists()
+    assert aspect.exists()
+
+    grid = _grid_from_raster(dem)
+    # All three should be exactly aligned.
+    validate_terrain_stack(dem, slope, aspect, grid, strict=True)
+
+
+def test_sample_slope_aspect_value_sanity():
+    root = _repo_root()
+    slope_path = root / "data" / "terrain" / "smoke_grid" / "slope_smoke_grid_epsg4326_0p01deg.tif"
+    aspect_path = root / "data" / "terrain" / "smoke_grid" / "aspect_smoke_grid_epsg4326_0p01deg.tif"
+    assert slope_path.exists()
+    assert aspect_path.exists()
+
+    with rasterio.open(slope_path) as ssrc:
+        slope = ssrc.read(1, masked=True).filled(np.nan).astype(float)
+    with rasterio.open(aspect_path) as asrc:
+        aspect = asrc.read(1, masked=True).filled(np.nan).astype(float)
+
+    slope_vals = slope[np.isfinite(slope)]
+    assert slope_vals.size > 0
+    assert float(np.nanmin(slope_vals)) >= 0.0
+    assert float(np.nanmax(slope_vals)) <= 90.0
+
+    # Aspect is defined where slope > 0; elsewhere it can be NaN (flat) or nodata.
+    mask = np.isfinite(slope) & (slope > 0.0) & np.isfinite(aspect)
+    assert bool(mask.any()) is True
+    a = aspect[mask]
+    assert float(np.nanmin(a)) >= 0.0
+    assert float(np.nanmax(a)) < 360.0
+
+
+def test_compute_slope_aspect_known_plane_has_constant_aspect_and_positive_slope():
+    height, width = 64, 96
+    cell_size_deg = 0.01
+
+    # North-up raster convention: row 0 is north, row index increases southward.
+    # Make elevation decrease southward so downslope points south (aspect ~ 180°).
+    z = (-np.arange(height, dtype=float)[:, None] * 10.0) * np.ones((1, width), dtype=float)
+
+    # Lat centers (north->south) decrease by row.
+    lat_north = 40.0
+    lat_centers = lat_north - (np.arange(height, dtype=float) + 0.5) * cell_size_deg
+
+    slope, aspect = compute_slope_aspect(z, cell_size_deg=cell_size_deg, lat_centers_deg=lat_centers)
+    core = (slice(1, -1), slice(1, -1))
+
+    s = slope[core]
+    a = aspect[core]
+    assert float(np.nanmedian(s)) > 0.0
+    assert float(np.nanmax(s)) <= 90.0
+    assert np.isfinite(a).all()
+    assert float(np.nanmedian(a)) == pytest.approx(180.0, abs=1.0)
+
+
+def _write_geotiff_for_grid(path: Path, *, grid: GridSpec, data_latlon: np.ndarray) -> None:
+    """Write a north-up GeoTIFF for an array in analysis convention (lat increasing)."""
+    assert data_latlon.shape == (grid.n_lat, grid.n_lon)
+    north = grid.origin_lat + grid.n_lat * grid.cell_size_deg
+    transform = from_origin(
+        west=grid.origin_lon,
+        north=north,
+        xsize=grid.cell_size_deg,
+        ysize=grid.cell_size_deg,
+    )
+    # Stored GeoTIFF is north-up, so flip the analysis array on write.
+    raster_data = np.flipud(data_latlon).astype(np.float32)
+    profile = {
+        "driver": "GTiff",
+        "height": grid.n_lat,
+        "width": grid.n_lon,
+        "count": 1,
+        "dtype": "float32",
+        "crs": grid.crs,
+        "transform": transform,
+        "nodata": -9999.0,
+    }
+    with rasterio.open(path, "w", **profile) as dst:
+        dst.write(raster_data, 1)
+
+
+def test_validate_raster_matches_grid_catches_misalignment(tmp_path: Path, caplog: pytest.LogCaptureFixture):
+    grid = GridSpec(crs="EPSG:4326", cell_size_deg=0.1, origin_lat=0.0, origin_lon=0.0, n_lat=5, n_lon=7)
+    data = np.zeros((grid.n_lat, grid.n_lon), dtype=np.float32)
+
+    good = tmp_path / "good.tif"
+    bad_shift_west = tmp_path / "bad_shift_west.tif"
+
+    _write_geotiff_for_grid(good, grid=grid, data_latlon=data)
+
+    # Shift by half a cell west: same shape/resolution but wrong origin edge/bounds.
+    shifted_grid = GridSpec(
+        crs=grid.crs,
+        cell_size_deg=grid.cell_size_deg,
+        origin_lat=grid.origin_lat,
+        origin_lon=grid.origin_lon - grid.cell_size_deg / 2.0,
+        n_lat=grid.n_lat,
+        n_lon=grid.n_lon,
+    )
+    _write_geotiff_for_grid(bad_shift_west, grid=shifted_grid, data_latlon=data)
+
+    validate_raster_matches_grid(good, grid, strict=True)
+
+    with pytest.raises(ValueError):
+        validate_raster_matches_grid(bad_shift_west, grid, strict=True)
+
+    caplog.clear()
+    validate_raster_matches_grid(bad_shift_west, grid, strict=False)
+    assert any("mismatch" in rec.message.lower() for rec in caplog.records)
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Purpose: give newcomers and contributors a single navigation point, reduce dupli
 - System architecture: `architecture.md`
 - Setup & tooling: `SETUP.md`, `dev-python-env.md`
 - Ingestion (pipelines): `ingest/ingest_firms.md`, `ingest/ingest_weather.md`, `ingest/ingest_dem.md`, `ingest/data_quality.md`
+- Terrain + grid contract: `terrain_grid.md`
 - Data & schema: `data/data_formats.md`, `data/data_schema_fires.md`, `data/db-migrations.md`
 - Scripts/helpers: `scripts/` are lightly documented inline; ingestion make targets in `Makefile`
 

--- a/docs/WILDFIRE_NOWCAST_101.md
+++ b/docs/WILDFIRE_NOWCAST_101.md
@@ -97,6 +97,7 @@ At a high level, the app should support:
   - Role:
     - Derive **slope** and **aspect** (slope direction).
     - Influence spread (fires move faster upslope, etc.).
+  - Conventions: see `docs/grid_choice.md` and `docs/terrain_grid.md` (grid + terrain alignment contract).
 
 ### 3.2 Optional Context Layers
 

--- a/docs/terrain_grid.md
+++ b/docs/terrain_grid.md
@@ -1,0 +1,135 @@
+## Terrain + Grid Contract (Contributor Guide)
+
+Audience: anyone touching **terrain rasters**, **grid indexing**, **ML features**, **API windowing**, or the **UI map**.
+
+This doc describes the **contract** that makes `(lat, lon) ↔ (i, j)` stable across ingest → API → ML → UI, and explains how terrain rasters (DEM / slope / aspect) must align to that grid.
+
+### Canonical CRS + resolution
+
+Source of truth: `docs/grid_choice.md`.
+
+- **CRS**: `EPSG:4326` (WGS84 lon/lat)
+- **Cell size**: `0.01°` (default)
+
+### Grid definition (what `GridSpec` means)
+
+`GridSpec` lives in `api/core/grid.py`.
+
+- **Indices**: `(i, j) = (lat_index, lon_index)` (0-based)
+- **Direction**:
+  - `i` increases **south → north** (latitude increases)
+  - `j` increases **west → east** (longitude increases)
+- **Origin**:
+  - `origin_lat` and `origin_lon` are the **southern / western cell edges**
+  - They are **not** cell centers
+- **Cell centers**:
+  - `lat[i] = origin_lat + (i + 0.5) * cell_size_deg`
+  - `lon[j] = origin_lon + (j + 0.5) * cell_size_deg`
+- **Extent is half-open**:
+  - Bounds are `(min_lon, min_lat, max_lon, max_lat) = (origin_lon, origin_lat, origin_lon + n_lon*cell, origin_lat + n_lat*cell)`
+  - Points on the **max edge** are **out of bounds** (they map to index `n_lat` / `n_lon`)
+
+### Windowing (half-open slices)
+
+Most APIs use half-open windows `(i0:i1, j0:j1)`:
+
+- `i0`, `j0` are inclusive
+- `i1`, `j1` are exclusive
+- `len(lat) == i1 - i0`, `len(lon) == j1 - j0`
+
+Use:
+- `api.core.grid.get_grid_window_for_bbox(...)` (bbox → indices + coords)
+- `api.core.grid.window_coords(...)` (indices → cell-center coords)
+
+### Terrain alignment contract (DEM / slope / aspect)
+
+All terrain rasters for a region must be on the **exact same** grid:
+
+- **CRS equals** the grid CRS (`EPSG:4326`)
+- **Pixel size equals** `grid.cell_size_deg` (square pixels)
+- **Width/height equal** `grid.n_lon` / `grid.n_lat`
+- **Bounds match** the grid edges:
+  - left == `grid.origin_lon`
+  - bottom == `grid.origin_lat`
+  - right == `grid.origin_lon + grid.n_lon * cell`
+  - top == `grid.origin_lat + grid.n_lat * cell`
+
+Runtime enforcement (fail fast):
+- `api/terrain/validate.py`:
+  - `validate_raster_matches_grid(...)`
+  - `validate_terrain_stack(...)`
+
+### GeoTIFF row order vs analysis convention (important!)
+
+GeoTIFFs are usually **north-up**:
+- raster row `0` is the **northmost** pixels
+- row index increases **southward**
+
+But analysis arrays in this repo are **lat-ascending**:
+- `lat` is monotonic increasing (south → north)
+- array index `i` increases (south → north)
+
+Therefore:
+- When reading via rasterio windows (see `api/terrain/window.py`), we convert
+  analysis indices to raster row offsets and **flip rows once** (`np.flipud`) so
+  consumers always get `(lat, lon)` arrays with **lat increasing**.
+- When writing synthetic test rasters, you typically need to **flip on write** to
+  store as north-up.
+
+### File locations and naming conventions
+
+On-disk paths (typical):
+
+- **DEM**: `data/dem/<region>/dem_<region>_epsg4326_0p01deg.tif`
+- **Slope**: `data/terrain/<region>/slope_<region>_epsg4326_0p01deg.tif`
+- **Aspect**: `data/terrain/<region>/aspect_<region>_epsg4326_0p01deg.tif`
+
+Database metadata:
+
+- `terrain_metadata` stores DEM path + grid fields (origin, size, cell size, bbox)
+- `terrain_features_metadata` stores slope/aspect paths + grid fields and nodata/conventions
+
+### Usage recipes
+
+#### 1) Get a grid window for a bbox / AOI
+
+```python
+from api.core.grid import GridSpec, get_grid_window_for_bbox
+
+grid = GridSpec.from_bbox(lat_min=35.0, lat_max=36.0, lon_min=5.0, lon_max=6.0)  # snapped
+bbox = (5.12, 35.45, 5.99, 36.00)  # (min_lon, min_lat, max_lon, max_lat)
+win = get_grid_window_for_bbox(grid, bbox, clip=True)
+# win.i0, win.i1, win.j0, win.j1 are half-open indices
+```
+
+#### 2) Load slope/aspect (and optional DEM) for that window
+
+```python
+from api.terrain.window import load_terrain_window
+
+tw = load_terrain_window("smoke_grid", bbox, include_dem=True)
+# tw.slope, tw.aspect, tw.elevation are numpy arrays shaped (n_lat, n_lon) in (lat, lon) order
+```
+
+#### 3) Map fire detections → (i, j) and build a heatmap
+
+```python
+import numpy as np
+from api.core.grid import GridSpec, latlon_to_index
+
+grid = GridSpec.from_bbox(lat_min=35.0, lat_max=36.0, lon_min=5.0, lon_max=6.0)
+heat = np.zeros((grid.n_lat, grid.n_lon), dtype=np.float32)
+
+# detections: arrays of lat/lon (EPSG:4326)
+i, j = latlon_to_index(grid, lat=detections_lat, lon=detections_lon)
+in_bounds = (0 <= i) & (i < grid.n_lat) & (0 <= j) & (j < grid.n_lon)
+np.add.at(heat, (i[in_bounds], j[in_bounds]), 1.0)
+```
+
+### Common pitfalls (things that silently break alignment)
+
+- **North-up vs analysis order**: reading a GeoTIFF directly as an array without flipping/coord sorting can invert latitude.
+- **Lon normalization**: standardize longitudes to `[-180, 180]` before indexing if your source uses `[0, 360)`.
+- **Boundary semantics**: `max_lat` / `max_lon` edges are out-of-bounds by design (half-open extent).
+- **“Looks aligned” but isn’t**: rasters can have the same CRS/resolution but differ by a half-cell origin shift. Use `validate_terrain_stack(...)`.
+


### PR DESCRIPTION
closes #32
closes #33 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce strict terrain/grid validation utilities and apply them in DEM/features loaders and windowing, with new tests and docs on grid/terrain contract.
> 
> - **Validation (new)**:
>   - Add `api/terrain/validate.py` with `validate_raster_matches_grid` and `validate_terrain_stack` (CRS/resolution/extent/north-up checks).
> - **Terrain loading/windowing**:
>   - Enforce grid alignment in `api/terrain/dem_loader.load_dem_for_bbox` and `api/terrain/features_loader.load_slope_aspect_for_bbox` using validators.
>   - Simplify `api/terrain/window.py`: validate slope/aspect (and optional DEM) stack once; remove manual grid comparisons.
> - **Ingest**:
>   - `ingest/terrain_features.py`: validate DEM before computing; validate output slope/aspect against DEM/grid (including COG outputs).
> - **Core grid**:
>   - Expose `DEFAULT_CRS`, `DEFAULT_CELL_SIZE_DEG`, `grid_bounds`; docstring links to new terrain/grid docs.
> - **Tests**:
>   - Add `api/tests/test_terrain_alignment.py` for validator behavior, sample raster alignment, slope/aspect sanity, and synthetic misalignment.
>   - Expand `api/tests/test_grid.py` for defaults, boundary semantics (half-open), and window/bounds consistency.
> - **Docs**:
>   - Add `docs/terrain_grid.md`; link from `README.md`, `docs/README.md`, `docs/WILDFIRE_NOWCAST_101.md`, and module docstrings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a61afcd4d03400d1629bcf10f894f11294f8d5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->