### PR TITLE
feat(ml): add SPREAD_STRICT_WEATHER flag for science_grade weather fallback enforcement

### DIFF
--- a/ml/spread/service.py
+++ b/ml/spread/service.py
@@ -45,6 +45,9 @@ SPREAD_MVP_GUARD_HORIZON_HOURS_ENV = "SPREAD_MVP_GUARD_HORIZON_HOURS"
 SPREAD_MVP_GUARD_PROB_THRESHOLD_ENV = "SPREAD_MVP_GUARD_PROB_THRESHOLD"
 SPREAD_MVP_GUARD_MAX_COVERAGE_ENV = "SPREAD_MVP_GUARD_MAX_COVERAGE"
 SPREAD_MVP_GUARD_MAX_SEED_CELLS_ENV = "SPREAD_MVP_GUARD_MAX_SEED_CELLS"
+# Science-grade weather strictness: hard-stop on zero-wind fallback when true.
+# Set to true for science_grade maturity deployments; default false (mvp_operational).
+SPREAD_STRICT_WEATHER_ENV = "SPREAD_STRICT_WEATHER"
 
 # Performance limit: avoid OOM/high latency for very large areas in synchronous calls.
 # 200x200 = 40,000 cells. At 0.01 degree, this is roughly 220km x 220km.
@@ -53,6 +56,15 @@ MAX_AOI_CELLS = 40000
 
 class ForecastInputFallbackError(RuntimeError):
     """Raised when strict mode forbids fallback input data."""
+
+
+class WeatherFallbackBlockedError(RuntimeError):
+    """Raised when SPREAD_STRICT_WEATHER=true and zero-wind weather fallback was used.
+
+    This is the science_grade hard-stop: do not serve a forecast built on fabricated
+    wind inputs.  Set SPREAD_STRICT_WEATHER=false (default) for mvp_operational deployments
+    where the warning path is acceptable.
+    """
 
 
 @dataclass(frozen=True, slots=True)
@@ -146,13 +158,18 @@ def run_spread_forecast(
         weather_bias_corrector_path=weather_bias_corrector_path,
     )
 
+    weather_fallback_reason = getattr(inputs_package.weather_cube, "attrs", {}).get("weather_fallback_reason")
+    _enforce_strict_weather(
+        weather_fallback_used=inputs_package.weather_fallback_used,
+        weather_fallback_reason=weather_fallback_reason,
+    )
     _enforce_no_fallback_if_strict(
         request=request,
         weather_fallback_used=inputs_package.weather_fallback_used,
-        weather_fallback_reason=getattr(inputs_package.weather_cube, "attrs", {}).get("weather_fallback_reason"),
+        weather_fallback_reason=weather_fallback_reason,
         terrain_fallback_used=inputs_package.terrain_fallback_used,
     )
-    
+
     # Check AOI size limit
     n_cells = inputs_package.window.lat.size * inputs_package.window.lon.size
     LOGGER.info(
@@ -459,6 +476,33 @@ def _enforce_no_fallback_if_strict(
     if reasons:
         raise ForecastInputFallbackError(
             "Strict forecast inputs mode rejected this request: " + "; ".join(reasons)
+        )
+
+
+def _enforce_strict_weather(
+    *,
+    weather_fallback_used: bool,
+    weather_fallback_reason: str | None,
+) -> None:
+    """Hard-stop if SPREAD_STRICT_WEATHER=true and zero-wind fallback was used.
+
+    This is the science_grade enforcement gate.  Set SPREAD_STRICT_WEATHER=true on
+    science_grade deployments; leave false (default) for mvp_operational.
+
+    Raises
+    ------
+    WeatherFallbackBlockedError
+        STOP: zero-wind weather fallback is not permitted in strict-weather mode.
+    """
+    if not _env_bool(SPREAD_STRICT_WEATHER_ENV, default=False):
+        return
+    if weather_fallback_used:
+        reason = weather_fallback_reason or "unknown"
+        raise WeatherFallbackBlockedError(
+            f"STOP: SPREAD_STRICT_WEATHER=true rejects zero-wind weather fallback "
+            f"(reason: {reason}). "
+            "Ensure a valid weather run is available or disable strict-weather mode "
+            "for mvp_operational deployments."
         )
 
 

--- a/ml/tests/test_spread_service.py
+++ b/ml/tests/test_spread_service.py
@@ -9,6 +9,7 @@ from ml.spread.service import (
     ForecastInputFallbackError,
     MAX_AOI_CELLS,
     SpreadForecastRequest,
+    WeatherFallbackBlockedError,
     run_spread_forecast,
 )
 from ml.spread.contract import SpreadForecast, SpreadModelInput
@@ -655,3 +656,69 @@ def test_run_spread_forecast_cpu_latency_p95_40k_cells(monkeypatch):
 
     p95 = float(np.percentile(np.asarray(latencies, dtype=np.float64), 95))
     assert p95 <= 1.5
+
+
+# ---------------------------------------------------------------------------
+# SPREAD_STRICT_WEATHER tests
+# ---------------------------------------------------------------------------
+
+def test_spread_strict_weather_blocks_on_fallback(monkeypatch, mock_spread_inputs):
+    """science_grade mode: SPREAD_STRICT_WEATHER=true must hard-stop on zero-wind fallback."""
+    monkeypatch.setenv("SPREAD_STRICT_WEATHER", "true")
+    # Ensure the generic strict-inputs gate is off so only the new flag is tested.
+    monkeypatch.delenv("STRICT_FORECAST_INPUTS", raising=False)
+
+    ref_time = datetime(2025, 12, 26, 12, 0, tzinfo=timezone.utc)
+    mock_spread_inputs.weather_fallback_used = True
+    mock_spread_inputs.weather_cube.attrs = {"weather_fallback_reason": "no_weather_run_found"}
+
+    request = SpreadForecastRequest(
+        region_name="test_region",
+        bbox=(20.0, 40.0, 20.2, 40.2),
+        forecast_reference_time=ref_time,
+        strict_inputs=False,  # generic gate off
+    )
+
+    with patch("ml.spread.service.build_spread_inputs", return_value=mock_spread_inputs):
+        with pytest.raises(WeatherFallbackBlockedError, match="STOP"):
+            run_spread_forecast(request)
+
+
+def test_spread_strict_weather_allows_fallback_when_disabled(monkeypatch, mock_spread_inputs):
+    """mvp_operational mode: SPREAD_STRICT_WEATHER=false (default) permits fallback with warning."""
+    import xarray as xr
+
+    monkeypatch.setenv("SPREAD_STRICT_WEATHER", "false")
+    monkeypatch.delenv("STRICT_FORECAST_INPUTS", raising=False)
+
+    ref_time = datetime(2025, 12, 26, 12, 0, tzinfo=timezone.utc)
+    mock_spread_inputs.weather_fallback_used = True
+    mock_spread_inputs.weather_cube.attrs = {"weather_fallback_reason": "no_weather_run_found"}
+
+    forecast = SpreadForecast(
+        probabilities=xr.DataArray(
+            np.full((1, 2, 2), 0.2, dtype=np.float32),
+            dims=("time", "lat", "lon"),
+            coords={"time": [0], "lat": [0.0, 1.0], "lon": [0.0, 1.0], "lead_time_hours": ("time", [24])},
+        ),
+        forecast_reference_time=ref_time,
+        horizons_hours=[24],
+        model_name="dummy",
+        model_version="x",
+    )
+    model = MagicMock()
+    model.predict.return_value = forecast
+
+    request = SpreadForecastRequest(
+        region_name="test_region",
+        bbox=(20.0, 40.0, 20.2, 40.2),
+        forecast_reference_time=ref_time,
+        strict_inputs=False,
+    )
+
+    with patch("ml.spread.service.build_spread_inputs", return_value=mock_spread_inputs):
+        out = run_spread_forecast(request, model=model)
+
+    # Forecast is served; fallback is annotated but not blocked.
+    assert out.probabilities.attrs["weather_fallback_used"] is True
+    assert out.probabilities.attrs["confidence_level"] == "low"


### PR DESCRIPTION
## Summary

- Adds `SPREAD_STRICT_WEATHER` env flag (default `false`) that hard-stops spread inference when a zero-wind weather fallback is used
- When `true` (science_grade deployments), raises `WeatherFallbackBlockedError` with a `STOP:` prefix — forecast is rejected rather than served at degraded confidence
- When `false` (mvp_operational, default), existing warning path is preserved unchanged
- Distinct from the existing `STRICT_FORECAST_INPUTS` gate, which covers both weather and terrain fallback generically

## Test plan

- [x] `test_spread_strict_weather_blocks_on_fallback` — `SPREAD_STRICT_WEATHER=true` + fallback → `WeatherFallbackBlockedError` raised
- [x] `test_spread_strict_weather_allows_fallback_when_disabled` — `SPREAD_STRICT_WEATHER=false` → forecast served, `confidence_level=low`, `weather_fallback_used=true` annotated
- [x] All 19 existing spread service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)