### PR TITLE
Add Cache-Control headers to API endpoints

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -1,0 +1,24 @@
+"""Shared FastAPI dependencies."""
+
+from typing import Callable, Optional
+
+from fastapi import Response
+
+
+def cache_control(max_age: Optional[int] = None) -> Callable[[Response], None]:
+    """Return a dependency that sets Cache-Control on the response.
+
+    Pass max_age (seconds) for cacheable GETs, or omit for no-cache on POSTs.
+    """
+    header_value = "no-cache" if max_age is None else f"max-age={max_age}"
+
+    def _dep(response: Response) -> None:
+        response.headers["Cache-Control"] = header_value
+
+    return _dep
+
+
+# Named shortcuts used in route decorators
+cache_60 = cache_control(60)
+cache_300 = cache_control(300)
+no_cache = cache_control()

--- a/api/routes/aois.py
+++ b/api/routes/aois.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from typing import Any, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from api.deps import no_cache
 from pydantic import BaseModel
 from shapely.geometry import shape
 from shapely.geometry.base import BaseGeometry
@@ -95,7 +97,7 @@ def _validate_geometry(geojson: dict[str, Any]) -> None:
         )
 
 
-@aois_router.post("", response_model=AOIResponse, status_code=status.HTTP_201_CREATED)
+@aois_router.post("", response_model=AOIResponse, status_code=status.HTTP_201_CREATED, dependencies=[Depends(no_cache)])
 def create_aoi(request: CreateAOIRequest):
     """Create a new Area of Interest."""
     _validate_geometry(request.geometry)

--- a/api/routes/archive.py
+++ b/api/routes/archive.py
@@ -8,7 +8,9 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Literal
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from api.deps import no_cache
 from pydantic import BaseModel
 from sqlalchemy import text
 
@@ -147,6 +149,7 @@ async def check_archive_availability(date: str, timeframe: str) -> ArchiveAvaila
     "/fires/archive/ingest",
     response_model=ArchiveIngestResponse,
     status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[Depends(no_cache)],
 )
 async def trigger_archive_ingest(body: ArchiveIngestRequest) -> ArchiveIngestResponse:
     """Trigger a background FIRMS re-ingest for a historical date/timeframe."""

--- a/api/routes/assistant.py
+++ b/api/routes/assistant.py
@@ -1,7 +1,9 @@
 """Assistant proxy router — forwards chat requests to Gemini server-side."""
 
 import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.deps import no_cache
 from pydantic import BaseModel
 
 from api.config import settings
@@ -22,7 +24,7 @@ async def get_assistant_config() -> AssistantConfigResponse:
     )
 
 
-@assistant_router.post("/chat")
+@assistant_router.post("/chat", dependencies=[Depends(no_cache)])
 async def proxy_chat(body: dict) -> dict:
     """Proxy a Gemini generateContent request, injecting the server-side API key."""
     if not settings.gemini_api_key:

--- a/api/routes/exports.py
+++ b/api/routes/exports.py
@@ -15,6 +15,7 @@ from fastapi.responses import StreamingResponse, FileResponse
 from fastapi_limiter.depends import RateLimiter
 from pydantic import BaseModel
 
+from api.deps import no_cache
 from api.aois import repo as aois_repo
 from api.exports import repo as jobs_repo
 from api.exports.worker import queue, export_task
@@ -366,7 +367,7 @@ class ExportJobResponse(BaseModel):
     "/exports",
     response_model=ExportJobResponse,
     status_code=status.HTTP_202_ACCEPTED,
-    dependencies=[Depends(RateLimiter(times=10, seconds=60))]
+    dependencies=[Depends(RateLimiter(times=10, seconds=60)), Depends(no_cache)]
 )
 def create_export_job(job_request: ExportJobRequest):
     """Enqueue an async export job."""

--- a/api/routes/fires.py
+++ b/api/routes/fires.py
@@ -4,6 +4,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi_limiter.depends import RateLimiter
 
+from api.deps import cache_60
 from api.fires.repo import (
     validate_bbox,
     list_fire_detections_bbox_time,
@@ -120,7 +121,7 @@ async def get_fires(
     )
 
 
-@fires_router.get("/detections", dependencies=[Depends(RateLimiter(times=30, seconds=60))])
+@fires_router.get("/detections", dependencies=[Depends(RateLimiter(times=30, seconds=60)), Depends(cache_60)])
 async def get_detections(
     min_lon: float = Query(..., description="Minimum longitude (west boundary)"),
     min_lat: float = Query(..., description="Minimum latitude (south boundary)"),
@@ -158,7 +159,7 @@ async def get_detections(
     )
 
 
-@fires_router.get("/events", dependencies=[Depends(RateLimiter(times=30, seconds=60))])
+@fires_router.get("/events", dependencies=[Depends(RateLimiter(times=30, seconds=60)), Depends(cache_60)])
 async def get_events(
     min_lon: float = Query(..., description="Minimum longitude (west boundary)"),
     min_lat: float = Query(..., description="Minimum latitude (south boundary)"),
@@ -192,7 +193,7 @@ async def get_events(
     return {"count": len(events), "events": events}
 
 
-@fires_router.get("/fronts", dependencies=[Depends(RateLimiter(times=30, seconds=60))])
+@fires_router.get("/fronts", dependencies=[Depends(RateLimiter(times=30, seconds=60)), Depends(cache_60)])
 async def get_fronts(
     min_lon: float = Query(..., description="Minimum longitude (west boundary)"),
     min_lat: float = Query(..., description="Minimum latitude (south boundary)"),

--- a/api/routes/forecast.py
+++ b/api/routes/forecast.py
@@ -17,6 +17,7 @@ from fastapi_limiter.depends import RateLimiter
 from pydantic import BaseModel, ConfigDict
 
 from api.config import settings
+from api.deps import no_cache
 from api.fires.repo import get_fire_front_by_id, validate_bbox
 from api.forecast import repo
 from api.forecast.cache_lock import acquire_forecast_result_lock, release_forecast_result_lock
@@ -198,7 +199,7 @@ async def get_forecast(
     "/jit",
     response_model=JitForecastResponse,
     status_code=status.HTTP_202_ACCEPTED,
-    dependencies=[Depends(RateLimiter(times=10, seconds=60))],
+    dependencies=[Depends(RateLimiter(times=10, seconds=60)), Depends(no_cache)],
 )
 def create_jit_forecast(request: JitForecastRequest):
     """Enqueue a JIT forecast pipeline for arbitrary bbox.
@@ -307,7 +308,7 @@ def create_jit_forecast(request: JitForecastRequest):
     "/jit/from-front",
     response_model=JitForecastFromFrontResponse,
     status_code=status.HTTP_202_ACCEPTED,
-    dependencies=[Depends(RateLimiter(times=10, seconds=60))],
+    dependencies=[Depends(RateLimiter(times=10, seconds=60)), Depends(no_cache)],
 )
 def create_jit_forecast_from_front(request: JitForecastFromFrontRequest):
     """Enqueue JIT forecast pipeline from an existing fire front geometry."""
@@ -683,7 +684,7 @@ def _parse_iso8601_datetime(value: str) -> datetime:
     return parsed
 
 
-@forecast_router.post("/generate")
+@forecast_router.post("/generate", dependencies=[Depends(no_cache)])
 def generate_forecast_endpoint(request: GenerateForecastRequest):
     """Generate a spread forecast on-the-fly for a given bbox and persist it.
 

--- a/api/routes/risk.py
+++ b/api/routes/risk.py
@@ -3,14 +3,15 @@
 from datetime import datetime
 from typing import Optional
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 
+from api.deps import cache_300
 from api.risk.grid import compute_risk_grid
 
 risk_router = APIRouter(prefix="/risk", tags=["risk"])
 
 
-@risk_router.get("")
+@risk_router.get("", dependencies=[Depends(cache_300)])
 async def get_risk(
     min_lon: float = Query(..., description="Minimum longitude (west boundary)"),
     min_lat: float = Query(..., description="Minimum latitude (south boundary)"),


### PR DESCRIPTION
## Changes

- Create new `api/deps.py` module with `cache_control()` dependency factory
- Add named cache control shortcuts: `cache_60`, `cache_300`, and `no_cache`
- Apply `no_cache` to POST/write endpoints (AOIs, archive, assistant, exports, forecast)
- Apply `cache_60` to read endpoints (fires detections, events, fronts)
- Apply `cache_300` to risk endpoint

## Details

The `cache_control()` dependency sets appropriate `Cache-Control` headers on responses:
- Write operations use `no-cache` to prevent unintended caching
- Read operations use `max-age` directives for efficient caching
- Uses FastAPI's `Depends()` injection pattern for clean route decoration