### PR TITLE
fix(ui): prevent infinite render loop when entering archive mode

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -149,7 +149,11 @@ export default function App(): JSX.Element {
   const { requestLocation } = useGeolocation();
 
   useForecastPolling();
-  useSafetyMetrics(isArchiveMode ? [] : visibleEvents);
+  const safetyEvents = useMemo(
+    () => (isArchiveMode ? [] : visibleEvents),
+    [isArchiveMode, visibleEvents]
+  );
+  useSafetyMetrics(safetyEvents);
 
   const filteredEvents = useMemo(() => {
     return visibleEvents.filter((event) => {


### PR DESCRIPTION
## Summary

- Clicking the historical reports badge triggered React error #185 (Maximum update depth exceeded), crashing the UI
- Root cause: `isArchiveMode ? [] : visibleEvents` passed a new array literal on every render, causing `useSafetyMetrics`'s `useEffect` to fire continuously — each call updated Zustand state, which triggered a re-render, which created a new `[]`, repeating infinitely
- Fix: wrap the expression in `useMemo` so the array reference is only recreated when `isArchiveMode` or `visibleEvents` actually change

## Test plan

- [ ] Click the historical reports badge — UI should stay up and render archive data
- [ ] Toggle in and out of archive mode several times — no crash, no console errors
- [ ] Verify safety mode still updates correctly when exiting archive mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)