### PR TITLE
feat(ingest): add JOB_DENOISER_DRIFT drift monitor to orchestrator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,20 @@ DENOISER_MODEL_RUN_DIR=             # e.g. /app/models/denoiser/run_001
 # SPREAD_SHADOW_MODEL_ID=<model_id>
 # SPREAD_DRIFT_ZSCORE_ALERT=2.0
 # SPREAD_CALIBRATION_DRIFT_ALERT=0.15
+
+# =============================================================================
+# Denoiser Drift Monitor (orchestrator JOB_DENOISER_DRIFT, runs daily)
+# =============================================================================
+# Thresholds — single source of truth for both the orchestrator and direct CLI runs.
+# PSI (Population Stability Index): warn at 0.2, hard-BLOCKER at 0.35
+# Mean score delta (absolute): warn at 0.10, hard-BLOCKER at 0.20
+# DENOISER_DRIFT_PSI_WARN_THRESHOLD=0.2
+# DENOISER_DRIFT_PSI_HARD_THRESHOLD=0.35
+# DENOISER_DRIFT_MEAN_DELTA_WARN_THRESHOLD=0.10
+# DENOISER_DRIFT_MEAN_DELTA_HARD_THRESHOLD=0.20
+# DENOISER_DRIFT_WINDOW_HOURS=24
+# DENOISER_DRIFT_BASELINE_DAYS=7
+# DENOISER_DRIFT_MIN_SAMPLES=500
 # FORECAST_FAIL_CLOSED_ON_STALE=true
 # FORECAST_RESULT_CACHE_TTL_MINUTES=60
 # SPREAD_MODEL_CATALOG_JSON={"v0_default":{"model_name":"HeuristicSpreadModelV0","model_params":{}}}

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -1,10 +1,11 @@
-"""Scheduler/orchestrator for FIRMS, weather, terrain, perimeter, and industrial ingestion."""
+"""Scheduler/orchestrator for FIRMS, weather, terrain, perimeter, industrial, and drift-monitor ingestion."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import logging
+import os
 import signal
 import sys
 import time
@@ -31,7 +32,8 @@ JOB_WEATHER = "weather"
 JOB_TERRAIN = "terrain"
 JOB_PERIMETERS = "perimeters"
 JOB_INDUSTRIAL = "industrial"
-JOB_ORDER = (JOB_FIRMS, JOB_WEATHER, JOB_TERRAIN, JOB_PERIMETERS, JOB_INDUSTRIAL)
+JOB_DENOISER_DRIFT = "denoiser_drift"
+JOB_ORDER = (JOB_FIRMS, JOB_WEATHER, JOB_TERRAIN, JOB_PERIMETERS, JOB_INDUSTRIAL, JOB_DENOISER_DRIFT)
 DEFAULT_DASHBOARD_PATH = REPO_ROOT / "data" / "ingest" / "orchestrator_dashboard.json"
 
 
@@ -99,8 +101,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=str,
         default=",".join(JOB_ORDER),
         help=(
-            "Comma-separated job list. Supported: firms,weather,terrain,perimeters,industrial. "
-            "Execution order is fixed as firms->weather->terrain->perimeters->industrial."
+            "Comma-separated job list. Supported: firms,weather,terrain,perimeters,industrial,denoiser_drift. "
+            "Execution order is fixed as firms->weather->terrain->perimeters->industrial->denoiser_drift."
         ),
     )
     parser.add_argument(
@@ -174,6 +176,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=float,
         default=1440.0,
         help="Industrial source ingest interval in minutes (loop mode).",
+    )
+    parser.add_argument(
+        "--denoiser-drift-interval-minutes",
+        type=float,
+        default=1440.0,
+        help="Denoiser drift monitor run interval in minutes (loop mode).",
     )
 
     parser.add_argument(
@@ -348,6 +356,7 @@ def _validate_args(args: argparse.Namespace) -> None:
         ("--terrain-interval-minutes", args.terrain_interval_minutes),
         ("--perimeters-interval-minutes", args.perimeters_interval_minutes),
         ("--industrial-interval-minutes", args.industrial_interval_minutes),
+        ("--denoiser-drift-interval-minutes", args.denoiser_drift_interval_minutes),
     )
     for flag, value in interval_flags:
         if value <= 0:
@@ -456,6 +465,67 @@ def _run_industrial(args: argparse.Namespace) -> int:
     return int(run_industrial_ingest(_build_industrial_argv(args)))
 
 
+def _run_denoiser_drift(args: argparse.Namespace) -> int:
+    """Run drift monitor (alert-only; never auto-rollbacks from orchestrator)."""
+    # Lazy import: avoids pulling api.db into module scope at startup.
+    from ingest.denoiser_drift_monitor import monitor_denoiser_drift
+
+    psi_warn = float(os.getenv("DENOISER_DRIFT_PSI_WARN_THRESHOLD", "0.2"))
+    psi_hard = float(os.getenv("DENOISER_DRIFT_PSI_HARD_THRESHOLD", "0.35"))
+    mean_delta_warn = float(os.getenv("DENOISER_DRIFT_MEAN_DELTA_WARN_THRESHOLD", "0.10"))
+    mean_delta_hard = float(os.getenv("DENOISER_DRIFT_MEAN_DELTA_HARD_THRESHOLD", "0.20"))
+    window_hours = int(os.getenv("DENOISER_DRIFT_WINDOW_HOURS", "24"))
+    baseline_days = int(os.getenv("DENOISER_DRIFT_BASELINE_DAYS", "7"))
+    min_samples = int(os.getenv("DENOISER_DRIFT_MIN_SAMPLES", "500"))
+
+    summary = monitor_denoiser_drift(
+        window_hours=window_hours,
+        baseline_days=baseline_days,
+        min_samples=min_samples,
+        psi_warn_threshold=psi_warn,
+        psi_hard_threshold=psi_hard,
+        mean_delta_warn_threshold=mean_delta_warn,
+        mean_delta_hard_threshold=mean_delta_hard,
+        allow_rollback=False,  # orchestrator is alert-only; rollback is a manual ops decision
+    )
+
+    metrics = summary.get("metrics", {})
+    psi_entry = metrics.get("psi_score", {})
+    mean_entry = metrics.get("score_mean_delta", {})
+    psi_severity = psi_entry.get("severity", "ok")
+    mean_severity = mean_entry.get("severity", "ok")
+    hard_violation = psi_severity == "hard" or mean_severity == "hard"
+    warn_violation = psi_severity == "warn" or mean_severity == "warn"
+    psi_val = psi_entry.get("value") or 0.0
+    mean_val = mean_entry.get("value") or 0.0
+
+    if hard_violation:
+        LOGGER.error(
+            "BLOCKER: denoiser drift hard violation — "
+            "psi=%.4f (hard_threshold=%.2f) score_mean_delta=%.4f (hard_threshold=%.2f) "
+            "— manual review required; rollback via `make model-rollback FAMILY=denoiser`",
+            psi_val,
+            psi_hard,
+            mean_val,
+            mean_delta_hard,
+        )
+        return 1  # surfaces as job failure in dashboard; no rollback triggered
+    if warn_violation:
+        LOGGER.warning(
+            "Denoiser drift WARNING: psi=%.4f score_mean_delta=%.4f "
+            "— approaching threshold, monitor closely [target: science_grade]",
+            psi_val,
+            mean_val,
+        )
+    else:
+        LOGGER.info(
+            "Denoiser drift OK: psi=%.4f score_mean_delta=%.4f",
+            psi_val,
+            mean_val,
+        )
+    return 0
+
+
 def _run_with_logging(name: str, runner: Callable[[], int]) -> int:
     started = time.monotonic()
     LOGGER.info("Job started: %s", name)
@@ -482,6 +552,7 @@ def build_jobs(args: argparse.Namespace) -> list[ScheduledJob]:
         JOB_TERRAIN: lambda: _run_terrain(args),
         JOB_PERIMETERS: lambda: _run_perimeters(args),
         JOB_INDUSTRIAL: lambda: _run_industrial(args),
+        JOB_DENOISER_DRIFT: lambda: _run_denoiser_drift(args),
     }
 
     intervals_seconds = {
@@ -490,6 +561,7 @@ def build_jobs(args: argparse.Namespace) -> list[ScheduledJob]:
         JOB_TERRAIN: args.terrain_interval_minutes * 60.0,
         JOB_PERIMETERS: args.perimeters_interval_minutes * 60.0,
         JOB_INDUSTRIAL: args.industrial_interval_minutes * 60.0,
+        JOB_DENOISER_DRIFT: args.denoiser_drift_interval_minutes * 60.0,
     }
 
     return [

--- a/ingest/tests/test_orchestrator.py
+++ b/ingest/tests/test_orchestrator.py
@@ -1,10 +1,15 @@
 import argparse
 import unittest
+from unittest.mock import patch
 
 from ingest.orchestrator import (
+    JOB_DENOISER_DRIFT,
+    JOB_INDUSTRIAL,
+    JOB_ORDER,
     ScheduledJob,
     _build_industrial_argv,
     _build_weather_argv,
+    _run_denoiser_drift,
     run_once,
     run_scheduler,
 )
@@ -241,6 +246,82 @@ class TestOrchestrator(unittest.TestCase):
 
         self.assertEqual(0, exit_code)
         self.assertEqual(0, calls["count"])
+
+
+class TestDriftJob(unittest.TestCase):
+    def test_denoiser_drift_in_job_order(self):
+        self.assertIn(JOB_DENOISER_DRIFT, JOB_ORDER)
+        # Must come after industrial (ingest jobs run before monitoring)
+        self.assertGreater(JOB_ORDER.index(JOB_DENOISER_DRIFT), JOB_ORDER.index(JOB_INDUSTRIAL))
+
+    def test_run_denoiser_drift_ok_returns_zero(self):
+        summary = {
+            "metrics": {
+                "psi_score": {"value": 0.05, "severity": "ok"},
+                "score_mean_delta": {"value": 0.02, "severity": "ok"},
+            }
+        }
+        args = argparse.Namespace()
+        with patch("ingest.denoiser_drift_monitor.monitor_denoiser_drift", return_value=summary):
+            code = _run_denoiser_drift(args)
+        self.assertEqual(0, code)
+
+    def test_run_denoiser_drift_warn_returns_zero(self):
+        summary = {
+            "metrics": {
+                "psi_score": {"value": 0.25, "severity": "warn"},
+                "score_mean_delta": {"value": 0.05, "severity": "ok"},
+            }
+        }
+        args = argparse.Namespace()
+        with patch("ingest.denoiser_drift_monitor.monitor_denoiser_drift", return_value=summary):
+            code = _run_denoiser_drift(args)
+        self.assertEqual(0, code)
+
+    def test_run_denoiser_drift_hard_violation_returns_one_and_logs_blocker(self):
+        summary = {
+            "metrics": {
+                "psi_score": {"value": 0.42, "severity": "hard"},
+                "score_mean_delta": {"value": 0.22, "severity": "hard"},
+            }
+        }
+        args = argparse.Namespace()
+        with patch("ingest.denoiser_drift_monitor.monitor_denoiser_drift", return_value=summary):
+            with self.assertLogs("ingest_orchestrator", level="ERROR") as log_ctx:
+                code = _run_denoiser_drift(args)
+        self.assertEqual(1, code)
+        self.assertTrue(
+            any("BLOCKER" in line for line in log_ctx.output),
+            f"Expected BLOCKER in logs, got: {log_ctx.output}",
+        )
+
+    def test_run_denoiser_drift_hard_violation_does_not_rollback(self):
+        """allow_rollback must be False when called from orchestrator."""
+        summary = {
+            "metrics": {
+                "psi_score": {"value": 0.50, "severity": "hard"},
+                "score_mean_delta": {"value": 0.25, "severity": "hard"},
+            }
+        }
+        args = argparse.Namespace()
+        with patch("ingest.denoiser_drift_monitor.monitor_denoiser_drift", return_value=summary) as mock_monitor:
+            with self.assertLogs("ingest_orchestrator", level="ERROR"):
+                _run_denoiser_drift(args)
+        _call_kwargs = mock_monitor.call_args.kwargs
+        self.assertFalse(_call_kwargs.get("allow_rollback"), "orchestrator must never auto-rollback")
+
+    def test_drift_job_failure_surfaces_in_run_once_metrics(self):
+        """A hard-violation (exit=1) is tracked as a failure in orchestrator metrics."""
+        calls: list[str] = []
+
+        def _drift_hard() -> int:
+            calls.append("drift")
+            return 1
+
+        jobs = [ScheduledJob(name="denoiser_drift", interval_seconds=60.0, runner=_drift_hard)]
+        exit_code = run_once(jobs, stop_on_error=False)
+        self.assertEqual(1, exit_code)
+        self.assertEqual(["drift"], calls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes

- **Add denoiser drift monitoring job** to orchestrator with configurable thresholds and intervals
  - New `JOB_DENOISER_DRIFT` job runs daily (default 1440 min) as final orchestrator stage
  - Alert-only mode: logs warnings/blockers but never auto-rollbacks (manual ops decision)
  - Configurable via environment variables for PSI, mean delta, window, baseline, and sample thresholds

- **Environment configuration** (`.env.example`)
  - Added 7 new drift monitor config parameters with sensible defaults
  - PSI thresholds: warn at 0.2, hard-blocker at 0.35
  - Mean score delta thresholds: warn at 0.10, hard-blocker at 0.20
  - Window/baseline/sample size controls

- **Orchestrator updates**
  - Added `_run_denoiser_drift()` function with comprehensive logging
  - Hard violations (severity="hard") return exit code 1 and surface as job failure
  - Warn violations log warnings but return 0 (non-blocking)
  - CLI argument `--denoiser-drift-interval-minutes` added
  - Updated help text and job order documentation

- **Test coverage** (81 new test lines)
  - Job ordering validation
  - OK/warn/hard violation scenarios
  - Blocker logging verification
  - Confirmation that orchestrator never enables auto-rollback
  - Metrics tracking in run_once integration