### PR TITLE
wn-50: Document spread model design, assumptions, and limitations

### DIFF
--- a/docs/WILDFIRE_NOWCAST_101.md
+++ b/docs/WILDFIRE_NOWCAST_101.md
@@ -128,6 +128,7 @@ Planned components:
    - Output:
      - **Probability of fire presence** on a local grid for T+6/12/24/48/72h.
      - Uncertainty estimates (ensembles / Monte Carlo).
+   - Details / assumptions / limitations: see `docs/spread_model_design.md`.
 
 3. **Probability calibration**
    - Learned from historical data:
@@ -160,7 +161,8 @@ Planned components:
 As of late 2025, only some parts of this pipeline are implemented in code; others are still design targets.  
 For a current-status walkthrough (what exists vs planned), see `docs/architecture.md`. Roughly:
 - **Implemented**: FIRMS fire detection ingest + dedupe (`fire_detections`, `ingest_batches`), GFS 0.25° weather ingest + `weather_runs`, DEM stitching + `terrain_metadata`, basic FastAPI API with DB wiring, and a Streamlit UI with placeholder layers.
-- **Not yet implemented**: spread and risk models, probability calibration and weather bias correction, tile serving/COGs, LLM AOI summaries, and background workers/caching.
+- **Partially implemented**: spread model (heuristic v0 + learned v1 baseline). See `docs/spread_model_design.md` for what is implemented today and its limitations.
+- **Not yet implemented**: risk models, probability calibration and weather bias correction, tile serving for UI consumption, LLM AOI summaries, and background workers/caching.
 
 1. **Data ingest**
    - Periodically pull:

--- a/docs/spread_model_design.md
+++ b/docs/spread_model_design.md
@@ -1,129 +1,177 @@
-# Spread Forecasting Model (v1): Design & Contract
+# Spread Forecasting Models: v0 heuristic + v1 baseline (Design, Contract, and Limitations)
 
-This document defines the contract for the **Wildfire Spread Forecasting Model (24–72h v1)**. It specifies the inputs, outputs, and calling patterns to ensure consistency between ML development, API serving, and UI visualization.
+This document exists so the spread model is **not misused or oversold**.
 
-## 1. Goal & Horizons
+It has two roles:
+1. **Contract**: the stable interface (`ml/spread/contract.py`) that callers and UI can rely on.
+2. **Reality check**: what the currently implemented models actually do (v0 heuristic, v1 learned baseline), what they assume, and what they do *not* model.
+
+## 0. What is implemented today (and what “probability” means here)
+
+### 0.1 Implemented models
+- **Heuristic v0 (default runtime model)**: `ml/spread/heuristic_v0.py`.
+  - Selected by default in `ml/spread/service.py::run_spread_forecast`.
+  - Produces a relative probability footprint by convolving a fire mask with a wind/terrain-biased kernel, then normalizing by the maximum value.
+- **Learned v1 baseline (implemented but not the default)**: training `ml/train_spread_v1.py`, inference `ml/spread/learned_v1.py`.
+  - Trains per-horizon `HistGradientBoostingClassifier` models on a hindcast dataset built by `ml/spread/hindcast_dataset.py`.
+
+### 0.2 What v0 probabilities are (and are not)
+The v0 output is bounded to \([0, 1]\) and looks like a probability field, but **it is not calibrated** and it is **normalized per-horizon**.
+
+Concretely, v0 computes an unnormalized score by convolution and then divides by the maximum value in the AOI for that horizon (`ml/spread/heuristic_v0.py`). That means:
+- **Good use**: as a **relative spread footprint** / “where is more likely than elsewhere” overlay.
+- **Bad use**: interpreting 0.7 as “70% chance of fire presence” in an absolute, calibrated sense.
+- **Important**: because of per-horizon max-normalization, the same physical situation can yield different absolute values depending on AOI/window shape and kernel support.
+
+## 1. Goal & Horizons (contract-level intent)
 
 The spread model predicts the **probability of fire presence** at future time horizons given the current fire state, weather forecast, and static terrain features.
 
-- **MVP Horizons (v1)**: **T+24h, T+48h, T+72h**.
-- **Optional Horizons (interface-supported)**: T+6h, T+12h.
-- **Resolution**: 0.01° (~1 km) on the canonical analysis grid (`EPSG:4326`).
+- **Default horizons in code**: T+24h, T+48h, T+72h (`ml/spread/contract.py::DEFAULT_HORIZONS_HOURS`).
+- **Resolution**: region grid cell size (commonly 0.01° on `EPSG:4326`; see `api.core.grid` / `get_region_grid_spec`).
+- **Granularity**: model runs per AOI window (bbox), typically a clipped subset of the region grid.
 
-## 2. Core Abstraction (`SpreadModel`)
+## 2. Core Abstraction (`SpreadModel`) — contract
 
-The model is defined as a `Protocol` in `ml/spread/contract.py`. This allows different implementations (e.g., cell-based, convolutional, or ensemble) to be swapped without changing the calling code.
+The model is a `Protocol` in `ml/spread/contract.py`, enabling different implementations to be swapped without changing the caller.
 
 ### 2.1 Inputs (`SpreadModelInput`)
 
-| Input | Type | Source / Pattern |
+| Input | Type | Where it comes from in this repo |
 | :--- | :--- | :--- |
-| `grid` | `GridSpec` | `api.core.grid.GridSpec` |
-| `window` | `GridWindow` | `api.core.grid.GridWindow` (the analysis bbox) |
-| `active_fires` | `FireHeatmapWindow` | `api.fires.service.get_fire_cells_heatmap` (heatmap of current detections) |
-| `weather_cube` | `xr.Dataset` | `data/weather/...` (GFS 0.25° interpolated to analysis grid) |
-| `terrain` | `TerrainWindow` | `api.terrain.window.load_terrain_window` (slope, aspect, elevation) |
-| `horizons` | `Sequence[int]` | e.g. `[24, 48, 72]` hours |
+| `grid` | `GridSpec` | `api.fires.service.get_region_grid_spec` |
+| `window` | `GridWindow` | `api.core.grid.get_grid_window_for_bbox(..., clip=True)` |
+| `active_fires` | `FireHeatmapWindow` | `api.fires.service.get_fire_cells_heatmap` (assembled via `ml/spread_features.py::build_spread_inputs`) |
+| `weather_cube` | `xr.Dataset` | Loaded/aligned by `ml/spread_features.py::_load_weather_cube` (from `weather_runs`, with calm fallback) |
+| `terrain` | `TerrainWindow` | `api.terrain.window.load_terrain_window` (assembled via `ml/spread_features.py::build_spread_inputs`) |
+| `forecast_reference_time` | `datetime` | Request field (`ml/spread/service.py::SpreadForecastRequest`) |
+| `horizons_hours` | `Sequence[int]` | Request field, defaults to `DEFAULT_HORIZONS_HOURS` |
+
+#### Inputs used by v0 specifically
+v0 uses:
+- **Fires**: a binary/thresholded mask from `active_fires.heatmap` (`ml/spread/heuristic_v0.py`).
+- **Weather**: **window-mean** `u10` and `v10`, selected at the nearest weather time to each horizon (`ml/spread/heuristic_v0.py`).
+- **Terrain (optional)**: if enabled, v0 uses **window-mean** slope/aspect to bias spread upslope (`HeuristicSpreadV0Config.enable_slope_bias` in `ml/spread/heuristic_v0.py`).
+- **Masks**: applies `terrain.valid_data_mask` and `terrain.aoi_mask` if present.
 
 ### 2.2 Outputs (`SpreadForecast`)
 
-The primary output is an **`xarray.DataArray`** with the following specification:
-
+The primary output is an `xarray.DataArray`:
 - **Dimensions**: `("time", "lat", "lon")`.
-    - This repo’s canonical raster naming is `lat/lon` (see `api.core.grid`). If you think of a generic ML tensor `(time, y, x)`, then `y ↔ lat` and `x ↔ lon`, and the canonical index order is `(i, j) = (lat_index, lon_index)`.
 - **Coordinates**:
-    - `time`: `datetime` objects (Reference Time + Horizon).
-    - `lat` / `lon`: Cell-center coordinates matching the input window.
-    - `lead_time_hours`: (optional) Coordinate mapping time to horizon hours.
-- **Values**: Probability of fire presence in range `[0.0, 1.0]`.
-- **Data Type**: `float32` (preferred) or `float64`.
+  - `time`: reference time + horizon.
+  - `lat` / `lon`: cell-center coordinates matching the input window.
+  - `lead_time_hours`: optional but recommended; aligned with the `time` dimension.
+- **Values**: \([0.0, 1.0]\) floats.
+- **Validation**: enforced by `SpreadForecast.validate()` in `ml/spread/contract.py`.
 
-## 3. AOI & Cluster Handling
+## 3. AOI & Cluster Handling (today)
 
-- **Granularity**: The model runs per **AOI window** (bounding box).
-- **Clusters**: If multiple fire clusters are active, the calling service (e.g., a background worker) determines the appropriate window size to cover the cluster and its expected spread area.
-- **Clipping**: Use `api.terrain.window.load_terrain_for_aoi` to obtain a polygon-clipped mask if the user specifies a non-rectangular AOI. The model may use this mask to zero out probabilities or weight results.
+- **AOI**: bbox → clipped window via `get_grid_window_for_bbox(..., clip=True)` (`ml/spread_features.py`).
+- **Cluster support**: `SpreadForecastRequest.fire_cluster_id` exists but is currently **not implemented** (`ml/spread/service.py` raises `NotImplementedError`).
+- **Performance guardrail**: synchronous forecasting rejects AOIs above `MAX_AOI_CELLS` (`ml/spread/service.py`).
 
-## 4. Expected Calling Pattern (API/Worker)
+## 4. How heuristic v0 derives probabilities
 
-```python
-from datetime import datetime, timedelta, timezone
-import xarray as xr
+This section is intentionally grounded in `ml/spread/heuristic_v0.py`.
 
-from ml.spread import SpreadModelInput
-from api.core.grid import get_grid_window_for_bbox
-from api.fires.service import get_fire_cells_heatmap, get_region_grid_spec
-from api.terrain.window import load_terrain_window
+### 4.1 Fire input → source mask
+v0 thresholds the active fire heatmap:
+- `fire_mask = (inputs.active_fires.heatmap > fire_threshold)` where `fire_threshold` is configurable (`HeuristicSpreadV0Config.fire_threshold`).
+- If there are **no active fire cells**, v0 returns all-zero probability grids.
 
-# 1. Define window
-bbox = (5.1, 35.4, 6.0, 36.0) # (min_lon, min_lat, max_lon, max_lat)
-region = "smoke_grid"
-now = datetime.now(timezone.utc)
-start_time = now - timedelta(hours=24)
+### 4.2 Kernel generation (distance + wind + optional slope)
+For each horizon \(h\) (hours), v0 constructs a 2D kernel over (lat, lon) pixels:
+- **Base spread distance**: `base_dist = base_spread_km_h * h`.
+- **Wind**:
+  - Uses window-mean `u10`, `v10` from `weather_cube`.
+  - Wind speed: \(\sqrt{u^2 + v^2}\).
+  - Shapes the kernel by:
+    - **Elongation**: downwind distances are “easier” than upwind using `wind_elongation_factor`.
+    - **Wind speed scaling**: expands the footprint with wind speed (`wind_influence_km_h_per_ms`).
+- **Optional slope bias** (if enabled): computes window-mean slope and a circular mean of aspect; then biases spread toward **upslope** direction (aspect + 180°), scaling strength with slope (`slope_influence`, `slope_reference_deg`).
+- **Distance decay**: kernel values decay exponentially with effective distance:
 
-# 2. Gather Features
-grid = get_region_grid_spec(region)
-window = get_grid_window_for_bbox(grid, bbox)
+  `kernel = exp(-eff_dist / (base_dist + distance_decay_km))`
 
-fires = get_fire_cells_heatmap(region, bbox, start_time, now)
-terrain = load_terrain_window(region, bbox, include_dem=True)
+  where `eff_dist` incorporates wind and (optional) slope bias.
 
-# Weather loading is intentionally left to the caller (worker/service), since the
-# API package does not currently expose a single "latest weather cube" helper.
-# The contract requires an xr.Dataset with coords/dims including: time, lat, lon.
-# Example sketch:
-# weather = xr.open_dataset(path_to_latest_weather_netcdf)
-# weather = weather.sel(lat=window.lat, lon=window.lon, method="nearest")
-# weather = weather.sel(time=desired_times)
-weather = xr.Dataset(coords={"time": [], "lat": window.lat, "lon": window.lon})
+### 4.3 Convolution + normalization
+- v0 convolves the `fire_mask` with the kernel using `scipy.signal.fftconvolve(..., mode="same")`.
+- It normalizes by the maximum value in the AOI for that horizon (if max > 0).
+- It clamps to \([0,1]\) and applies `valid_data_mask` and `aoi_mask` if present.
 
-# 3. Predict
-inputs = SpreadModelInput(
-    grid=grid,
-    window=window,
-    active_fires=fires,
-    weather_cube=weather,
-    terrain=terrain,
-    forecast_reference_time=now,
-    horizons_hours=[24, 48, 72]
-)
+## 5. Known limitations (v0 heuristic)
 
-forecast = model.predict(inputs)
-forecast.validate()
+These are direct implications of the current implementation.
 
-# 4. Use
-# probabilities = forecast.probabilities  # xr.DataArray (3, H, W)
-```
+- **Not a physical fire behavior model**: no fuels, no moisture model, no energy balance, no fireline intensity.
+- **No spotting / ember transport**: cannot create disconnected ignitions.
+- **No barriers**: rivers/roads/firebreaks/urban areas are not modeled as discontinuities.
+- **Wind is spatially collapsed**: v0 uses **mean wind over the AOI**, so it cannot represent spatial wind gradients.
+- **Terrain is spatially collapsed (if enabled)**: slope/aspect bias uses **window-mean** slope/aspect, not per-cell effects.
+- **No stepwise dynamics**: each horizon is computed independently; there is no iterative propagation or coupling between horizons.
+- **Per-horizon normalization**: useful as a footprint, but prevents interpreting values as calibrated probabilities.
+- **Grid-distance approximation**: converts degrees to km using mean latitude.
 
-## 5. Storage & Serving
+## 6. Expected calling pattern (repo entrypoints)
 
-- **Raster**: Forecast probability grids should be stored as **Cloud-Optimized GeoTIFFs (COGs)** or **Zarr** in `data/forecasts/`.
-- **Vector**: Iso-probability contours (isochrones) can be extracted using `skimage.measure.find_contours` or similar and stored in PostGIS for fast UI rendering.
+### 6.1 End-to-end orchestration
+- Use `ml/spread/service.py::run_spread_forecast` for the standard “assemble inputs → run model → validate output” path.
+- Inputs are assembled by `ml/spread_features.py::build_spread_inputs`.
 
-## 6. Training Pipeline (v1)
+### 6.2 Persistence of products (rasters/contours)
+- The CLI `ingest/spread_forecast.py` saves per-horizon probability rasters (GeoTIFF/COG) and generates thresholded polygon contours for storage.
 
-The training pipeline for learned spread models uses a **hindcast** approach, where historical FIRMS detections are used to build both features (at T=0) and labels (at T+24/48/72h).
+## 7. Learned v1 baseline (implemented): training data, features, metrics
 
-### 6.1 Building the Dataset
+This is a **baseline** learned model; treat it as experimental unless evaluated and calibrated for a region.
 
-The script `ml/spread/hindcast_dataset.py` assembles a tabular dataset by:
-1. Sampling historical reference times with sufficient fire activity.
-2. Building `SpreadInputs` for each time using the canonical feature pipeline.
-3. Extracting future fire presence from the DB as the target label.
-4. Flattening grid cells into rows with spatial and weather features.
-5. Applying negative sampling to manage the extreme sparsity of fire spread.
+### 7.1 Training data (hindcast)
+`ml/spread/hindcast_dataset.py` builds a dataset by:
+1. Sampling reference times with sufficient detections in a bbox (`sample_fire_reference_times`, querying `fire_detections`).
+2. Building aligned inputs via `ml/spread_features.py::build_spread_inputs`.
+3. Defining labels by querying future fire presence in a small time window around each target horizon (`get_fire_cells_heatmap(..., mode="presence")` for \(T+h \pm 3\) hours).
+4. Flattening each grid cell into a row (tabular dataset).
+5. Negative sampling to handle sparsity (while always keeping cells with fire at \(T=0\)).
 
-### 6.2 Training
+### 7.2 Features (current baseline)
+The baseline feature set comes from the hindcast builder and training config (`configs/spread_train_v1.yaml`). Today it includes:
+- `fire_t0`
+- `slope_deg`, `aspect_sin`, `aspect_cos`
+- `u10`, `v10`, `wind_speed`
 
-Use the `ml/train_spread_v1.py` script with a YAML config:
+Optional columns exist in code (`elevation_m`, `t2m`, `rh2m`) but are not included in the default YAML.
 
-```bash
-uv run --project ml -m ml.train_spread_v1 --config configs/spread_train_v1.yaml
-```
+### 7.3 Model + metrics
+`ml/train_spread_v1.py` trains one `HistGradientBoostingClassifier` per horizon and writes artifacts to `models/spread_v1/<run_id>/`.
 
-This trains an ensemble of `HistGradientBoostingClassifier` models (one per horizon) and saves them to `models/spread_v1/<run_id>/`.
+It reports:
+- **ROC-AUC** and **PR-AUC** (when defined), and
+- thresholded metrics including **precision/recall/F1** and a simple mask **IoU (Jaccard)**.
 
-### 6.3 Inference
+### 7.4 Inference
+`ml/spread/learned_v1.py::LearnedSpreadModelV1`:
+- loads `model.pkl` (mapping horizon → classifier) and `feature_list.json`,
+- builds per-horizon tabular features from `SpreadModelInput`,
+- returns an `xr.DataArray` with the same contract dims/coords, and
+- applies `valid_data_mask`/`aoi_mask` similarly to v0.
 
-The `LearnedSpreadModelV1` class (`ml/spread/learned_v1.py`) implements the `SpreadModel` protocol and can be initialized from a trained run directory to produce forecasts.
+## 8. Future improvements
 
+### 8.1 More physical modeling
+- Stepwise propagation (time stepping) instead of independent per-horizon kernels.
+- Incorporate rate-of-spread heuristics from fire behavior literature as features or constraints.
+- Explicit handling of barriers and suppression (where data exists).
+
+### 8.2 Better integration with fuels and land cover
+- Add fuel/vegetation/land-cover layers and derive fuel-dependent spread modifiers.
+- Add dryness proxies (precipitation history, fuel moisture indices) when available.
+- Region-specific calibration and validation.
+
+### 8.3 More advanced ML approaches
+- Spatial models (CNN/UNet-style) operating directly on rasters.
+- Sequence models that consume weather time series rather than a single horizon slice.
+- Uncertainty: ensembles, quantile regression, or Bayesian-ish approximations.
+- Probability calibration + reliability curves per region/horizon.
+- Better evaluation: spatial metrics (distance-to-fireline), event-based metrics, and calibration metrics (ECE/Brier).

--- a/ingest/spread_forecast.py
+++ b/ingest/spread_forecast.py
@@ -1,4 +1,7 @@
-"""CLI for running wildfire spread forecasts and persisting products."""
+"""CLI for running wildfire spread forecasts and persisting products.
+
+See `docs/spread_model_design.md` for what the spread models do today and their limitations.
+"""
 
 from __future__ import annotations
 

--- a/ml/spread/heuristic_v0.py
+++ b/ml/spread/heuristic_v0.py
@@ -2,6 +2,8 @@
 
 This model implements a simple rule-based spread using wind direction and speed
 to produce a downwind-biased probability footprint.
+
+See `docs/spread_model_design.md` for a higher-level description, assumptions, and limitations.
 """
 
 from __future__ import annotations

--- a/ml/spread/learned_v1.py
+++ b/ml/spread/learned_v1.py
@@ -1,4 +1,7 @@
-"""Learned spread model (v1) inference implementation."""
+"""Learned spread model (v1) inference implementation.
+
+See `docs/spread_model_design.md` for training/inference details and evaluation notes.
+"""
 
 import logging
 import os

--- a/ml/spread/service.py
+++ b/ml/spread/service.py
@@ -1,4 +1,7 @@
-"""Spread forecast service for orchestrating model execution."""
+"""Spread forecast service for orchestrating model execution.
+
+See `docs/spread_model_design.md` for model behavior, assumptions, and limitations.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
closes #50 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Adds spread model documentation and a forecast persistence CLI**
> 
> - Introduces `docs/spread_model_design.md` detailing the v0 heuristic and v1 learned baseline, input/output contract, calling patterns, limitations, and future work
> - Updates `docs/WILDFIRE_NOWCAST_101.md` to reference the new design doc and clarify implementation status (spread model partially implemented)
> - New `ingest/spread_forecast.py` CLI: runs spread forecasts, saves per-horizon probability rasters as COGs, and generates thresholded contour polygons; includes robust horizon slice selection and consistent georeferencing
> - Adds docstring pointers to the design doc in `ml/spread/heuristic_v0.py`, `ml/spread/learned_v1.py`, and `ml/spread/service.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42c8e5d4b9d0af7f3e16cd48380d5e353afdd6e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->