### PR TITLE
feat: add terrain coverage inventory health endpoint

### DIFF
--- a/api/routes/internal.py
+++ b/api/routes/internal.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from api.config import settings
 from api.data_status import build_data_status_snapshot
 from api.model_registry import list_active_models
+from api.terrain.features_repo import list_terrain_coverage_inventory
 from api.fires.repo import (
     get_latest_denoiser_gate_report,
     get_latest_denoiser_coverage_status,
@@ -106,6 +107,54 @@ async def version() -> dict:
         "version": settings.version,
         "git_commit": settings.git_commit,
         "environment": settings.environment,
+    }
+
+
+@internal_router.get("/internal/health/terrain-coverage")
+async def terrain_coverage_inventory() -> dict:
+    """Return DEM coverage inventory: regions with preprocessed terrain, bboxes, resolution, staleness.
+
+    Operators use this to determine where forecasts will use real terrain vs the D1 flat-terrain fallback.
+    Staleness is computed against DATA_STALE_TERRAIN_MINUTES (default 10080 = 7 days).
+    """
+    as_of = datetime.now(timezone.utc)
+    try:
+        rows = list_terrain_coverage_inventory()
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        return {"as_of": as_of.isoformat(), "regions": [], "error": str(exc)}
+
+    regions = []
+    for row in rows:
+        created_at_utc = row.created_at.replace(tzinfo=timezone.utc)
+        age_minutes = (as_of - created_at_utc).total_seconds() / 60.0
+        is_stale = age_minutes > settings.data_stale_terrain_minutes
+        regions.append(
+            {
+                "region_name": row.region_name,
+                "bbox": {
+                    "min_lon": row.bbox[0],
+                    "min_lat": row.bbox[1],
+                    "max_lon": row.bbox[2],
+                    "max_lat": row.bbox[3],
+                },
+                "resolution_deg": row.cell_size_deg,
+                "crs_epsg": row.crs_epsg,
+                "grid": {"n_lat": row.grid_n_lat, "n_lon": row.grid_n_lon},
+                "terrain_fallback_used": row.terrain_fallback_used,
+                "coverage_fraction": row.coverage_fraction,
+                "preprocessed_at": created_at_utc.isoformat(),
+                "age_minutes": round(age_minutes, 1),
+                "is_stale": is_stale,
+                "slope_path": row.slope_path,
+                "aspect_path": row.aspect_path,
+            }
+        )
+
+    return {
+        "as_of": as_of.isoformat(),
+        "stale_threshold_minutes": settings.data_stale_terrain_minutes,
+        "region_count": len(regions),
+        "regions": regions,
     }
 
 

--- a/api/terrain/features_repo.py
+++ b/api/terrain/features_repo.py
@@ -194,6 +194,46 @@ def insert_terrain_features_metadata(
     return _row_to_features(row)
 
 
+def list_terrain_coverage_inventory() -> list[TerrainFeaturesMetadata]:
+    """Return the latest terrain_features_metadata row for each distinct region."""
+    stmt = text(
+        """
+        SELECT DISTINCT ON (region_name)
+            id,
+            region_name,
+            source_dem_metadata_id,
+            slope_path,
+            aspect_path,
+            crs_epsg,
+            cell_size_deg,
+            origin_lat,
+            origin_lon,
+            grid_n_lat,
+            grid_n_lon,
+            slope_units,
+            aspect_units,
+            aspect_convention,
+            nodata_value,
+            slope_min,
+            slope_max,
+            aspect_min,
+            aspect_max,
+            coverage_fraction,
+            terrain_fallback_used,
+            created_at,
+            ST_XMin(bbox) AS bbox_min_lon,
+            ST_YMin(bbox) AS bbox_min_lat,
+            ST_XMax(bbox) AS bbox_max_lon,
+            ST_YMax(bbox) AS bbox_max_lat
+        FROM terrain_features_metadata
+        ORDER BY region_name, created_at DESC
+        """
+    )
+    with get_engine().begin() as conn:
+        rows = conn.execute(stmt).mappings().all()
+    return [_row_to_features(row) for row in rows]
+
+
 def get_latest_terrain_features_metadata_for_region(
     region_name: str,
 ) -> Optional[TerrainFeaturesMetadata]:

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -142,6 +142,93 @@ def test_denoiser_industrial_coverage_endpoint(monkeypatch) -> None:
     assert body["coverage"] == payload
 
 
+def test_terrain_coverage_inventory_endpoint(monkeypatch) -> None:
+    from datetime import datetime, timezone
+
+    preprocessed_at = datetime(2026, 3, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+    class _FakeRow:
+        region_name = "us_west"
+        bbox = (-125.0, 32.0, -114.0, 49.0)
+        cell_size_deg = 0.01
+        crs_epsg = 4326
+        grid_n_lat = 1700
+        grid_n_lon = 1100
+        terrain_fallback_used = False
+        coverage_fraction = 0.97
+        created_at = preprocessed_at.replace(tzinfo=None)  # stored as naive UTC
+        slope_path = "data/terrain/us_west/slope_us_west_epsg4326_0p01deg.tif"
+        aspect_path = "data/terrain/us_west/aspect_us_west_epsg4326_0p01deg.tif"
+
+    monkeypatch.setattr(
+        "api.routes.internal.list_terrain_coverage_inventory",
+        lambda: [_FakeRow()],
+    )
+
+    response = client.get("/internal/health/terrain-coverage")
+    assert response.status_code == 200
+    body = response.json()
+    assert "as_of" in body
+    assert "stale_threshold_minutes" in body
+    assert body["region_count"] == 1
+
+    region = body["regions"][0]
+    assert region["region_name"] == "us_west"
+    assert region["bbox"] == {"min_lon": -125.0, "min_lat": 32.0, "max_lon": -114.0, "max_lat": 49.0}
+    assert region["resolution_deg"] == 0.01
+    assert region["crs_epsg"] == 4326
+    assert region["grid"] == {"n_lat": 1700, "n_lon": 1100}
+    assert region["terrain_fallback_used"] is False
+    assert region["coverage_fraction"] == 0.97
+    assert region["preprocessed_at"] == "2026-03-20T12:00:00+00:00"
+    assert "age_minutes" in region
+    assert isinstance(region["is_stale"], bool)
+    assert region["slope_path"] == "data/terrain/us_west/slope_us_west_epsg4326_0p01deg.tif"
+    assert region["aspect_path"] == "data/terrain/us_west/aspect_us_west_epsg4326_0p01deg.tif"
+
+
+def test_terrain_coverage_inventory_fallback_region(monkeypatch) -> None:
+    """Fallback (flat-terrain stub) regions are included and flagged."""
+    from datetime import datetime
+
+    class _FallbackRow:
+        region_name = "remote_stub"
+        bbox = (-110.0, 35.0, -100.0, 45.0)
+        cell_size_deg = 0.01
+        crs_epsg = 4326
+        grid_n_lat = 1000
+        grid_n_lon = 1000
+        terrain_fallback_used = True
+        coverage_fraction = None
+        created_at = datetime(2026, 3, 1, 0, 0, 0)
+        slope_path = "data/terrain/remote_stub/slope_remote_stub_epsg4326_0p01deg.tif"
+        aspect_path = "data/terrain/remote_stub/aspect_remote_stub_epsg4326_0p01deg.tif"
+
+    monkeypatch.setattr(
+        "api.routes.internal.list_terrain_coverage_inventory",
+        lambda: [_FallbackRow()],
+    )
+
+    response = client.get("/internal/health/terrain-coverage")
+    assert response.status_code == 200
+    region = response.json()["regions"][0]
+    assert region["terrain_fallback_used"] is True
+    assert region["coverage_fraction"] is None
+    assert region["is_stale"] is True  # 24+ days old, well past threshold
+
+
+def test_terrain_coverage_inventory_empty(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "api.routes.internal.list_terrain_coverage_inventory",
+        lambda: [],
+    )
+    response = client.get("/internal/health/terrain-coverage")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["region_count"] == 0
+    assert body["regions"] == []
+
+
 def test_denoiser_review_queue_endpoints(monkeypatch) -> None:
     rows = [{"id": 1, "event_id": "evt_1", "status": "open"}]
     monkeypatch.setattr("api.routes.internal.list_denoiser_review_queue", lambda limit=200, status="open": rows)


### PR DESCRIPTION
## Changes

Add new internal health endpoint `GET /internal/health/terrain-coverage` to expose DEM coverage inventory.

### Details

- **New endpoint**: Returns latest terrain features metadata for each region, including:
  - Bounding boxes and grid dimensions
  - Resolution and CRS information
  - Coverage fraction and staleness indicators
  - Paths to slope/aspect GeoTIFF files
- **New repository function**: `list_terrain_coverage_inventory()` queries the latest metadata per region from the database
- **Staleness calculation**: Compares preprocessed timestamp against `DATA_STALE_TERRAIN_MINUTES` config (default 7 days)
- **Fallback region support**: Includes regions using flat-terrain fallback, flagged with `terrain_fallback_used`
- **Comprehensive tests**: Coverage for happy path, fallback regions, and empty inventory cases

Operators use this endpoint to determine where forecasts will use real terrain vs. D1 flat-terrain fallback.