### PR TITLE
feat(ui): improve fire inspector UX, assistant context, and forecast quality

### DIFF
--- a/ui/src/components/AIChatAssistant.tsx
+++ b/ui/src/components/AIChatAssistant.tsx
@@ -46,7 +46,13 @@ function compactEventContext(selectedEvent: FireEvent | null): Record<string, un
     region_name: selectedEvent.region_name,
     admin1_name: selectedEvent.admin1_name,
     admin0_name: selectedEvent.admin0_name,
-    country: selectedEvent.country
+    country: selectedEvent.country,
+    frp_max: selectedEvent.frp_max ?? null,
+    frp_mean: selectedEvent.frp_mean ?? null,
+    brightness_max: selectedEvent.brightness_max ?? null,
+    brightness_mean: selectedEvent.brightness_mean ?? null,
+    geom_source: selectedEvent.geom_source ?? null,
+    geom_method: selectedEvent.geom_method ?? null
   };
 }
 
@@ -125,6 +131,12 @@ export default function AIChatAssistant(): JSX.Element {
         active_job_id: forecast.jobId,
         last_run_id: forecast.lastForecast?.run.id || null,
         last_event_key: forecast.lastForecast?.eventKey || null,
+        run_quality: forecast.lastForecast?.runMeta
+          ? {
+              weather_available: forecast.lastForecast.runMeta.weatherRunId !== null,
+              confidence_level: forecast.lastForecast.runMeta.confidenceLevel
+            }
+          : null,
         active_request: forecast.activeRequest
           ? {
               event_id: forecast.activeRequest.eventId || null,

--- a/ui/src/components/FireDetailsPanel.tsx
+++ b/ui/src/components/FireDetailsPanel.tsx
@@ -135,14 +135,29 @@ function formatIntensity(value: number, unit: "MW" | "K"): string {
   return `${value.toFixed(1)} ${unit}`;
 }
 
-function insightText(event: FireEvent): string {
+function observationSummary(event: FireEvent): string {
   if (event.review_required) {
-    return "This event is marked for analyst review. Treat the perimeter as provisional until verified.";
+    return "This event is flagged for analyst review. Treat the perimeter and intensity as provisional until verified.";
   }
-  if (typeof event.denoiser_decision === "string" && event.denoiser_decision.trim().length > 0) {
-    return `Denoiser decision is ${event.denoiser_decision}. Continue monitoring event score and fronts for escalation.`;
-  }
-  return "No denoiser decision is attached to this event snapshot.";
+  const time = typeof event.start_time === "string" && event.start_time.trim().length > 0
+    ? ` at ${formattedTime(event.start_time)}`
+    : "";
+  const provenance = String(event.geom_source || "").toLowerCase() === "authoritative"
+    ? "Authoritative perimeter from official source."
+    : "Perimeter is estimated from detection cluster.";
+  const fronts = Number(event.front_count || 0);
+  const frontStr = fronts === 1 ? "1 active front tracked." : fronts > 1 ? `${fronts} active fronts tracked.` : "No fronts tracked yet.";
+  return `Satellite thermal anomaly detected${time}. ${provenance} ${frontStr}`;
+}
+
+function satelliteLabel(source?: string | null, sensor?: string | null): string {
+  const s = `${source || ""} ${sensor || ""}`.toUpperCase();
+  if (s.includes("VIIRS") && (s.includes("NOAA20") || s.includes("NOAA-20"))) return "VIIRS · NOAA-20";
+  if (s.includes("VIIRS") && (s.includes("SNPP") || s.includes("NPP"))) return "VIIRS · Suomi-NPP";
+  if (s.includes("MODIS") && s.includes("TERRA")) return "MODIS · Terra";
+  if (s.includes("MODIS") && s.includes("AQUA")) return "MODIS · Aqua";
+  if (s.includes("CLUSTER") || s.includes("AGGREGATED")) return "Multi-sensor cluster";
+  return [source, sensor].filter(Boolean).join(" · ") || "Unknown sensor";
 }
 
 function geometryProvenanceLabel(event: FireEvent): "Authoritative perimeter" | "Estimated perimeter" {
@@ -548,11 +563,11 @@ export default function FireDetailsPanel({ visibleEvents }: FireDetailsPanelProp
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.85 }}>
             <InfoOutlinedIcon sx={{ fontSize: 14, color: "#60a5fa" }} />
             <Typography sx={{ fontSize: 10, color: "#fff", fontWeight: 800, letterSpacing: "0.12em", textTransform: "uppercase" }}>
-              Environment Insight
+              Observation
             </Typography>
           </Box>
           <Typography sx={{ fontSize: 12, color: "#9ca3af", lineHeight: 1.65, p: 1.6, borderRadius: 2.4, border: "1px solid rgba(255,255,255,0.06)", bgcolor: "rgba(22,27,34,0.55)", fontStyle: "italic" }}>
-            {insightText(selectedEvent)}
+            {observationSummary(selectedEvent)}
           </Typography>
         </Stack>
 
@@ -560,39 +575,38 @@ export default function FireDetailsPanel({ visibleEvents }: FireDetailsPanelProp
 
         <Stack spacing={1}>
           <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
-            <Typography sx={{ fontSize: 11, color: "#6b7280", fontWeight: 700 }}>Event ID</Typography>
-            <Typography sx={{ fontSize: 11, color: "#e5e7eb", fontFamily: "monospace" }}>{String(selectedEvent.event_id || "unknown")}</Typography>
+            <Typography sx={{ fontSize: 11, color: "#6b7280", fontWeight: 700 }}>First detected</Typography>
+            <Typography sx={{ fontSize: 11, color: "#e5e7eb" }}>{formattedTime(selectedEvent.start_time)}</Typography>
           </Box>
           <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
-            <Typography sx={{ fontSize: 11, color: "#6b7280", fontWeight: 700 }}>Source / Sensor</Typography>
+            <Typography sx={{ fontSize: 11, color: "#6b7280", fontWeight: 700 }}>Satellite</Typography>
             <Typography sx={{ fontSize: 11, color: "#e5e7eb" }}>
-              {String(selectedEvent.source || "unknown")} • {String(selectedEvent.sensor || "unknown")}
+              {satelliteLabel(selectedEvent.source, selectedEvent.sensor)}
             </Typography>
           </Box>
           <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
-            <Typography sx={{ fontSize: 11, color: "#6b7280", fontWeight: 700 }}>Detections</Typography>
-            <Typography sx={{ fontSize: 11, color: "#e5e7eb" }}>{Number(selectedEvent.detection_count || 0)}</Typography>
-          </Box>
-          <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
-            <Typography sx={{ fontSize: 11, color: "#6b7280", fontWeight: 700 }}>Window</Typography>
-            <Typography sx={{ fontSize: 11, color: "#e5e7eb" }}>
-              {formattedTime(selectedEvent.start_time)} → {formattedTime(selectedEvent.end_time)}
-            </Typography>
-          </Box>
-          <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
-            <Typography sx={{ fontSize: 11, color: "#6b7280", fontWeight: 700 }}>Fronts</Typography>
+            <Typography sx={{ fontSize: 11, color: "#6b7280", fontWeight: 700 }}>Active fronts</Typography>
             <Typography sx={{ fontSize: 11, color: "#e5e7eb" }}>{Number(selectedEvent.front_count || 0)}</Typography>
           </Box>
           <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
-            <Typography sx={{ fontSize: 11, color: "#6b7280", fontWeight: 700 }}>Decision</Typography>
-            <Typography sx={{ fontSize: 11, color: "#e5e7eb" }}>{String(selectedEvent.denoiser_decision || "unknown")}</Typography>
+            <Typography sx={{ fontSize: 11, color: "#6b7280", fontWeight: 700 }}>Perimeter</Typography>
+            <Typography sx={{ fontSize: 11, color: "#e5e7eb" }}>{geometryProvenanceLabel(selectedEvent)}</Typography>
           </Box>
 
           {selectedEvent.review_required && (
             <Box sx={{ mt: 0.8, px: 1.25, py: 1, border: "1px solid rgba(250,204,21,0.3)", bgcolor: "rgba(250,204,21,0.08)", borderRadius: 1.6, display: "flex", alignItems: "center", gap: 0.85 }}>
               <WarningAmberIcon sx={{ fontSize: 14, color: "#facc15" }} />
               <Typography sx={{ fontSize: 11, color: "#fcd34d", fontWeight: 700 }}>
-                Review required flag is active for this event.
+                Analyst review required — perimeter and intensity are provisional.
+              </Typography>
+            </Box>
+          )}
+
+          {forecast.lastForecast?.runMeta && forecast.lastForecast.runMeta.weatherRunId === null && (
+            <Box sx={{ mt: 0.8, px: 1.25, py: 1, border: "1px solid rgba(251,146,60,0.3)", bgcolor: "rgba(251,146,60,0.08)", borderRadius: 1.6, display: "flex", alignItems: "flex-start", gap: 0.85 }}>
+              <WarningAmberIcon sx={{ fontSize: 14, color: "#fb923c", mt: 0.1 }} />
+              <Typography sx={{ fontSize: 11, color: "#fdba74", fontWeight: 600, lineHeight: 1.5 }}>
+                Spread forecast assumed calm conditions — no weather data was available for this area and time. The symmetric shape reflects this, not actual wind direction.
               </Typography>
             </Box>
           )}

--- a/ui/src/config/assistant.ts
+++ b/ui/src/config/assistant.ts
@@ -16,10 +16,12 @@ Speak like a knowledgeable field analyst giving a verbal briefing — not like a
 - Avoid "AI fluff" — no "Great question!", "I'm happy to help", or unnecessary sign-offs.
 
 ### DATA INTERPRETATION GUIDELINES
-1. **Fire Radiative Power (FRP):** FRP in Megawatts indicates heat release rate. High FRP = intense fire behavior and greater fuel consumption. Contextualize against seasonal or regional norms when possible.
+1. **Fire Radiative Power (FRP):** FRP in Megawatts indicates heat release rate. Context: < 10 MW is low intensity (smoldering, agricultural), 10–100 MW is moderate, 100–500 MW is intense, > 500 MW is extreme. Translate the raw number into a plain-language severity when answering.
 2. **Confidence levels:** "Nominal" detections may include industrial flares, solar glint, or small agricultural burns. "High" confidence detections are almost certainly active wildfires.
 3. **Latency:** Satellite data has a ~3-hour processing lag. It's a snapshot, not a live feed — acknowledge this when timing matters.
 4. **Denoiser decisions:** If the denoiser flagged a detection as noise or requires review, surface that caveat.
+5. **Spread forecast quality:** The "run_quality" field in "forecast_context" tells you about the last generated spread forecast. If "weather_available" is false, the forecast assumed calm (zero-wind) conditions because no weather data was available for that area and time — the resulting shape will be a symmetric circle with no directional bias. Say this clearly when discussing the forecast shape. If "confidence_level" is present, interpret it for the user (e.g. "moderate confidence" rather than echoing the raw string).
+6. **Geometry provenance:** The "geom_source" field is "authoritative" when a confirmed fire perimeter exists from an official source, otherwise "estimated" (derived from detection cluster). Flag estimated perimeters as provisional when precision matters.
 
 ### SENSITIVE CONTEXTS
 When asked about causes, focus on ecological drivers (fuel load, humidity, wind patterns) rather than speculative human causes unless confirmed by official ground reports.

--- a/ui/src/hooks/useForecastPolling.ts
+++ b/ui/src/hooks/useForecastPolling.ts
@@ -47,7 +47,9 @@ export function useForecastPolling(): void {
     if (status === "completed") {
       const runId = String(query.data.result?.run_id || "");
       if (runId) {
-        completeForecastJob(runId);
+        const weatherRunId = (query.data.result?.weather_run_id as string | null | undefined) ?? null;
+        const confidenceLevel = (query.data.result?.confidence_level as string | null | undefined) ?? null;
+        completeForecastJob(runId, { weatherRunId, confidenceLevel });
         setForecastNotification({
           kind: "ready",
           message: `Forecast for the fire event from ${activeRequest?.locationLabel || "the selected area"} is ready!`,

--- a/ui/src/state/store.ts
+++ b/ui/src/state/store.ts
@@ -7,6 +7,7 @@ import type {
   ForecastJobState,
   ForecastNotification,
   ForecastRequestContext,
+  ForecastRunMeta,
   LayersState,
   MapViewState
 } from "../types/state";
@@ -74,7 +75,7 @@ interface AppStoreState {
   setFrontIndexByEvent: (index: Record<string, { frontId: string; detectionCount: number }>) => void;
   startForecastJob: (jobId: string, request: ForecastRequestContext) => void;
   incrementForecastPoll: () => void;
-  completeForecastJob: (runId: string) => void;
+  completeForecastJob: (runId: string, runMeta?: ForecastRunMeta) => void;
   clearForecastJob: () => void;
   setForecastNotification: (notification: ForecastNotification | null) => void;
   setAssistantViewContext: (context: AssistantViewContext) => void;
@@ -170,7 +171,7 @@ export const useAppStore = create<AppStoreState>((set) => ({
     }));
   },
 
-  completeForecastJob: (runId) => {
+  completeForecastJob: (runId, runMeta) => {
     set((state) => ({
       forecast: {
         ...state.forecast,
@@ -178,6 +179,7 @@ export const useAppStore = create<AppStoreState>((set) => ({
         pollCount: 0,
         lastForecast: {
           run: { id: runId },
+          ...(runMeta ? { runMeta } : {}),
           ...(state.forecast.activeRequest || {})
         },
         activeRequest: null

--- a/ui/src/types/state.ts
+++ b/ui/src/types/state.ts
@@ -50,10 +50,15 @@ export interface ForecastNotification {
   };
 }
 
+export interface ForecastRunMeta {
+  weatherRunId: string | null;
+  confidenceLevel: string | null;
+}
+
 export interface ForecastJobState {
   jobId: string | null;
   pollCount: number;
-  lastForecast: ({ run: { id: string } } & Partial<ForecastRequestContext>) | null;
+  lastForecast: ({ run: { id: string }; runMeta?: ForecastRunMeta } & Partial<ForecastRequestContext>) | null;
   activeRequest: ForecastRequestContext | null;
   notification: ForecastNotification | null;
 }


### PR DESCRIPTION
## Summary

- **Fire Inspector redesign**: replaces internal ML plumbing fields (denoiser decision, event ID, raw sensor strings) with user-facing situational awareness — "First detected", translated satellite name (e.g. "Multi-sensor cluster"), active fronts count, and perimeter type. Observation summary now reads as natural prose rather than a status dump.
- **Ecological assistant enrichment**: `compactEventContext()` now passes FRP, brightness, `geom_source`, and `geom_method` to Gemini. After a forecast completes, `run_quality` (`weather_available`, `confidence_level`) is included in the context so the assistant can explain forecast shape limitations.
- **Forecast quality transparency**: when a spread forecast ran without real weather data (`weather_run_id` is null — the zero-wind fallback path), an amber warning appears in the Fire Inspector: *"Spread forecast assumed calm conditions — no weather data was available for this area and time. The symmetric shape reflects this, not actual wind direction."*
- **System prompt**: adds FRP severity thresholds (< 10 MW smoldering → > 500 MW extreme), forecast quality guidance, and geometry provenance interpretation.

## Test plan

- [ ] Select a fire event with FRP > 0 — ask the assistant "how intense is this fire?" — it should reference the MW value with severity context
- [ ] Fire Inspector panel no longer shows "Denoiser decision", "Event ID", "Decision", or raw "Source / Sensor" row
- [ ] Satellite row shows translated name (e.g. "Multi-sensor cluster" for aggregated events)
- [ ] Generate a spread forecast — after completion, check `forecast.lastForecast.runMeta` in store contains `weatherRunId` and `confidenceLevel`
- [ ] If `weatherRunId` is null, orange warning box appears below the metadata in Fire Inspector
- [ ] Ask the assistant "what does the spread forecast show?" — if weather was unavailable it should explain the circular shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)