### PR TITLE
feat(ingest): add precipitation to GFS ingest with APCP handling

### DIFF
--- a/ingest/tests/test_weather_ingest.py
+++ b/ingest/tests/test_weather_ingest.py
@@ -6,10 +6,13 @@ from unittest.mock import MagicMock, patch
 import tempfile
 
 import httpx
+import numpy as np
 import pytest
+import xarray as xr
 
 from ingest.config import WeatherIngestSettings
 from ingest.weather_ingest import (
+    _derive_per_step_precip,
     _validate_grib_file,
     download_grib_files,
     ingest_weather_for_bbox,
@@ -400,6 +403,90 @@ class TestWeatherIngestPatchMode(unittest.TestCase):
         # Verify default parameters are preserved
         self.assertEqual(call_kwargs["horizon_hours"], 72)
         self.assertEqual(call_kwargs["step_hours"], 3)
+
+
+# ---------------------------------------------------------------------------
+# Tests for _derive_per_step_precip
+# ---------------------------------------------------------------------------
+
+
+def _make_tp(lead_times: list[int], values_1d: list[float]) -> xr.DataArray:
+    """Build a minimal (time, lat, lon) DataArray mimicking loaded GFS APCP."""
+    arr = np.array(values_1d, dtype=float)[:, np.newaxis, np.newaxis]
+    return xr.DataArray(
+        arr,
+        dims=["time", "lat", "lon"],
+        coords={"lead_time_hours": ("time", lead_times)},
+    )
+
+
+def test_derive_per_step_precip_6h_steps_no_differencing():
+    """For 6h steps, each GFS APCP value is already a per-6h-period amount.
+
+    GFS pgrb2 stepRange for 6h cadence: "0-6", "6-12", "12-18" — each file
+    contains a fresh 6h bucket total.  No differencing should be applied.
+    """
+    # lt=0: 0mm | lt=6: 3mm (0-6h bucket) | lt=12: 5mm (6-12h bucket) | lt=18: 2mm
+    tp = _make_tp([0, 6, 12, 18], [0.0, 3.0, 5.0, 2.0])
+    result = _derive_per_step_precip(tp)
+
+    np.testing.assert_array_equal(
+        result.values[:, 0, 0], [0.0, 3.0, 5.0, 2.0],
+        err_msg="6h-step APCP must not be differenced",
+    )
+    assert result.attrs["step_type"] == "per_step"
+    assert result.attrs["source_step_type"] == "accum"
+    assert result.attrs["units"] == "kg m**-2"
+    assert result.attrs["accumulation_bucket_hours"] == 6
+
+
+def test_derive_per_step_precip_3h_steps_diffs_at_6h_boundaries():
+    """For 3h steps, bucket-end values (lead_time % 6 == 0, > 0) are differenced.
+
+    GFS pgrb2 stepRange for 3h cadence (two-step illustration):
+      f003: stepRange="0-3"  → 0-3h period (2 mm, used as-is)
+      f006: stepRange="0-6"  → 0-6h running total (5 mm → diff: 5-2=3 mm for 3-6h)
+      f009: stepRange="6-9"  → 6-9h period after reset (1 mm, used as-is)
+      f012: stepRange="6-12" → 6-12h running total (4 mm → diff: 4-1=3 mm for 9-12h)
+    """
+    tp = _make_tp([0, 3, 6, 9, 12], [0.0, 2.0, 5.0, 1.0, 4.0])
+    result = _derive_per_step_precip(tp)
+    v = result.values[:, 0, 0]
+
+    assert v[0] == pytest.approx(0.0), "lt=0: analysis time must be 0"
+    assert v[1] == pytest.approx(2.0), "lt=3h: 0-3h period amount unchanged"
+    assert v[2] == pytest.approx(3.0), "lt=6h: 5-2=3mm (3-6h period)"
+    assert v[3] == pytest.approx(1.0), "lt=9h: fresh after 6h reset, unchanged"
+    assert v[4] == pytest.approx(3.0), "lt=12h: 4-1=3mm (9-12h period)"
+
+
+def test_derive_per_step_precip_clips_negative_fp_noise():
+    """Floating-point differencing must never produce negative precipitation."""
+    # f003=1.0, f006=1.0+eps → diff ≈ 0 but could be negative due to FP
+    eps = 1e-12
+    tp = _make_tp([0, 3, 6], [0.0, 1.0, 1.0 + eps])
+    result = _derive_per_step_precip(tp)
+    assert (result.values >= 0).all(), "No negative precipitation values after clipping"
+
+
+def test_derive_per_step_precip_single_timestep():
+    """Single-step datasets (only lt=0) should not error and return 0."""
+    tp = _make_tp([0], [0.0])
+    result = _derive_per_step_precip(tp)
+    assert result.values[0, 0, 0] == pytest.approx(0.0)
+
+
+def test_derive_per_step_precip_preserves_spatial_dims():
+    """Spatial (lat, lon) dimensions must be preserved exactly."""
+    arr = np.array([[[0.0, 1.0], [2.0, 3.0]], [[4.0, 5.0], [6.0, 7.0]]])
+    tp = xr.DataArray(
+        arr,
+        dims=["time", "lat", "lon"],
+        coords={"lead_time_hours": ("time", [0, 6])},
+    )
+    result = _derive_per_step_precip(tp)
+    assert result.shape == arr.shape
+    assert result.dims == ("time", "lat", "lon")
 
 
 if __name__ == "__main__":

--- a/ingest/tests/validate_precip_gfs_spot_check.py
+++ b/ingest/tests/validate_precip_gfs_spot_check.py
@@ -113,7 +113,7 @@ def main() -> None:
     print("GFS APCP spot-check validation")
     print(f"  Cycle : {_VALIDATION_CYCLE} {_VALIDATION_HH}Z")
     print(f"  Bbox  : {_BBOX}")
-    print(f"  Steps : f003 (0-3h period) + f006 (0-6h running total)")
+    print("  Steps : f003 (0-3h period) + f006 (0-6h running total)")
     print("=" * 70)
 
     with tempfile.TemporaryDirectory(prefix="gfs_spot_") as tmpdir:

--- a/ingest/tests/validate_precip_gfs_spot_check.py
+++ b/ingest/tests/validate_precip_gfs_spot_check.py
@@ -1,0 +1,209 @@
+"""GFS APCP spot-check validation script.
+
+Validates that ``_derive_per_step_precip`` produces physically correct output
+against a *real* GFS 0.25° GRIB2 file for a fixed cycle.
+
+Usage (requires FIRMS_MAP_KEY and network access to NOMADS):
+    cd <repo-root>
+    uv run python -m ingest.tests.validate_precip_gfs_spot_check
+
+The script:
+  1. Downloads two consecutive 3-hourly GFS GRIB files (f003, f006) for a
+     known historical cycle using the NOMADS filter CGI.
+  2. Loads raw APCP from each file via cfgrib.
+  3. Applies ``_derive_per_step_precip`` and confirms the derivation is
+     physically consistent:
+       - No negative values.
+       - f003 period == f003 raw  (first step of 0-6h bucket, no diff).
+       - f006 period == f006 raw − f003 raw  (bucket-end step, diff applied).
+       - Total (f003 + f006 period) == f006 raw  (conservation check).
+  4. Prints a summary table of global stats (min/max/mean) so the human
+     reviewer can cross-reference against a GRIB viewer or wgrib2.
+
+This script does NOT use pytest fixtures or mock data.  It is intended to be
+run manually as part of Task B1 acceptance validation.
+
+Reference GFS cycle used: 2024-05-01 00Z (publicly available on NOMADS).
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+# Allow running as a script from repo root
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+import numpy as np
+import xarray as xr
+
+from ingest.weather_ingest import _derive_per_step_precip
+
+# ---------------------------------------------------------------------------
+# Fixed validation cycle (historical, always available on NOMADS)
+# ---------------------------------------------------------------------------
+_VALIDATION_CYCLE = "20240501"
+_VALIDATION_HH = "00"
+_ATMOS_DIR = f"/gfs.{_VALIDATION_CYCLE}/{_VALIDATION_HH}/atmos"
+_NOMADS_FILTER = "https://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_0p25.pl"
+
+# Small bbox to minimise download size (~100 km × 100 km over the Pacific)
+_BBOX = (-125.0, 35.0, -120.0, 40.0)
+
+
+def _build_url(forecast_hour: int) -> str:
+    from urllib.parse import urlencode
+
+    params = {
+        "dir": _ATMOS_DIR,
+        "file": f"gfs.t{_VALIDATION_HH}z.pgrb2.0p25.f{forecast_hour:03d}",
+        "leftlon": _BBOX[0],
+        "rightlon": _BBOX[2],
+        "toplat": _BBOX[3],
+        "bottomlat": _BBOX[1],
+        "var_APCP": "on",
+        "lev_surface": "on",
+    }
+    return f"{_NOMADS_FILTER}?{urlencode(params)}"
+
+
+def _download(url: str, dest: Path) -> None:
+    import httpx
+
+    print(f"  Downloading {url}")
+    with httpx.Client(timeout=120) as client:
+        with client.stream("GET", url) as resp:
+            resp.raise_for_status()
+            with dest.open("wb") as fh:
+                for chunk in resp.iter_bytes():
+                    fh.write(chunk)
+    print(f"  Saved {dest.stat().st_size:,} bytes → {dest.name}")
+
+
+def _load_apcp(path: Path) -> xr.DataArray:
+    """Open APCP from a single GRIB2 file via cfgrib."""
+    ds = xr.open_dataset(
+        path,
+        engine="cfgrib",
+        backend_kwargs={
+            "filter_by_keys": {"shortName": "tp"},
+            "indexpath": "",
+        },
+    )
+    ds.load()
+    # cfgrib may name the variable "tp" or "unknown"; take the first data var.
+    var_name = next(iter(ds.data_vars))
+    da = ds[var_name].copy()
+    ds.close()
+    return da
+
+
+def _stats(da: xr.DataArray) -> dict:
+    v = da.values.astype(float)
+    return {
+        "min": float(np.nanmin(v)),
+        "max": float(np.nanmax(v)),
+        "mean": float(np.nanmean(v)),
+    }
+
+
+def main() -> None:
+    print("=" * 70)
+    print("GFS APCP spot-check validation")
+    print(f"  Cycle : {_VALIDATION_CYCLE} {_VALIDATION_HH}Z")
+    print(f"  Bbox  : {_BBOX}")
+    print(f"  Steps : f003 (0-3h period) + f006 (0-6h running total)")
+    print("=" * 70)
+
+    with tempfile.TemporaryDirectory(prefix="gfs_spot_") as tmpdir:
+        f003_path = Path(tmpdir) / "f003.grib2"
+        f006_path = Path(tmpdir) / "f006.grib2"
+
+        print("\n[1] Downloading GRIB files …")
+        _download(_build_url(3), f003_path)
+        _download(_build_url(6), f006_path)
+
+        print("\n[2] Loading raw APCP …")
+        raw_f003 = _load_apcp(f003_path)
+        raw_f006 = _load_apcp(f006_path)
+
+        print(f"  f003 raw  stats: {_stats(raw_f003)}")
+        print(f"  f006 raw  stats: {_stats(raw_f006)}")
+
+        print("\n[3] Building combined DataArray with lead_time_hours …")
+        # Stack into (time=2, lat, lon) with lead_time_hours coordinate.
+        combined = xr.concat(
+            [
+                raw_f003.expand_dims("time").assign_coords(time=[0]),
+                raw_f006.expand_dims("time").assign_coords(time=[1]),
+            ],
+            dim="time",
+        ).assign_coords(lead_time_hours=("time", [3, 6]))
+
+        print("\n[4] Applying _derive_per_step_precip …")
+        derived = _derive_per_step_precip(combined)
+
+        period_f003 = derived.isel(time=0).values.astype(float)
+        period_f006 = derived.isel(time=1).values.astype(float)
+        raw_f003_vals = raw_f003.values.astype(float)
+        raw_f006_vals = raw_f006.values.astype(float)
+
+        print(f"  f003 period stats (should == f003 raw): {_stats(derived.isel(time=0))}")
+        print(f"  f006 period stats (should == f006_raw - f003_raw): {_stats(derived.isel(time=1))}")
+
+        # ---------------------------------------------------------------
+        # Assertion 1: No negative values
+        # ---------------------------------------------------------------
+        assert (period_f003 >= 0).all(), "FAIL: negative values in f003 period"
+        assert (period_f006 >= 0).all(), "FAIL: negative values in f006 period"
+        print("\n  [PASS] No negative precipitation values")
+
+        # ---------------------------------------------------------------
+        # Assertion 2: f003 period == f003 raw (first step, no diff)
+        # ---------------------------------------------------------------
+        # lt=3 → lt%6 != 0 → no differencing → period must equal raw.
+        np.testing.assert_allclose(
+            period_f003, raw_f003_vals,
+            rtol=1e-6,
+            err_msg="FAIL: f003 period should equal raw APCP (no differencing)",
+        )
+        print("  [PASS] f003 period == f003 raw (no differencing at non-boundary step)")
+
+        # ---------------------------------------------------------------
+        # Assertion 3: f006 period == f006_raw − f003_raw  (bucket-end diff)
+        # ---------------------------------------------------------------
+        expected_f006_period = np.clip(raw_f006_vals - raw_f003_vals, 0.0, None)
+        np.testing.assert_allclose(
+            period_f006, expected_f006_period,
+            rtol=1e-6,
+            err_msg="FAIL: f006 period should equal f006_raw - f003_raw",
+        )
+        print("  [PASS] f006 period == f006_raw − f003_raw (bucket-end differencing)")
+
+        # ---------------------------------------------------------------
+        # Assertion 4: Conservation — sum of periods == f006 raw total
+        # ---------------------------------------------------------------
+        total_derived = period_f003 + period_f006
+        np.testing.assert_allclose(
+            total_derived, raw_f006_vals,
+            rtol=1e-6,
+            err_msg="FAIL: f003_period + f006_period should equal f006_raw (conservation)",
+        )
+        print("  [PASS] f003_period + f006_period == f006_raw (mass conservation)")
+
+        # ---------------------------------------------------------------
+        # Assertion 5: Metadata attributes
+        # ---------------------------------------------------------------
+        assert derived.attrs.get("step_type") == "per_step", "FAIL: step_type attr"
+        assert derived.attrs.get("source_step_type") == "accum", "FAIL: source_step_type attr"
+        assert derived.attrs.get("units") == "kg m**-2", "FAIL: units attr"
+        print("  [PASS] Metadata attributes correct")
+
+    print("\n" + "=" * 70)
+    print("All spot-check assertions PASSED")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/ingest/weather_ingest.py
+++ b/ingest/weather_ingest.py
@@ -66,6 +66,9 @@ SHORT_NAME_MAP = {
 ANALYSIS_CRS = DEFAULT_CRS
 ANALYSIS_CELL_SIZE_DEG = DEFAULT_CELL_SIZE_DEG
 
+# GFS APCP accumulation resets every 6 hours (hard-coded in GFS v16 pgrb2 output).
+GFS_ACCUMULATION_BUCKET_HOURS = 6
+
 
 def build_grid_spec(settings: WeatherIngestSettings) -> GridSpec:
     """Build the canonical analysis grid snapped to 0.01°."""
@@ -563,6 +566,89 @@ def _open_variable_dataset(
         raise
 
 
+def _derive_per_step_precip(tp: xr.DataArray) -> xr.DataArray:
+    """Convert GFS APCP raw GRIB values to per-step precipitation.
+
+    GFS APCP GRIB metadata this function relies on:
+      - ``stepType``: "accum" (confirmed via cfgrib ``filter_by_keys`` shortName="tp").
+      - Accumulation bucket: **6 hours**, hard-coded in GFS v16 operational pgrb2 output.
+      - ``stepRange`` examples for 3h steps: "0-3", "0-6", "6-9", "6-12".
+        The 6h bucket resets at lead-times 6, 12, 18, 24 … hours from the cycle start.
+        Within each bucket, values are cumulative from the bucket start.
+      - ``stepRange`` examples for 6h steps: "0-6", "6-12", "12-18".
+        At 6h cadence the only value in each bucket IS the full-bucket total;
+        no differencing is required.
+
+    Derivation logic (inferred step size from ``lead_time_hours`` spacing):
+
+    For **step_hours >= 6** (default GFS operational cadence):
+        Each downloaded GRIB file covers exactly one 6h bucket.  The APCP value
+        already equals the per-6h-period precipitation.  Values are returned
+        unchanged (clipping only).
+
+    For **step_hours < 6** (e.g. 3h, 1h):
+        At a lead time that is an exact multiple of 6 (the "bucket-end" step),
+        the GRIB value is a running total from the bucket start.  Subtracting
+        the immediately preceding step yields the final sub-step contribution::
+
+            period(3-6h) = raw_f006 - raw_f003  (raw_f006 = 0-6h running total)
+            period(9-12h) = raw_f012 - raw_f009 (raw_f012 = 6-12h running total)
+
+        All other steps within a bucket are period amounts (not running totals)
+        and are used as-is.
+
+    Negative values produced by floating-point differencing are clipped to 0.
+
+    Returns a DataArray with:
+      - ``units``: "kg m**-2"  (= mm liquid water equivalent, raw GFS convention)
+      - ``step_type``: "per_step"
+      - ``source_step_type``: "accum"
+      - ``accumulation_bucket_hours``: 6
+    """
+    lead_times = tp.coords["lead_time_hours"].values.astype(int)
+
+    # Infer step size from the first gap in lead_time_hours.
+    step_hours = GFS_ACCUMULATION_BUCKET_HOURS
+    if len(lead_times) > 1:
+        step_hours = int(lead_times[1] - lead_times[0])
+
+    if step_hours >= GFS_ACCUMULATION_BUCKET_HOURS:
+        # Each file already carries a full 6h-period amount.
+        # clip() creates the only copy needed — no prior copy required.
+        per_step = tp.clip(min=0.0)
+    else:
+        # Bucket-end steps (lead_time % 6 == 0, > 0) contain a running total from
+        # the bucket start; all other steps are already period amounts.
+        bucket_end_idx = np.where(
+            (lead_times % GFS_ACCUMULATION_BUCKET_HOURS == 0) & (lead_times > 0)
+        )[0]
+
+        # Single float copy; selectively update in-place with vectorized indexing.
+        per_step_values = np.array(tp.values, dtype=float)
+        per_step_values[lead_times == 0] = 0.0
+        if bucket_end_idx.size > 0:
+            per_step_values[bucket_end_idx] = (
+                tp.values[bucket_end_idx] - tp.values[bucket_end_idx - 1]
+            )
+        np.clip(per_step_values, 0.0, None, out=per_step_values)
+        per_step = tp.copy(data=per_step_values)
+
+    per_step.attrs.update(
+        {
+            "long_name": "total precipitation per time step",
+            "units": "kg m**-2",
+            "step_type": "per_step",
+            "source_step_type": "accum",
+            "accumulation_bucket_hours": GFS_ACCUMULATION_BUCKET_HOURS,
+            "gfs_grib_note": (
+                "GFS APCP (stepType=accum) resets every 6h. "
+                "For sub-6h steps, bucket-end values are differenced to yield per-step amounts."
+            ),
+        }
+    )
+    return per_step
+
+
 def build_weather_dataset(
     grib_paths: list[Path],
     run_time: datetime,
@@ -602,6 +688,12 @@ def build_weather_dataset(
     ds = ds.assign_coords(forecast_reference_time=run_time64)
     lead_time = (ds["time"].values - run_time64) / np.timedelta64(1, "h")
     ds = ds.assign_coords(lead_time_hours=("time", lead_time.astype(int)))
+
+    # Convert raw cumulative GFS APCP to per-step precipitation.
+    # Must run after lead_time_hours is assigned (used to infer step size and bucket boundaries).
+    if include_precip and "tp" in ds:
+        ds["tp"] = _derive_per_step_precip(ds["tp"])
+
     return ds
 
 


### PR DESCRIPTION
## Summary
Adds GFS precipitation (APCP) ingest capability with proper handling of accumulation bucket resets.

## Changes

### Core Implementation (`weather_ingest.py`)
- Added `_derive_per_step_precip()` function to convert raw GFS cumulative APCP values to per-step precipitation amounts
- Handles 6-hour accumulation bucket resets in GFS output:
  - For ≥6h steps: values used as-is (already period amounts)
  - For <6h steps: bucket-end values (multiples of 6h) are differenced to extract sub-step contributions
- Clips negative values from floating-point arithmetic to zero
- Adds metadata attributes tracking step type, source, and bucket size

### Tests (`test_weather_ingest.py`)
- Added comprehensive unit tests for `_derive_per_step_precip()`:
  - 6h step handling (no differencing)
  - 3h step handling (differencing at bucket boundaries)
  - Floating-point noise clipping
  - Edge cases (single timestep, spatial dimension preservation)

### Validation Script (`validate_precip_gfs_spot_check.py`)
- Added standalone spot-check script using real GFS GRIB data from NOMADS
- Validates:
  - No negative precipitation values
  - Correct period extraction (f003 raw vs. f006 raw − f003 raw)
  - Mass conservation (sum of periods equals running total)
  - Metadata attributes
- Can be run manually for acceptance testing
