### PR TITLE
feat(ingest): add JOB_LFMC and JOB_LULC to orchestrator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,13 +181,15 @@ services:
     command: >
       uv run --project ingest -m ingest.orchestrator
       --loop
-      --jobs firms,perimeters
+      --jobs firms,perimeters,lfmc,lulc
       --enforce-freshness
       --max-retries 3
       --retry-backoff-seconds 20
       --firms-interval-minutes 30
       --weather-interval-minutes 180
       --perimeters-interval-minutes 1440
+      --lfmc-interval-minutes 360
+      --lulc-interval-minutes 10080
       --dashboard-path /app/data/ingest/orchestrator_dashboard.json
     restart: unless-stopped
     volumes:
@@ -215,6 +217,10 @@ services:
       # Bootstrap batches can reach ~10k rows (full day of VIIRS globally filtered to
       # FIRMS_INITIAL_LOOKBACK_MINUTES). 180s is not enough; 900s gives safe headroom.
       DENOISER_SUBPROCESS_TIMEOUT_SECONDS: ${DENOISER_SUBPROCESS_TIMEOUT_SECONDS:-900}
+      # LFMC ecLand: set LFMC_ECLAND_API_URL to enable; LFMC_ECLAND_API_TOKEN is optional bearer.
+      # If LFMC_ECLAND_API_URL is unset the job will fail gracefully without blocking FIRMS/weather.
+      LFMC_ECLAND_API_URL: ${LFMC_ECLAND_API_URL:-}
+      LFMC_ECLAND_API_TOKEN: ${LFMC_ECLAND_API_TOKEN:-}
       FIRMS_MAP_KEY: ${FIRMS_MAP_KEY}
       FIRMS_DAY_RANGE: ${FIRMS_DAY_RANGE:-1}
       FIRMS_INITIAL_LOOKBACK_MINUTES: ${FIRMS_INITIAL_LOOKBACK_MINUTES:-360}

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -29,11 +29,13 @@ LOGGER = logging.getLogger("ingest_orchestrator")
 
 JOB_FIRMS = "firms"
 JOB_WEATHER = "weather"
+JOB_LFMC = "lfmc"
+JOB_LULC = "lulc"
 JOB_TERRAIN = "terrain"
 JOB_PERIMETERS = "perimeters"
 JOB_INDUSTRIAL = "industrial"
 JOB_DENOISER_DRIFT = "denoiser_drift"
-JOB_ORDER = (JOB_FIRMS, JOB_WEATHER, JOB_TERRAIN, JOB_PERIMETERS, JOB_INDUSTRIAL, JOB_DENOISER_DRIFT)
+JOB_ORDER = (JOB_FIRMS, JOB_WEATHER, JOB_LFMC, JOB_LULC, JOB_TERRAIN, JOB_PERIMETERS, JOB_INDUSTRIAL, JOB_DENOISER_DRIFT)
 DEFAULT_DASHBOARD_PATH = REPO_ROOT / "data" / "ingest" / "orchestrator_dashboard.json"
 
 # Watermarks whose source name ends with _NRT are near-real-time feeds.
@@ -42,6 +44,7 @@ DEFAULT_DASHBOARD_PATH = REPO_ROOT / "data" / "ingest" / "orchestrator_dashboard
 # to NULL triggers safe bootstrap mode on the next ingest cycle.
 _WATERMARK_FUTURE_TOLERANCE_SECONDS: float = 300.0  # 5 min clock-skew grace
 _WATERMARK_NRT_MAX_AGE_DAYS: int = 30
+_DEFAULT_CONUS_BBOX: tuple[float, float, float, float] = (-179.5, 18.0, -66.0, 72.0)
 
 
 @dataclass
@@ -108,8 +111,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=str,
         default=",".join(JOB_ORDER),
         help=(
-            "Comma-separated job list. Supported: firms,weather,terrain,perimeters,industrial,denoiser_drift. "
-            "Execution order is fixed as firms->weather->terrain->perimeters->industrial->denoiser_drift."
+            "Comma-separated job list. Supported: firms,weather,lfmc,lulc,terrain,perimeters,industrial,denoiser_drift. "
+            "Execution order is fixed as firms->weather->lfmc->lulc->terrain->perimeters->industrial->denoiser_drift."
         ),
     )
     parser.add_argument(
@@ -189,6 +192,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=float,
         default=1440.0,
         help="Denoiser drift monitor run interval in minutes (loop mode).",
+    )
+    parser.add_argument(
+        "--lfmc-interval-minutes",
+        type=float,
+        default=360.0,
+        help="LFMC ecLand ingest interval in minutes (loop mode). 4x/day matches API job delay.",
+    )
+    parser.add_argument(
+        "--lulc-interval-minutes",
+        type=float,
+        default=10080.0,
+        help="LULC WorldCover backfill interval in minutes (loop mode). Weekly; tiles are static.",
     )
 
     parser.add_argument(
@@ -340,6 +355,60 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Run industrial ingest in dry-run mode.",
     )
 
+    parser.add_argument(
+        "--lfmc-bbox",
+        type=float,
+        nargs=4,
+        metavar=("MIN_LON", "MIN_LAT", "MAX_LON", "MAX_LAT"),
+        help="Override LFMC ingest bbox. Defaults to CONUS (-179.5 18.0 -66.0 72.0).",
+    )
+    parser.add_argument(
+        "--lfmc-timeout-seconds",
+        type=int,
+        default=1800,
+        help=(
+            "Max seconds to wait for an LFMC API job to complete before giving up. "
+            "Capped well below the FIRMS/weather interval to avoid blocking the pipeline."
+        ),
+    )
+
+    parser.add_argument(
+        "--lulc-bbox",
+        type=float,
+        nargs=4,
+        metavar=("MIN_LON", "MIN_LAT", "MAX_LON", "MAX_LAT"),
+        help="Override LULC WorldCover backfill bbox. Defaults to CONUS (-179.5 18.0 -66.0 72.0).",
+    )
+    parser.add_argument(
+        "--lulc-lookback-days",
+        type=int,
+        default=7,
+        help="Backfill fire_detections this many days back on each LULC run.",
+    )
+    parser.add_argument(
+        "--lulc-version",
+        type=str,
+        default="v200",
+        help="ESA WorldCover product version.",
+    )
+    parser.add_argument(
+        "--lulc-year",
+        type=int,
+        default=2021,
+        help="ESA WorldCover reference year.",
+    )
+    parser.add_argument(
+        "--lulc-force",
+        action="store_true",
+        help="Recompute LULC classes even for detections that are already classified.",
+    )
+    parser.add_argument(
+        "--lulc-cache-dir",
+        type=str,
+        default=None,
+        help="Local cache dir for ESA WorldCover tiles. Defaults to data/lulc/worldcover/v200_2021_tiles.",
+    )
+
     args = parser.parse_args(argv)
     _validate_args(args)
     return args
@@ -360,6 +429,8 @@ def _validate_args(args: argparse.Namespace) -> None:
     interval_flags = (
         ("--firms-interval-minutes", args.firms_interval_minutes),
         ("--weather-interval-minutes", args.weather_interval_minutes),
+        ("--lfmc-interval-minutes", args.lfmc_interval_minutes),
+        ("--lulc-interval-minutes", args.lulc_interval_minutes),
         ("--terrain-interval-minutes", args.terrain_interval_minutes),
         ("--perimeters-interval-minutes", args.perimeters_interval_minutes),
         ("--industrial-interval-minutes", args.industrial_interval_minutes),
@@ -409,6 +480,54 @@ def _run_firms(args: argparse.Namespace) -> int:
 
 def _run_weather(args: argparse.Namespace) -> int:
     return int(run_weather_ingest(_build_weather_argv(args)))
+
+
+def _run_lfmc(args: argparse.Namespace) -> int:
+    """Run LFMC ecLand ingest.
+
+    Timeout is enforced via ``--lfmc-timeout-seconds`` (default 1800s) to prevent
+    a stalled or slow API job from blocking terrain/perimeters/industrial downstream.
+    FIRMS and weather have already completed before this job starts (JOB_ORDER).
+    """
+    # Lazy import: lfmc_ecland_ingest pulls httpx/xarray/sqlalchemy at module scope.
+    from ingest.lfmc_ecland_ingest import ingest_lfmc_ecland_for_bbox
+
+    bbox: tuple[float, float, float, float] = tuple(args.lfmc_bbox) if args.lfmc_bbox else _DEFAULT_CONUS_BBOX  # type: ignore[assignment]
+    try:
+        ingest_lfmc_ecland_for_bbox(bbox=bbox, timeout_seconds=args.lfmc_timeout_seconds)
+    except Exception as exc:
+        LOGGER.warning(
+            "LFMC ingest failed (timeout_seconds=%s): %s — pipeline continues",
+            args.lfmc_timeout_seconds,
+            exc,
+        )
+        return 1
+    return 0
+
+
+def _run_lulc(args: argparse.Namespace) -> int:
+    """Backfill fire_detections with ESA WorldCover landcover classes."""
+    # Lazy import: lulc_worldcover_ingest pulls numpy/rasterio/sqlalchemy at module scope.
+    from ingest.lulc_worldcover_ingest import backfill_worldcover
+
+    bbox: tuple[float, float, float, float] = tuple(args.lulc_bbox) if args.lulc_bbox else _DEFAULT_CONUS_BBOX  # type: ignore[assignment]
+    now = _utc_now()
+    cache_dir = Path(args.lulc_cache_dir) if args.lulc_cache_dir else Path("data/lulc/worldcover/v200_2021_tiles")
+
+    result = backfill_worldcover(
+        start_time=now - timedelta(days=args.lulc_lookback_days),
+        end_time=now,
+        bbox=bbox,
+        version=args.lulc_version,
+        year=args.lulc_year,
+        force=args.lulc_force,
+        max_tiles=0,
+        query_batch_size=50000,
+        update_batch_size=5000,
+        cache_dir=cache_dir,
+    )
+    LOGGER.info("LULC WorldCover backfill complete: %s", result)
+    return 0
 
 
 def _run_terrain(args: argparse.Namespace) -> int:
@@ -556,6 +675,8 @@ def build_jobs(args: argparse.Namespace) -> list[ScheduledJob]:
     runners: dict[str, Callable[[], int]] = {
         JOB_FIRMS: lambda: _run_firms(args),
         JOB_WEATHER: lambda: _run_weather(args),
+        JOB_LFMC: lambda: _run_lfmc(args),
+        JOB_LULC: lambda: _run_lulc(args),
         JOB_TERRAIN: lambda: _run_terrain(args),
         JOB_PERIMETERS: lambda: _run_perimeters(args),
         JOB_INDUSTRIAL: lambda: _run_industrial(args),
@@ -565,6 +686,8 @@ def build_jobs(args: argparse.Namespace) -> list[ScheduledJob]:
     intervals_seconds = {
         JOB_FIRMS: args.firms_interval_minutes * 60.0,
         JOB_WEATHER: args.weather_interval_minutes * 60.0,
+        JOB_LFMC: args.lfmc_interval_minutes * 60.0,
+        JOB_LULC: args.lulc_interval_minutes * 60.0,
         JOB_TERRAIN: args.terrain_interval_minutes * 60.0,
         JOB_PERIMETERS: args.perimeters_interval_minutes * 60.0,
         JOB_INDUSTRIAL: args.industrial_interval_minutes * 60.0,

--- a/ingest/tests/test_orchestrator.py
+++ b/ingest/tests/test_orchestrator.py
@@ -6,11 +6,15 @@ from unittest.mock import patch
 from ingest.orchestrator import (
     JOB_DENOISER_DRIFT,
     JOB_INDUSTRIAL,
+    JOB_LFMC,
+    JOB_LULC,
     JOB_ORDER,
+    JOB_WEATHER,
     ScheduledJob,
     _build_industrial_argv,
     _build_weather_argv,
     _run_denoiser_drift,
+    _run_lfmc,
     run_once,
     run_scheduler,
     validate_and_reset_watermarks,
@@ -461,6 +465,102 @@ class TestWatermarkValidation(unittest.TestCase):
         count, resets = self._run([])
         self.assertEqual(0, count)
         self.assertEqual([], resets)
+
+
+class TestFuelJobs(unittest.TestCase):
+    """Tests for LFMC and LULC orchestrator integration."""
+
+    def test_lfmc_in_job_order(self):
+        self.assertIn(JOB_LFMC, JOB_ORDER)
+
+    def test_lulc_in_job_order(self):
+        self.assertIn(JOB_LULC, JOB_ORDER)
+
+    def test_lfmc_after_weather(self):
+        self.assertGreater(JOB_ORDER.index(JOB_LFMC), JOB_ORDER.index(JOB_WEATHER))
+
+    def test_lulc_after_weather(self):
+        self.assertGreater(JOB_ORDER.index(JOB_LULC), JOB_ORDER.index(JOB_WEATHER))
+
+    def test_lfmc_before_lulc(self):
+        self.assertLess(JOB_ORDER.index(JOB_LFMC), JOB_ORDER.index(JOB_LULC))
+
+    def test_run_lfmc_timeout_returns_one_and_logs_warning(self):
+        """A TimeoutError from the LFMC API must return exit_code=1 with a warning log."""
+        args = argparse.Namespace(
+            lfmc_bbox=None,
+            lfmc_timeout_seconds=30.0,
+        )
+        with patch(
+            "ingest.lfmc_ecland_ingest.ingest_lfmc_ecland_for_bbox",
+            side_effect=TimeoutError("LFMC ecLand job timed out"),
+        ):
+            with self.assertLogs("ingest_orchestrator", level="WARNING") as log_ctx:
+                code = _run_lfmc(args)
+
+        self.assertEqual(1, code)
+        self.assertTrue(
+            any("pipeline continues" in line for line in log_ctx.output),
+            f"Expected 'pipeline continues' in warning log, got: {log_ctx.output}",
+        )
+
+    def test_run_lfmc_api_error_returns_one(self):
+        """Any LFMC exception (e.g. missing API URL) returns exit_code=1."""
+        args = argparse.Namespace(
+            lfmc_bbox=None,
+            lfmc_timeout_seconds=30.0,
+        )
+        with patch(
+            "ingest.lfmc_ecland_ingest.ingest_lfmc_ecland_for_bbox",
+            side_effect=RuntimeError("LFMC_ECLAND_API_URL is not set"),
+        ):
+            with self.assertLogs("ingest_orchestrator", level="WARNING"):
+                code = _run_lfmc(args)
+
+        self.assertEqual(1, code)
+
+    def test_lfmc_failure_does_not_stop_subsequent_jobs(self):
+        """LFMC timeout/failure must not block downstream jobs in run_once."""
+        calls: list[str] = []
+
+        def _lfmc_timeout() -> int:
+            calls.append("lfmc")
+            return 1  # simulates _run_lfmc returning 1 after timeout
+
+        def _downstream() -> int:
+            calls.append("downstream")
+            return 0
+
+        jobs = [
+            ScheduledJob(name="lfmc", interval_seconds=21600.0, runner=_lfmc_timeout),
+            ScheduledJob(name="terrain", interval_seconds=86400.0, runner=_downstream),
+        ]
+        exit_code = run_once(jobs, stop_on_error=False)
+
+        # Pipeline completes; overall exit is 1 (has failure) but downstream ran
+        self.assertEqual(1, exit_code)
+        self.assertEqual(["lfmc", "downstream"], calls)
+
+    def test_lfmc_failure_with_stop_on_error_halts_pipeline(self):
+        """stop_on_error=True must stop after LFMC failure (existing semantics, not LFMC-specific)."""
+        calls: list[str] = []
+
+        def _lfmc_timeout() -> int:
+            calls.append("lfmc")
+            return 1
+
+        def _downstream() -> int:  # pragma: no cover
+            calls.append("downstream")
+            return 0
+
+        jobs = [
+            ScheduledJob(name="lfmc", interval_seconds=21600.0, runner=_lfmc_timeout),
+            ScheduledJob(name="terrain", interval_seconds=86400.0, runner=_downstream),
+        ]
+        exit_code = run_once(jobs, stop_on_error=True)
+
+        self.assertEqual(1, exit_code)
+        self.assertEqual(["lfmc"], calls)  # downstream did not run
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes

- Add `JOB_LFMC` and `JOB_LULC` job types to orchestrator with fixed execution order (after weather, before terrain)
- Implement `_run_lfmc()` to ingest LFMC ecLand data with configurable timeout to prevent blocking downstream jobs
- Implement `_run_lulc()` to backfill fire_detections with ESA WorldCover landcover classes
- Add CLI arguments for both jobs:
  - LFMC: `--lfmc-interval-minutes` (default 360), `--lfmc-bbox`, `--lfmc-timeout-seconds` (default 1800)
  - LULC: `--lulc-interval-minutes` (default 10080), `--lulc-bbox`, `--lulc-lookback-days`, `--lulc-version`, `--lulc-year`, `--lulc-force`, `--lulc-cache-dir`
- Update docker-compose.yml with new jobs in default config and LFMC API environment variables
- Add comprehensive unit tests for job ordering, timeout handling, and pipeline continuation semantics