### PR TITLE
fix(ui): increase news card image height to 110px

### DIFF
--- a/ui/src/components/FireDetailsPanel.tsx
+++ b/ui/src/components/FireDetailsPanel.tsx
@@ -254,7 +254,7 @@ function NewsCard({ item, expanded = false }: { item: GdeltArticle; expanded?: b
       }}
     >
       {item.socialimage && (
-        <Box sx={{ position: "relative", height: expanded ? 140 : 80, overflow: "hidden" }}>
+        <Box sx={{ position: "relative", height: expanded ? 140 : 110, overflow: "hidden" }}>
           <Box
             component="img"
             src={item.socialimage}


### PR DESCRIPTION
## Changes

- Increased the collapsed news card image height from 80px to 110px
- This adjustment provides better visual balance, resulting in an approximately 150px total card height when collapsed
- The expanded state height (140px) remains unchanged

## Files Modified

- `ui/src/components/FireDetailsPanel.tsx`: Updated the `Box` component's `height` property in the `NewsCard` component