### PR TITLE
fix(ingest): harden GRIB validation with retry logic and logging

### DIFF
--- a/ingest/tests/test_weather_ingest.py
+++ b/ingest/tests/test_weather_ingest.py
@@ -1,3 +1,4 @@
+import logging
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
@@ -98,17 +99,104 @@ def test_ingest_weather_for_bbox_respects_bbox_overrides():
     assert captured.get("bbox") == requested_bbox
 
 
-def test_validate_grib_file_allows_multilevel_archive_layout():
-    """Validation should not reject full archive GRIB files solely on level multiplicity."""
+def test_validate_grib_file_multilevel_succeeds_via_cfgrib_fallback(caplog):
+    """Multi-level GRIB: primary attempt fails, cfgrib.open_datasets fallback validates."""
+    mock_ds = MagicMock()
+    mock_ds.data_vars = {"u10": MagicMock(), "v10": MagicMock()}
+
     with tempfile.NamedTemporaryFile(suffix=".grib2") as tmp:
         tmp.write(b"x" * 256)
         tmp.flush()
 
-        with patch(
-            "ingest.weather_ingest.xr.open_dataset",
-            side_effect=ValueError("multiple values for unique key"),
+        with (
+            patch(
+                "ingest.weather_ingest.xr.open_dataset",
+                side_effect=Exception("multiple values for unique key — typeOfLevel"),
+            ),
+            patch("cfgrib.open_datasets", return_value=[mock_ds]) as mock_open_datasets,
+            caplog.at_level(logging.WARNING, logger="weather_ingest"),
         ):
             _validate_grib_file(Path(tmp.name))
+
+        mock_open_datasets.assert_called_once()
+        # The specific failure reason must appear in the warning log — no silent pass.
+        assert any(
+            "multiple values for unique key" in r.message for r in caplog.records
+        ), "Expected failure reason logged; got: " + str([r.message for r in caplog.records])
+
+
+def test_validate_grib_file_multilevel_retry_succeeds(caplog):
+    """Multi-level GRIB: primary fails, first xr retry (squeeze=False) succeeds."""
+    call_count = 0
+
+    def _selective_fail(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # Primary attempt — no squeeze kwarg
+            raise Exception("multiple values for unique key")
+        # Retry attempt with squeeze=False — succeed
+        mock_ds = MagicMock()
+        mock_ds.data_vars = {"u10": MagicMock()}
+        mock_ds.__enter__ = lambda s: s
+        mock_ds.__exit__ = MagicMock(return_value=False)
+        return mock_ds
+
+    with tempfile.NamedTemporaryFile(suffix=".grib2") as tmp:
+        tmp.write(b"x" * 256)
+        tmp.flush()
+
+        with (
+            patch("ingest.weather_ingest.xr.open_dataset", side_effect=_selective_fail),
+            caplog.at_level(logging.WARNING, logger="weather_ingest"),
+        ):
+            _validate_grib_file(Path(tmp.name))
+
+    assert any(
+        "multi-level file detected" in r.message for r in caplog.records
+    ), "Expected multi-level warning; got: " + str([r.message for r in caplog.records])
+
+
+def test_validate_grib_file_all_retries_fail_raises_with_reason():
+    """All cfgrib backend attempts fail → ValueError with specific failure reason."""
+    with tempfile.NamedTemporaryFile(suffix=".grib2") as tmp:
+        tmp.write(b"x" * 256)
+        tmp.flush()
+
+        with (
+            patch(
+                "ingest.weather_ingest.xr.open_dataset",
+                side_effect=Exception("multiple values for unique key — corrupt index"),
+            ),
+            patch(
+                "cfgrib.open_datasets",
+                side_effect=Exception("cfgrib fallback also failed"),
+            ),
+            pytest.raises(ValueError, match="multiple values for unique key"),
+        ):
+            _validate_grib_file(Path(tmp.name))
+
+
+def test_validate_grib_file_non_multilevel_error_raises_immediately():
+    """Non-multi-level errors must raise immediately without retrying."""
+    with tempfile.NamedTemporaryFile(suffix=".grib2") as tmp:
+        tmp.write(b"x" * 256)
+        tmp.flush()
+
+        open_calls = []
+
+        def _track_and_fail(*args, **kwargs):
+            open_calls.append(kwargs)
+            raise Exception("unexpected GRIB structure: missing section 3")
+
+        with (
+            patch("ingest.weather_ingest.xr.open_dataset", side_effect=_track_and_fail),
+            pytest.raises(ValueError, match="missing section 3"),
+        ):
+            _validate_grib_file(Path(tmp.name))
+
+    # Should only have been called once — no retries for non-multi-level errors.
+    assert len(open_calls) == 1, f"Expected 1 call, got {len(open_calls)}"
 
 
 def test_download_grib_files_preserves_connect_error_without_attribute_error(tmp_path):

--- a/ingest/weather_ingest.py
+++ b/ingest/weather_ingest.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Iterable, List, Sequence
 from urllib.parse import urlencode
 
-import cfgrib
 import httpx
 import numpy as np
 import xarray as xr
@@ -240,7 +239,11 @@ def _validate_grib_file(path: Path) -> None:
             )
 
     # --- Final fallback: cfgrib.open_datasets() handles multi-level natively ---
+    # Lazy import: cfgrib requires the ecCodes system library which is only
+    # present in the ingest environment, not in api or ml.
     try:
+        import cfgrib  # noqa: PLC0415
+
         datasets = cfgrib.open_datasets(path, indexpath="")
         if not datasets:
             raise ValueError(f"GRIB file produced no dataset groups: {path}")

--- a/ingest/weather_ingest.py
+++ b/ingest/weather_ingest.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Iterable, List, Sequence
 from urllib.parse import urlencode
 
+import cfgrib
 import httpx
 import numpy as np
 import xarray as xr
@@ -133,62 +134,150 @@ def _response_snippet(response: httpx.Response, limit: int = 400) -> str:
     return text[:limit] if text else ""
 
 
+# Alternative cfgrib backend_kwargs tried in order when the default open fails
+# with a multi-level ambiguity error.  Each entry is passed as backend_kwargs to
+# xr.open_dataset(..., engine="cfgrib").  Bounded at MAX_GRIB_RETRIES to prevent
+# infinite loops on genuinely corrupt files.
+_GRIB_RETRY_BACKEND_KWARGS: list[dict] = [
+    # Attempt 1 — squeeze=False avoids dimension-collapse conflicts on some files
+    {"indexpath": "", "squeeze": False},
+]
+MAX_GRIB_RETRIES = len(_GRIB_RETRY_BACKEND_KWARGS)
+
+
+def _is_multilevel_grib_error(message: str) -> bool:
+    """Return True if the error string is the known cfgrib multi-level ambiguity."""
+    return (
+        "multiple values for unique key" in message
+        or "multiple values for key 'typeOfLevel'" in message
+    )
+
+
 def _validate_grib_file(path: Path) -> None:
     """Validate GRIB file integrity by attempting to open it with cfgrib.
-    
+
     This function performs basic validation to detect corrupted or partial
     downloads before they are processed further.
-    
-    Args:
-        path: Path to the GRIB file to validate
-        
+
     Raises:
         ValueError: If the file is corrupted or cannot be read as GRIB
         FileNotFoundError: If the file does not exist
     """
     if not path.exists():
         raise FileNotFoundError(f"GRIB file not found: {path}")
-    
-    # Check file is non-empty
+
     file_size = path.stat().st_size
     if file_size == 0:
         raise ValueError(f"GRIB file is empty: {path}")
-    
-    # Minimum GRIB2 file size (GRIB header + some data + End section)
-    # A valid GRIB2 file needs at least ~100 bytes
+
     MIN_GRIB_SIZE = 100
     if file_size < MIN_GRIB_SIZE:
         raise ValueError(
             f"GRIB file too small ({file_size} bytes, min {MIN_GRIB_SIZE}): {path}"
         )
-    
-    # Try to open with cfgrib to verify it's a valid GRIB file
+
+    # 1 primary + MAX_GRIB_RETRIES xr retries + 1 cfgrib.open_datasets fallback
+    _TOTAL_ATTEMPTS = 1 + MAX_GRIB_RETRIES + 1
+
+    primary_reason = ""
+    last_retry_exc: Exception | None = None
+
+    # --- Primary attempt (no filter_by_keys — works for single-level files) ---
     try:
-        # Open with backend to validate without loading full dataset
         ds = xr.open_dataset(
             path,
             engine="cfgrib",
             backend_kwargs={"indexpath": ""},
         )
-        # Verify we can access at least one variable
         if len(ds.data_vars) == 0:
             raise ValueError(f"GRIB file contains no data variables: {path}")
         ds.close()
-    except Exception as exc:
-        # Full-field GRIB archives can contain many level groups in one file.
-        # This yields a known cfgrib "multiple values for unique key" error
-        # when opened without filter_by_keys, but the downstream per-variable
-        # loader uses filter_by_keys and can parse the file correctly.
-        message = str(exc)
-        if "multiple values for unique key" in message or "multiple values for key 'typeOfLevel'" in message:
-            LOGGER.debug(
-                "GRIB validation accepted multi-level archive file: %s",
+        LOGGER.debug("GRIB file validated: %s (%d bytes)", path, file_size)
+        return
+    except ValueError:
+        raise  # re-raise our own structural errors unchanged
+    except Exception as primary_exc:
+        primary_reason = str(primary_exc)
+        if not _is_multilevel_grib_error(primary_reason):
+            raise ValueError(
+                f"GRIB file validation failed for {path}: {primary_reason}"
+            ) from primary_exc
+        LOGGER.warning(
+            "GRIB primary validation failed (multi-level file detected): %s — %s; "
+            "attempting %d alternative backend option(s)",
+            path,
+            primary_reason,
+            _TOTAL_ATTEMPTS - 1,
+        )
+
+    # --- Retry loop with alternative backend kwargs ---
+    for attempt, retry_bkw in enumerate(_GRIB_RETRY_BACKEND_KWARGS, start=1):
+        try:
+            ds = xr.open_dataset(path, engine="cfgrib", backend_kwargs=retry_bkw)
+            if len(ds.data_vars) == 0:
+                raise ValueError(
+                    f"GRIB file contains no data variables (retry {attempt}): {path}"
+                )
+            ds.close()
+            LOGGER.info(
+                "GRIB multi-level validation succeeded on retry %d/%d: %s (%d bytes)",
+                attempt,
+                MAX_GRIB_RETRIES,
                 path,
+                file_size,
             )
             return
-        raise ValueError(f"GRIB file validation failed for {path}: {exc}") from exc
-    
-    LOGGER.debug("GRIB file validated: %s (%d bytes)", path, file_size)
+        except ValueError:
+            raise
+        except Exception as retry_exc:
+            last_retry_exc = retry_exc
+            LOGGER.warning(
+                "GRIB validation retry %d/%d failed: %s — %s",
+                attempt,
+                MAX_GRIB_RETRIES,
+                path,
+                retry_exc,
+            )
+
+    # --- Final fallback: cfgrib.open_datasets() handles multi-level natively ---
+    try:
+        datasets = cfgrib.open_datasets(path, indexpath="")
+        if not datasets:
+            raise ValueError(f"GRIB file produced no dataset groups: {path}")
+        total_vars = sum(len(ds.data_vars) for ds in datasets)
+        for ds in datasets:
+            ds.close()
+        if total_vars == 0:
+            raise ValueError(
+                f"GRIB file has no data variables across all groups: {path}"
+            )
+        LOGGER.info(
+            "GRIB multi-level validation succeeded via cfgrib.open_datasets: "
+            "%s (%d dataset group(s), %d total var(s), %d bytes)",
+            path,
+            len(datasets),
+            total_vars,
+            file_size,
+        )
+        return
+    except ValueError:
+        raise
+    except Exception as fallback_exc:
+        LOGGER.error(
+            "GRIB file failed all %d validation attempt(s): %s — "
+            "primary error: %s; last retry error: %s; fallback error: %s",
+            _TOTAL_ATTEMPTS,
+            path,
+            primary_reason,
+            last_retry_exc,
+            fallback_exc,
+        )
+        raise ValueError(
+            f"GRIB file failed all validation attempts for {path}. "
+            f"Primary error: {primary_reason}. "
+            f"Last retry error: {last_retry_exc}. "
+            f"Fallback error: {fallback_exc}"
+        ) from fallback_exc
 
 
 def _extract_error_context(exc: Exception) -> dict:


### PR DESCRIPTION
## Changes

### Enhanced GRIB File Validation
- **Retry mechanism**: Added configurable retry loop with alternative `backend_kwargs` for multi-level GRIB files
- **Error detection**: Implemented `_is_multilevel_grib_error()` to distinguish multi-level ambiguity errors from other failures
- **Fallback strategy**: Added `cfgrib.open_datasets()` as final fallback for files with multiple level groups
- **Improved logging**: 
  - Log specific failure reasons at each validation stage (primary, retries, fallback)
  - Warn on multi-level detection before attempting retries
  - Log success with dataset group/variable counts on fallback
  - Aggregate all error context in final failure message

### Test Coverage
- `test_validate_grib_file_multilevel_succeeds_via_cfgrib_fallback`: Validates cfgrib.open_datasets fallback path with logging
- `test_validate_grib_file_multilevel_retry_succeeds`: Validates xr.open_dataset retry with squeeze=False
- `test_validate_grib_file_all_retries_fail_raises_with_reason`: Ensures proper error message when all attempts fail
- `test_validate_grib_file_non_multilevel_error_raises_immediately`: Ensures non-multi-level errors fail fast without retries

### Implementation Details
- Multi-level files now validate successfully via retry or fallback instead of raising errors
- Non-multi-level errors raise immediately without retries
- All failure reasons are captured and reported for debugging
- Bounded retry attempts (MAX_GRIB_RETRIES) prevent infinite loops on corrupt files