### PR TITLE
feat(ml): geospatial alignment hard stops for spread pipeline

### DIFF
--- a/ml/eval_spread_champion_challenger.py
+++ b/ml/eval_spread_champion_challenger.py
@@ -21,7 +21,7 @@ from scipy import stats
 from sklearn.metrics import average_precision_score
 
 from api.db import get_engine
-from api.fires.service import get_fire_cells_heatmap
+from api.fires.service import get_fire_cells_heatmap, get_region_grid_spec
 from ml.spread.factory import get_spread_model, normalize_model_selection
 from ml.spread.hindcast_dataset import sample_fire_reference_times
 from ml.spread.runtime_contract import (
@@ -30,7 +30,7 @@ from ml.spread.runtime_contract import (
     load_contract,
     validate_channel_alignment,
 )
-from ml.spread_features import build_spread_inputs
+from ml.spread_features import assert_grid_alignment, build_spread_inputs
 
 LOGGER = logging.getLogger(__name__)
 
@@ -571,6 +571,12 @@ def _collect_comparison_arrays(config: dict[str, Any]) -> dict[int, dict[str, An
 
     champion = get_spread_model(champ_name, champ_params)
     challenger = get_spread_model(chall_name, chall_params)
+
+    # Pre-flight: validate grid alignment before sampling reference times.
+    # Fail fast before any DB queries if the region grid diverges from the
+    # canonical analysis-grid contract (CRS=EPSG:4326, cell_size=0.01°).
+    preflight_grid = get_region_grid_spec(region_name)
+    assert_grid_alignment(preflight_grid)
 
     engine = get_engine()
     ref_times = sample_fire_reference_times(

--- a/ml/spread_features.py
+++ b/ml/spread_features.py
@@ -12,7 +12,7 @@ import numpy as np
 import sqlalchemy as sa
 import xarray as xr
 
-from api.core.grid import GridSpec, GridWindow, get_grid_window_for_bbox
+from api.core.grid import DEFAULT_CELL_SIZE_DEG, DEFAULT_CRS, GridSpec, GridWindow, get_grid_window_for_bbox
 from api.db import get_engine
 from api.fires.service import FireHeatmapWindow, get_fire_cells_heatmap, get_region_grid_spec
 from api.terrain.window import TerrainWindow, load_terrain_window
@@ -96,6 +96,30 @@ def _assert_same_window(*, expected: GridWindow, actual: GridWindow, label: str)
             f"{label} window does not match requested AOI window. "
             f"expected={(expected.i0, expected.i1, expected.j0, expected.j1)} "
             f"actual={(actual.i0, actual.i1, actual.j0, actual.j1)}"
+        )
+
+
+def assert_grid_alignment(grid: GridSpec) -> None:
+    """Hard stop if the grid CRS or cell size diverges from the analysis-grid contract.
+
+    STOP-GEO-CRS: CRS must be EPSG:4326.  Any other projection breaks pixel-level
+    lat/lon alignment between fire, weather, and terrain layers.
+
+    STOP-GEO-RES: Cell size must match DEFAULT_CELL_SIZE_DEG (0.01°).  A mismatched
+    resolution means train-time features are computed at a different spatial scale than
+    inference, invalidating learned spatial relationships.
+    """
+    if grid.crs != DEFAULT_CRS:
+        raise ValueError(
+            f"STOP-GEO-CRS: analysis grid CRS={grid.crs!r} does not match the required "
+            f"CRS {DEFAULT_CRS!r}. Re-project the grid to EPSG:4326 before assembling "
+            f"spread inputs."
+        )
+    if abs(grid.cell_size_deg - DEFAULT_CELL_SIZE_DEG) > 1e-9:
+        raise ValueError(
+            f"STOP-GEO-RES: analysis grid cell_size_deg={grid.cell_size_deg!r} does not "
+            f"match the training grid cell size {DEFAULT_CELL_SIZE_DEG!r}. Regridding to "
+            f"a different resolution is not supported — use the canonical 0.01° grid."
         )
 
 
@@ -495,6 +519,9 @@ def build_spread_inputs(
     else:
         grid = get_region_grid_spec(region_name)
     window = get_grid_window_for_bbox(grid, bbox, clip=True)
+
+    # STOP-GEO-CRS / STOP-GEO-RES: grid must match the canonical analysis grid contract.
+    assert_grid_alignment(grid)
 
     # 2. Load fires — current state and two historical windows.
     #

--- a/ml/tests/test_eval_spread_champion_challenger.py
+++ b/ml/tests/test_eval_spread_champion_challenger.py
@@ -1,5 +1,9 @@
-import numpy as np
+from unittest.mock import patch
 
+import numpy as np
+import pytest
+
+from api.core.grid import GridSpec
 from ml.eval_spread_champion_challenger import (
     _build_stage_governance,
     compute_recommendation,
@@ -134,3 +138,41 @@ def test_stage_governance_requires_calibrator_for_v3_promotion(tmp_path):
     }
     out_with_cal = _build_stage_governance(config=config_with_cal, decision=decision, summary_rows=[])
     assert not any(s["id"] == "STOP-CAL-001" for s in out_with_cal["hard_stops"])
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight grid alignment hard-stop tests
+# ---------------------------------------------------------------------------
+
+_PREFLIGHT_CONFIG = {
+    "region_name": "test_region",
+    "bbox": [-120.0, 35.0, -119.0, 36.0],
+    "start_time": "2025-01-01T00:00:00Z",
+    "end_time": "2025-06-01T00:00:00Z",
+    "horizons_hours": [24, 48],
+    "champion": {"model_name": "HeuristicSpreadModelV0", "model_params": None},
+    "challenger": {"model_name": "HeuristicSpreadModelV0", "model_params": None},
+}
+
+
+@pytest.mark.parametrize(
+    "grid_spec,expected_stop",
+    [
+        (
+            GridSpec(crs="EPSG:3857", cell_size_deg=0.01, origin_lat=35.0, origin_lon=-120.0, n_lat=100, n_lon=100),
+            "STOP-GEO-CRS",
+        ),
+        (
+            GridSpec(crs="EPSG:4326", cell_size_deg=0.05, origin_lat=35.0, origin_lon=-120.0, n_lat=20, n_lon=20),
+            "STOP-GEO-RES",
+        ),
+    ],
+)
+@patch("ml.eval_spread_champion_challenger.get_region_grid_spec")
+def test_collect_comparison_arrays_preflight_raises_on_grid_mismatch(mock_get_spec, grid_spec, expected_stop):
+    """Pre-flight must raise the matching STOP code before any DB queries when the region grid is misaligned."""
+    from ml.eval_spread_champion_challenger import _collect_comparison_arrays
+
+    mock_get_spec.return_value = grid_spec
+    with pytest.raises(ValueError, match=expected_stop):
+        _collect_comparison_arrays(_PREFLIGHT_CONFIG)

--- a/ml/tests/test_spread_features.py
+++ b/ml/tests/test_spread_features.py
@@ -13,6 +13,7 @@ from api.fires.service import FireHeatmapWindow
 from api.terrain.window import TerrainWindow
 from ml.spread_features import (
     SpreadInputs,
+    assert_grid_alignment,
     _create_fallback_weather,
     _load_weather_cube,
     build_spread_inputs,
@@ -319,3 +320,63 @@ def test_build_spread_inputs_with_region_name_none(mock_get_fire_heatmap, mock_g
 
     assert "u10" in inputs.weather_cube.data_vars
     assert "v10" in inputs.weather_cube.data_vars
+
+
+# ---------------------------------------------------------------------------
+# Grid alignment hard-stop tests (STOP-GEO-CRS / STOP-GEO-RES)
+# ---------------------------------------------------------------------------
+
+def test_assert_grid_alignment_passes_for_canonical_grid():
+    """Canonical grid (EPSG:4326, 0.01°) must not raise."""
+    grid = GridSpec(crs="EPSG:4326", cell_size_deg=0.01, origin_lat=35.0, origin_lon=5.0, n_lat=10, n_lon=10)
+    assert_grid_alignment(grid)  # must not raise
+
+
+def test_assert_grid_alignment_raises_stop_geo_crs():
+    """STOP-GEO-CRS: any CRS other than EPSG:4326 is a hard stop."""
+    grid = GridSpec(crs="EPSG:3857", cell_size_deg=0.01, origin_lat=35.0, origin_lon=5.0, n_lat=10, n_lon=10)
+    with pytest.raises(ValueError, match="STOP-GEO-CRS"):
+        assert_grid_alignment(grid)
+
+
+def test_assert_grid_alignment_raises_stop_geo_res():
+    """STOP-GEO-RES: a cell size other than 0.01° is a hard stop."""
+    grid = GridSpec(crs="EPSG:4326", cell_size_deg=0.025, origin_lat=35.0, origin_lon=5.0, n_lat=10, n_lon=10)
+    with pytest.raises(ValueError, match="STOP-GEO-RES"):
+        assert_grid_alignment(grid)
+
+
+@patch("ml.spread_features.get_region_grid_spec")
+@patch("ml.spread_features.get_grid_window_for_bbox")
+def test_build_spread_inputs_hard_stop_on_misaligned_crs(mock_get_window, mock_get_spec):
+    """build_spread_inputs must raise STOP-GEO-CRS when the region grid has the wrong CRS."""
+    bad_grid = GridSpec(crs="EPSG:3857", cell_size_deg=0.01, origin_lat=35.0, origin_lon=5.0, n_lat=100, n_lon=100)
+    lat = np.linspace(35.005, 35.095, 10)
+    lon = np.linspace(5.005, 5.095, 10)
+    mock_get_spec.return_value = bad_grid
+    mock_get_window.return_value = GridWindow(i0=0, i1=10, j0=0, j1=10, lat=lat, lon=lon)
+
+    with pytest.raises(ValueError, match="STOP-GEO-CRS"):
+        build_spread_inputs(
+            region_name="test_region",
+            bbox=(5.0, 35.0, 5.1, 35.1),
+            forecast_reference_time=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        )
+
+
+@patch("ml.spread_features.get_region_grid_spec")
+@patch("ml.spread_features.get_grid_window_for_bbox")
+def test_build_spread_inputs_hard_stop_on_misaligned_cell_size(mock_get_window, mock_get_spec):
+    """build_spread_inputs must raise STOP-GEO-RES when the region grid has the wrong cell size."""
+    bad_grid = GridSpec(crs="EPSG:4326", cell_size_deg=0.05, origin_lat=35.0, origin_lon=5.0, n_lat=20, n_lon=20)
+    lat = np.linspace(35.025, 35.225, 5)
+    lon = np.linspace(5.025, 5.225, 5)
+    mock_get_spec.return_value = bad_grid
+    mock_get_window.return_value = GridWindow(i0=0, i1=5, j0=0, j1=5, lat=lat, lon=lon)
+
+    with pytest.raises(ValueError, match="STOP-GEO-RES"):
+        build_spread_inputs(
+            region_name="test_region",
+            bbox=(5.0, 35.0, 5.25, 35.25),
+            forecast_reference_time=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        )


### PR DESCRIPTION
## Summary

- Adds `assert_grid_alignment(grid)` to `spread_features.py` — hard stops on `STOP-GEO-CRS` (not EPSG:4326) and `STOP-GEO-RES` (cell size ≠ 0.01°) before any data loading in `build_spread_inputs`
- Adds pre-flight alignment check to `_collect_comparison_arrays` in the champion-challenger evaluator — fails fast before sampling reference times or hitting the DB loop
- 7 new tests covering: canonical grid pass, CRS mismatch, cell size mismatch, full `build_spread_inputs` hard-stop paths, and champion-challenger pre-flight paths

## Test plan

- [ ] `cd ml && uv run pytest tests/test_spread_features.py tests/test_eval_spread_champion_challenger.py -v` — all 19 tests pass
- [ ] Confirm `STOP-GEO-CRS` fires when a region grid is stored with a non-EPSG:4326 CRS
- [ ] Confirm `STOP-GEO-RES` fires when a region grid has a cell size other than 0.01°

🤖 Generated with [Claude Code](https://claude.com/claude-code)