### PR TITLE
feat(ml): enforce spread feature contract between train and infer

### DIFF
--- a/ml/eval_spread_champion_challenger.py
+++ b/ml/eval_spread_champion_challenger.py
@@ -24,6 +24,12 @@ from api.db import get_engine
 from api.fires.service import get_fire_cells_heatmap
 from ml.spread.factory import get_spread_model, normalize_model_selection
 from ml.spread.hindcast_dataset import sample_fire_reference_times
+from ml.spread.runtime_contract import (
+    CANONICAL_CHANNELS_BY_MODEL,
+    ContractViolationError,
+    load_contract,
+    validate_channel_alignment,
+)
 from ml.spread_features import build_spread_inputs
 
 LOGGER = logging.getLogger(__name__)
@@ -409,6 +415,49 @@ def _build_stage_governance(
                 "target_stage": maturity_stage,
             }
         )
+
+    # STOP-CONTRACT-001: challenger feature schema must exactly match the canonical
+    # channel list for spatial models. A mismatch means train/infer channels diverged
+    # and the metric comparison is scientifically invalid.
+    if challenger_name in CANONICAL_CHANNELS_BY_MODEL:
+        canonical = CANONICAL_CHANNELS_BY_MODEL[challenger_name]
+        challenger_model_run_dir = (challenger_params or {}).get("model_run_dir")
+        contract_stop: dict[str, Any] | None = None
+        if not challenger_model_run_dir:
+            contract_stop = {
+                "id": "STOP-CONTRACT-001",
+                "message": (
+                    f"challenger {challenger_name!r} has no model_run_dir in model_params; "
+                    "cannot verify feature contract."
+                ),
+                "mitigation": "Set challenger.model_params.model_run_dir to the trained model artifact directory.",
+                "target_stage": maturity_stage,
+            }
+        else:
+            run_dir = Path(challenger_model_run_dir)
+            try:
+                try:
+                    infer_channels = load_contract(run_dir / "runtime_contract.json").channels
+                except FileNotFoundError:
+                    payload = json.loads((run_dir / "feature_schema.json").read_text(encoding="utf-8"))
+                    raw = payload.get("channels")
+                    if not isinstance(raw, list) or not raw:
+                        raise KeyError("channels key missing or empty in feature_schema.json")
+                    infer_channels = tuple(str(c) for c in raw)
+                validate_channel_alignment(infer_channels, canonical)
+            except (ContractViolationError, FileNotFoundError, KeyError, ValueError) as exc:
+                contract_stop = {
+                    "id": "STOP-CONTRACT-001",
+                    "message": str(exc),
+                    "mitigation": (
+                        "Re-export the challenger model so its feature_schema.json / "
+                        "runtime_contract.json matches CANONICAL_V2_CHANNELS, or update "
+                        "CANONICAL_V2_CHANNELS and retrain."
+                    ),
+                    "target_stage": maturity_stage,
+                }
+        if contract_stop is not None:
+            hard_stops.append(contract_stop)
 
     weighted_bss = float(decision.get("weighted_bss_improvement", 0.0) or 0.0)
     if weighted_bss <= 0.0:

--- a/ml/spread/hindcast_dataset.py
+++ b/ml/spread/hindcast_dataset.py
@@ -15,32 +15,14 @@ from sqlalchemy.engine import Engine
 from api.db import get_engine
 from api.fires.service import get_fire_cells_heatmap
 from ml.spread.region_key import deterministic_region_bucket
+from ml.spread.runtime_contract import CANONICAL_V2_CHANNELS, CANONICAL_V3_CHANNELS
 from ml.spread_features import build_spread_inputs
 
 LOGGER = logging.getLogger(__name__)
 
-# Fixed channel order for v2 tensor training/inference.
-V2_TENSOR_CHANNELS: tuple[str, ...] = (
-    "fire_t0",
-    "fire_t-6h",
-    "fire_t-12h",
-    "u10",
-    "v10",
-    "t2m",
-    "rh2m",
-    "precip_24h",
-    "slope_deg",
-    "aspect_sin",
-    "aspect_cos",
-    "elevation_m",
-    "ruggedness",
-    "tpi",
-    "ndvi",
-    "lfmc",
-    "dfmc",
-    "region_id_embedding_input",
-)
-V3_TENSOR_CHANNELS: tuple[str, ...] = V2_TENSOR_CHANNELS
+# Channel order is owned by runtime_contract.py — do not redefine locally.
+V2_TENSOR_CHANNELS: tuple[str, ...] = CANONICAL_V2_CHANNELS
+V3_TENSOR_CHANNELS: tuple[str, ...] = CANONICAL_V3_CHANNELS
 
 
 def sample_fire_reference_times(

--- a/ml/spread/learned_v2.py
+++ b/ml/spread/learned_v2.py
@@ -14,8 +14,19 @@ import xarray as xr
 from ml.calibration import SpreadProbabilityCalibrator
 from ml.spread.contract import SpreadForecast, SpreadModel, SpreadModelInput
 from ml.spread.hindcast_dataset import V2_TENSOR_CHANNELS
+from ml.spread.runtime_contract import (
+    ContractViolationError,
+    load_contract,
+    validate_channel_alignment,
+)
 
 LOGGER = logging.getLogger(__name__)
+
+# Exhaustive set of channels this inference builder knows how to produce.
+# If a channel appears in channel_names but is absent here, _build_feature_tensor
+# would silently fail with a KeyError — instead we raise a ContractViolationError
+# at model-init time so the failure is loud and attributable.
+_PRODUCIBLE_CHANNELS: frozenset[str] = frozenset(V2_TENSOR_CHANNELS)
 
 
 def _sigmoid(x: np.ndarray) -> np.ndarray:
@@ -63,6 +74,23 @@ class LearnedSpreadModelV2(SpreadModel):
             channels = payload.get("channels")
             if isinstance(channels, list) and channels:
                 self.channel_names = [str(c) for c in channels]
+
+        # Contract validation: if runtime_contract.json is present, verify that
+        # the resolved channel list matches what the model was trained on.
+        try:
+            contract = load_contract(run_dir / "runtime_contract.json")
+            validate_channel_alignment(self.channel_names, contract.channels)
+        except FileNotFoundError:
+            pass  # contract file is optional for models exported before this check was added
+
+        # Guard: every channel in channel_names must be producible by this builder.
+        unproducible = [c for c in self.channel_names if c not in _PRODUCIBLE_CHANNELS]
+        if unproducible:
+            raise ContractViolationError(
+                f"STOP: model requires channels this inference builder cannot produce: {unproducible}. "
+                "Add them to _build_feature_tensor and _PRODUCIBLE_CHANNELS, or retrain with "
+                "CANONICAL_V2_CHANNELS."
+            )
 
         onnx_path = run_dir / self.onnx_filename
         if not onnx_path.exists():

--- a/ml/spread/runtime_contract.py
+++ b/ml/spread/runtime_contract.py
@@ -1,0 +1,195 @@
+"""Runtime contract for spread model feature channels.
+
+This module is the single source of truth for channel schema, tensor specs,
+and feature order across train and infer. Any drift between the hindcast
+dataset builder and the inference feature builder is a hard stop.
+
+Usage at training time:
+    write_contract(model_run_dir / "runtime_contract.json",
+                   SpreadRuntimeContract(channels=CANONICAL_V2_CHANNELS))
+
+Usage at inference time:
+    contract = load_contract(model_run_dir / "runtime_contract.json")
+    validate_channel_alignment(model.channel_names, contract.channels)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Canonical channel definitions
+# ---------------------------------------------------------------------------
+
+#: Authoritative channel list and order for v2/v3 spatial spread models.
+#: This tuple is imported by both hindcast_dataset.py (training) and
+#: learned_v2.py (inference). Never redefine it locally elsewhere.
+CANONICAL_V2_CHANNELS: tuple[str, ...] = (
+    "fire_t0",
+    "fire_t-6h",
+    "fire_t-12h",
+    "u10",
+    "v10",
+    "t2m",
+    "rh2m",
+    "precip_24h",
+    "slope_deg",
+    "aspect_sin",
+    "aspect_cos",
+    "elevation_m",
+    "ruggedness",
+    "tpi",
+    "ndvi",
+    "lfmc",
+    "dfmc",
+    "region_id_embedding_input",
+)
+
+#: v3 shares the same channel schema as v2.
+CANONICAL_V3_CHANNELS: tuple[str, ...] = CANONICAL_V2_CHANNELS
+
+#: Map model class name → canonical channels, for gate-time lookup.
+CANONICAL_CHANNELS_BY_MODEL: dict[str, tuple[str, ...]] = {
+    "LearnedSpreadModelV2": CANONICAL_V2_CHANNELS,
+    "LearnedSpreadModelV3": CANONICAL_V3_CHANNELS,
+}
+
+# ---------------------------------------------------------------------------
+# Contract dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SpreadRuntimeContract:
+    """Immutable specification of the feature tensor a model was trained on."""
+
+    channels: tuple[str, ...]
+    dtype: str = "float32"
+    layout: str = "CHW"  # channel-first spatial tensor
+
+    @property
+    def n_channels(self) -> int:
+        return len(self.channels)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"channels": list(self.channels), "dtype": self.dtype, "layout": self.layout}
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "SpreadRuntimeContract":
+        return cls(
+            channels=tuple(d["channels"]),
+            dtype=d.get("dtype", "float32"),
+            layout=d.get("layout", "CHW"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Error type
+# ---------------------------------------------------------------------------
+
+
+class ContractViolationError(RuntimeError):
+    """Raised when train-time and infer-time feature channels diverge."""
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def validate_channel_alignment(
+    infer_channels: Sequence[str],
+    dataset_channels: Sequence[str],
+) -> None:
+    """Raise ContractViolationError with a human-readable diff if channels diverge.
+
+    Both name AND order must match — a reordering is a silent data corruption,
+    not a recoverable warning.
+    """
+    infer = list(infer_channels)
+    dataset = list(dataset_channels)
+
+    if infer == dataset:
+        return
+
+    infer_set = set(infer)
+    dataset_set = set(dataset)
+
+    lines: list[str] = []
+    missing_in_infer = sorted(dataset_set - infer_set)
+    extra_in_infer = sorted(infer_set - dataset_set)
+
+    if missing_in_infer:
+        lines.append(f"  channels in dataset but missing from inference: {missing_in_infer}")
+    if extra_in_infer:
+        lines.append(f"  channels in inference but absent from dataset: {extra_in_infer}")
+
+    if not lines:
+        # Same set, but wrong order.
+        first_diff = next(
+            (i for i, (a, b) in enumerate(zip(infer, dataset)) if a != b), len(infer)
+        )
+        lines.append(
+            f"  channel order mismatch starting at index {first_diff}: "
+            f"inference has {infer[first_diff]!r}, dataset expects {dataset[first_diff]!r}"
+        )
+
+    raise ContractViolationError(
+        "STOP: feature channel mismatch between inference builder and training dataset.\n"
+        + "\n".join(lines)
+    )
+
+
+def validate_feature_tensor(tensor: np.ndarray, contract: SpreadRuntimeContract) -> None:
+    """Raise ContractViolationError if the tensor C-dimension doesn't match the contract.
+
+    Expects layout CHW (ndim == 3) or NCHW (ndim == 4, validates dim 1).
+    """
+    arr = np.asarray(tensor)
+    if arr.ndim == 3:
+        c = arr.shape[0]
+    elif arr.ndim == 4:
+        c = arr.shape[1]
+    else:
+        raise ContractViolationError(
+            f"STOP: expected 3-D (CHW) or 4-D (NCHW) tensor, got ndim={arr.ndim}"
+        )
+
+    if c != contract.n_channels:
+        raise ContractViolationError(
+            f"STOP: tensor has {c} channels, contract requires {contract.n_channels}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def write_contract(path: Path, contract: SpreadRuntimeContract) -> None:
+    """Write runtime_contract.json to *path* (file path, not directory)."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(contract.to_dict(), indent=2) + "\n", encoding="utf-8")
+
+
+def load_contract(path: Path) -> SpreadRuntimeContract:
+    """Load runtime_contract.json from *path*.
+
+    Raises FileNotFoundError if the file is absent — absence is a hard stop,
+    not a condition to silently skip.
+    """
+    path = Path(path)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            f"STOP: runtime_contract.json not found at {path}. "
+            "Re-export the model to generate a contract file."
+        )
+    return SpreadRuntimeContract.from_dict(payload)

--- a/ml/tests/test_spread_runtime_contract_integration.py
+++ b/ml/tests/test_spread_runtime_contract_integration.py
@@ -1,0 +1,404 @@
+"""Integration tests: spread feature contract enforcement (train vs. infer).
+
+Done criteria:
+  - Contract schema exists (runtime_contract.py)
+  - Integration test passes (this file)
+  - Gate report rejects on mismatch (STOP-CONTRACT-001)
+
+Tests in this file use no DB, no ONNX session, and no external services.
+They operate purely on channel lists and tensor shapes.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from ml.spread.runtime_contract import (
+    CANONICAL_V2_CHANNELS,
+    ContractViolationError,
+    SpreadRuntimeContract,
+    load_contract,
+    validate_channel_alignment,
+    validate_feature_tensor,
+    write_contract,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FakeGridWindow:
+    lat: np.ndarray
+    lon: np.ndarray
+
+
+@dataclass(frozen=True)
+class _FakeFireHeatmap:
+    heatmap: np.ndarray
+
+
+@dataclass(frozen=True)
+class _FakeTerrain:
+    slope: np.ndarray
+    aspect: np.ndarray
+    elevation: np.ndarray | None = None
+
+
+def _make_spread_model_input(ny: int = 8, nx: int = 8):
+    """Minimal SpreadModelInput-compatible object for _build_feature_tensor."""
+    lat = np.linspace(30.0, 31.0, ny, dtype=np.float32)
+    lon = np.linspace(-120.0, -119.0, nx, dtype=np.float32)
+    zeros = np.zeros((ny, nx), dtype=np.float32)
+    weather_cube = xr.Dataset(
+        {
+            "u10": (["lat", "lon"], zeros.copy()),
+            "v10": (["lat", "lon"], zeros.copy()),
+            "t2m": (["lat", "lon"], zeros.copy()),
+            "rh2m": (["lat", "lon"], zeros.copy()),
+            "precip_24h": (["lat", "lon"], zeros.copy()),
+            "ndvi": (["lat", "lon"], zeros.copy()),
+            "lfmc": (["lat", "lon"], zeros.copy()),
+            "dfmc": (["lat", "lon"], zeros.copy()),
+        },
+        coords={"lat": lat, "lon": lon},
+    )
+    return types.SimpleNamespace(
+        active_fires=_FakeFireHeatmap(heatmap=zeros.copy()),
+        terrain=_FakeTerrain(slope=zeros.copy(), aspect=zeros.copy(), elevation=zeros.copy()),
+        weather_cube=weather_cube,
+        horizons_hours=[2, 6, 12],
+        window=_FakeGridWindow(lat=lat, lon=lon),
+        forecast_reference_time=datetime.now(timezone.utc),
+        fire_history_t6h=None,
+        fire_history_t12h=None,
+    )
+
+
+class _DummyOrt:
+    """Minimal onnxruntime stand-in for tests that exercise model init but not inference."""
+
+    class SessionOptions:
+        intra_op_num_threads = 1
+
+    class InferenceSession:
+        def __init__(self, *a, **kw):
+            pass
+
+        def get_inputs(self):
+            return [types.SimpleNamespace(name="x")]
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Channel list identity — hindcast dataset must mirror canonical contract
+# ---------------------------------------------------------------------------
+
+
+def test_hindcast_channels_match_canonical():
+    """V2_TENSOR_CHANNELS in hindcast_dataset.py must equal CANONICAL_V2_CHANNELS.
+
+    If this fails, someone redefined the channel list locally instead of
+    importing from runtime_contract.py.
+    """
+    from ml.spread.hindcast_dataset import V2_TENSOR_CHANNELS
+
+    assert V2_TENSOR_CHANNELS == CANONICAL_V2_CHANNELS, (
+        "V2_TENSOR_CHANNELS in hindcast_dataset.py has diverged from CANONICAL_V2_CHANNELS. "
+        "Edit hindcast_dataset.py to re-import from ml.spread.runtime_contract."
+    )
+
+
+def test_hindcast_v3_channels_match_canonical():
+    from ml.spread.hindcast_dataset import V3_TENSOR_CHANNELS
+    from ml.spread.runtime_contract import CANONICAL_V3_CHANNELS
+
+    assert V3_TENSOR_CHANNELS == CANONICAL_V3_CHANNELS
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Inference builder produces a tensor matching CANONICAL_V2_CHANNELS
+# ---------------------------------------------------------------------------
+
+
+def test_learned_v2_build_feature_tensor_matches_canonical(monkeypatch):
+    """LearnedSpreadModelV2._build_feature_tensor must produce exactly len(CANONICAL_V2_CHANNELS) channels.
+
+    We instantiate the model via __new__ to skip ONNX loading, then call
+    _build_feature_tensor directly. No DB, no ONNX session needed.
+    """
+    from ml.spread.learned_v2 import LearnedSpreadModelV2
+
+    model = LearnedSpreadModelV2.__new__(LearnedSpreadModelV2)
+    model.channel_names = list(CANONICAL_V2_CHANNELS)
+
+    inp = _make_spread_model_input()
+    tensor = model._build_feature_tensor(inp)
+
+    # Shape: (1, C, H, W)
+    assert tensor.ndim == 4, f"Expected 4-D (NCHW) tensor, got ndim={tensor.ndim}"
+    n, c, h, w = tensor.shape
+    assert n == 1
+    assert c == len(CANONICAL_V2_CHANNELS), (
+        f"Tensor has {c} channels but CANONICAL_V2_CHANNELS has {len(CANONICAL_V2_CHANNELS)}. "
+        "Update _build_feature_tensor to match the canonical channel list."
+    )
+    assert h == 8 and w == 8
+
+    # Contract-level tensor validation must not raise.
+    contract = SpreadRuntimeContract(channels=CANONICAL_V2_CHANNELS)
+    validate_feature_tensor(tensor, contract)
+
+
+def test_learned_v2_rejects_unknown_channel_in_schema(tmp_path, monkeypatch):
+    """If feature_schema.json lists a channel the builder cannot produce,
+    model init must raise ContractViolationError — not silently fail at inference.
+    """
+    from ml.spread.learned_v2 import LearnedSpreadModelV2
+
+    run_dir = tmp_path / "model_run"
+    run_dir.mkdir()
+    bad_channels = list(CANONICAL_V2_CHANNELS[:-1]) + ["UNKNOWN_CHANNEL_XYZ"]
+    (run_dir / "feature_schema.json").write_text(
+        json.dumps({"channels": bad_channels}), encoding="utf-8"
+    )
+    (run_dir / "model.onnx").write_bytes(b"dummy")
+    monkeypatch.setitem(sys.modules, "onnxruntime", _DummyOrt())
+
+    with pytest.raises(ContractViolationError, match="UNKNOWN_CHANNEL_XYZ"):
+        LearnedSpreadModelV2(model_run_dir=str(run_dir))
+
+
+def test_learned_v2_passes_when_runtime_contract_matches(tmp_path, monkeypatch):
+    """When runtime_contract.json matches channel_names, init must succeed."""
+    from ml.spread.learned_v2 import LearnedSpreadModelV2
+
+    run_dir = tmp_path / "model_run"
+    run_dir.mkdir()
+    (run_dir / "feature_schema.json").write_text(
+        json.dumps({"channels": list(CANONICAL_V2_CHANNELS)}), encoding="utf-8"
+    )
+    write_contract(run_dir / "runtime_contract.json", SpreadRuntimeContract(channels=CANONICAL_V2_CHANNELS))
+    (run_dir / "model.onnx").write_bytes(b"dummy")
+    monkeypatch.setitem(sys.modules, "onnxruntime", _DummyOrt())
+
+    model = LearnedSpreadModelV2(model_run_dir=str(run_dir))
+    assert model.channel_names == list(CANONICAL_V2_CHANNELS)
+
+
+def test_learned_v2_rejects_when_runtime_contract_mismatches_schema(tmp_path, monkeypatch):
+    """If runtime_contract.json and feature_schema.json disagree, init must raise."""
+    from ml.spread.learned_v2 import LearnedSpreadModelV2
+
+    run_dir = tmp_path / "model_run"
+    run_dir.mkdir()
+    (run_dir / "feature_schema.json").write_text(
+        json.dumps({"channels": list(CANONICAL_V2_CHANNELS)}), encoding="utf-8"
+    )
+    wrong_channels = ("fire_t0", "fire_t-6h")  # severely truncated
+    write_contract(run_dir / "runtime_contract.json", SpreadRuntimeContract(channels=wrong_channels))
+    (run_dir / "model.onnx").write_bytes(b"dummy")
+    monkeypatch.setitem(sys.modules, "onnxruntime", _DummyOrt())
+
+    with pytest.raises(ContractViolationError, match="STOP"):
+        LearnedSpreadModelV2(model_run_dir=str(run_dir))
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Gate report rejects on channel mismatch (STOP-CONTRACT-001)
+# ---------------------------------------------------------------------------
+
+
+_GOOD_DECISION = {
+    "pass": True,
+    "weighted_bss_improvement": 0.05,
+    "recommend_challenger": True,
+    "reasons": [],
+}
+
+
+def test_gate_stop_contract_001_fires_on_wrong_feature_schema(tmp_path):
+    """STOP-CONTRACT-001 must appear when challenger feature_schema has wrong channels."""
+    from ml.eval_spread_champion_challenger import _build_stage_governance
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    bad_channels = list(CANONICAL_V2_CHANNELS[:-1]) + ["RENAMED_CHANNEL"]
+    (run_dir / "feature_schema.json").write_text(
+        json.dumps({"channels": bad_channels}), encoding="utf-8"
+    )
+
+    config = {
+        "gate": {"maturity_stage": "mvp_operational"},
+        "challenger": {
+            "model_name": "LearnedSpreadModelV2",
+            "model_params": {"model_run_dir": str(run_dir)},
+        },
+    }
+    governance = _build_stage_governance(config=config, decision=_GOOD_DECISION, summary_rows=[])
+    stop_ids = [s["id"] for s in governance["hard_stops"]]
+    assert "STOP-CONTRACT-001" in stop_ids, (
+        f"Expected STOP-CONTRACT-001 in hard_stops, got: {stop_ids}"
+    )
+    assert governance["promotion_decision"] == "hold_challenger"
+
+
+def test_gate_stop_contract_001_fires_on_missing_schema(tmp_path):
+    """STOP-CONTRACT-001 must appear when model_run_dir has no schema file at all."""
+    from ml.eval_spread_champion_challenger import _build_stage_governance
+
+    run_dir = tmp_path / "empty_run"
+    run_dir.mkdir()  # no feature_schema.json or runtime_contract.json
+
+    config = {
+        "gate": {"maturity_stage": "mvp_operational"},
+        "challenger": {
+            "model_name": "LearnedSpreadModelV2",
+            "model_params": {"model_run_dir": str(run_dir)},
+        },
+    }
+    governance = _build_stage_governance(config=config, decision=_GOOD_DECISION, summary_rows=[])
+    stop_ids = [s["id"] for s in governance["hard_stops"]]
+    assert "STOP-CONTRACT-001" in stop_ids
+
+
+def test_gate_stop_contract_001_fires_when_model_run_dir_missing(tmp_path):
+    """STOP-CONTRACT-001 must appear when model_params has no model_run_dir."""
+    from ml.eval_spread_champion_challenger import _build_stage_governance
+
+    config = {
+        "gate": {"maturity_stage": "mvp_operational"},
+        "challenger": {
+            "model_name": "LearnedSpreadModelV2",
+            "model_params": {},
+        },
+    }
+    governance = _build_stage_governance(config=config, decision=_GOOD_DECISION, summary_rows=[])
+    stop_ids = [s["id"] for s in governance["hard_stops"]]
+    assert "STOP-CONTRACT-001" in stop_ids
+
+
+def test_gate_passes_when_runtime_contract_matches_canonical(tmp_path):
+    """Gate must NOT fire STOP-CONTRACT-001 when runtime_contract.json is correct."""
+    from ml.eval_spread_champion_challenger import _build_stage_governance
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    write_contract(
+        run_dir / "runtime_contract.json",
+        SpreadRuntimeContract(channels=CANONICAL_V2_CHANNELS),
+    )
+
+    config = {
+        "gate": {"maturity_stage": "mvp_operational"},
+        "challenger": {
+            "model_name": "LearnedSpreadModelV2",
+            "model_params": {"model_run_dir": str(run_dir)},
+        },
+    }
+    governance = _build_stage_governance(config=config, decision=_GOOD_DECISION, summary_rows=[])
+    stop_ids = [s["id"] for s in governance["hard_stops"]]
+    assert "STOP-CONTRACT-001" not in stop_ids, (
+        f"STOP-CONTRACT-001 fired unexpectedly; hard_stops={governance['hard_stops']}"
+    )
+
+
+def test_gate_passes_when_feature_schema_matches_canonical(tmp_path):
+    """Gate must NOT fire STOP-CONTRACT-001 when feature_schema.json has correct channels."""
+    from ml.eval_spread_champion_challenger import _build_stage_governance
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "feature_schema.json").write_text(
+        json.dumps({"channels": list(CANONICAL_V2_CHANNELS)}), encoding="utf-8"
+    )
+
+    config = {
+        "gate": {"maturity_stage": "mvp_operational"},
+        "challenger": {
+            "model_name": "LearnedSpreadModelV2",
+            "model_params": {"model_run_dir": str(run_dir)},
+        },
+    }
+    governance = _build_stage_governance(config=config, decision=_GOOD_DECISION, summary_rows=[])
+    stop_ids = [s["id"] for s in governance["hard_stops"]]
+    assert "STOP-CONTRACT-001" not in stop_ids
+
+
+def test_gate_skips_contract_check_for_heuristic_model():
+    """Heuristic/tabular models have no tensor schema — gate must not fire STOP-CONTRACT-001."""
+    from ml.eval_spread_champion_challenger import _build_stage_governance
+
+    config = {
+        "gate": {"maturity_stage": "mvp_operational"},
+        "challenger": {
+            "model_name": "HeuristicSpreadModelV0",
+            "model_params": {},
+        },
+    }
+    governance = _build_stage_governance(config=config, decision=_GOOD_DECISION, summary_rows=[])
+    stop_ids = [s["id"] for s in governance["hard_stops"]]
+    assert "STOP-CONTRACT-001" not in stop_ids
+
+
+# ---------------------------------------------------------------------------
+# Test 4: runtime_contract.py utility round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_write_and_load_contract_roundtrip(tmp_path):
+    contract = SpreadRuntimeContract(channels=CANONICAL_V2_CHANNELS)
+    path = tmp_path / "runtime_contract.json"
+    write_contract(path, contract)
+    loaded = load_contract(path)
+    assert loaded.channels == CANONICAL_V2_CHANNELS
+    assert loaded.dtype == "float32"
+    assert loaded.layout == "CHW"
+
+
+def test_load_contract_raises_on_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError, match="STOP"):
+        load_contract(tmp_path / "does_not_exist.json")
+
+
+def test_validate_channel_alignment_passes_on_match():
+    validate_channel_alignment(CANONICAL_V2_CHANNELS, CANONICAL_V2_CHANNELS)
+
+
+def test_validate_channel_alignment_raises_on_missing_channel():
+    truncated = CANONICAL_V2_CHANNELS[:-1]
+    with pytest.raises(ContractViolationError, match="missing from inference"):
+        validate_channel_alignment(truncated, CANONICAL_V2_CHANNELS)
+
+
+def test_validate_channel_alignment_raises_on_wrong_order():
+    reordered = list(CANONICAL_V2_CHANNELS)
+    reordered[0], reordered[1] = reordered[1], reordered[0]
+    with pytest.raises(ContractViolationError, match="order mismatch"):
+        validate_channel_alignment(reordered, list(CANONICAL_V2_CHANNELS))
+
+
+def test_validate_feature_tensor_passes_correct_shape():
+    contract = SpreadRuntimeContract(channels=CANONICAL_V2_CHANNELS)
+    c = len(CANONICAL_V2_CHANNELS)
+    tensor_chw = np.zeros((c, 8, 8), dtype=np.float32)
+    validate_feature_tensor(tensor_chw, contract)  # must not raise
+
+    tensor_nchw = np.zeros((1, c, 8, 8), dtype=np.float32)
+    validate_feature_tensor(tensor_nchw, contract)  # must not raise
+
+
+def test_validate_feature_tensor_raises_on_wrong_channel_count():
+    contract = SpreadRuntimeContract(channels=CANONICAL_V2_CHANNELS)
+    wrong = np.zeros((5, 8, 8), dtype=np.float32)  # only 5 channels
+    with pytest.raises(ContractViolationError, match="channels"):
+        validate_feature_tensor(wrong, contract)

--- a/ml/train_spread_v2.py
+++ b/ml/train_spread_v2.py
@@ -24,6 +24,7 @@ from ml.spread.hindcast_dataset import (
     V2_TENSOR_CHANNELS,
     build_hindcast_tensor_dataset,
 )
+from ml.spread.runtime_contract import SpreadRuntimeContract, write_contract
 
 LOGGER = logging.getLogger("train_spread_v2")
 
@@ -433,6 +434,7 @@ def train_spread_v2(config: dict[str, Any]) -> Path:
         json.dumps(feature_schema, indent=2) + "\n",
         encoding="utf-8",
     )
+    write_contract(run_dir / "runtime_contract.json", SpreadRuntimeContract(channels=tuple(channel_names)))
     (run_dir / "config_resolved.yaml").write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
 
     metadata = {


### PR DESCRIPTION
## Summary

- Adds `ml/spread/runtime_contract.py` as the single source of truth for spread model channel schema, tensor specs, and feature order — replacing the locally-defined `V2_TENSOR_CHANNELS` tuple in `hindcast_dataset.py`
- Wires contract validation as a hard stop (`ContractViolationError`) in `LearnedSpreadModelV2._load_artifacts` — channels that the inference builder cannot produce are caught at model init, not silently at prediction time
- Adds `STOP-CONTRACT-001` to `_build_stage_governance` in the champion-challenger gate — any `LearnedSpreadModelV2/V3` challenger whose `feature_schema.json` or `runtime_contract.json` mismatches `CANONICAL_V2_CHANNELS` blocks promotion
- `train_spread_v2` now emits `runtime_contract.json` alongside `feature_schema.json` after each training run

## Test plan

- [ ] `uv run --project ml pytest ml/tests/test_spread_runtime_contract_integration.py -v` — 19 tests covering channel identity, tensor shape validation, gate rejection (missing schema, wrong channels, missing model_run_dir), gate pass (correct contract, correct schema), heuristic model bypass, and utility round-trips
- [ ] `uv run --project ml pytest ml/tests/ -m "not integration"` — full suite, zero regressions (158 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)