### PR TITLE
feat(ml): expose precipitation channel in spread feature builder

### DIFF
--- a/ml/spread_features.py
+++ b/ml/spread_features.py
@@ -312,6 +312,10 @@ def _load_weather_cube(
             lead_time_hours=("time", list(horizons_hours)),
         )
 
+        # Rename ingest-native 'tp' → contract-expected 'precip_24h'.
+        if "tp" in ds_final.data_vars and "precip_24h" not in ds_final.data_vars:
+            ds_final = ds_final.rename({"tp": "precip_24h"})
+
         # Ensure the caller doesn't hold an open file handle.
         ds_final = ds_final.load()
 
@@ -421,6 +425,8 @@ def _create_fallback_weather(
             "v10":  (("time", "lat", "lon"), np.zeros(shape, dtype=np.float32)),
             "t2m":  (("time", "lat", "lon"), np.full(shape, np.nan, dtype=np.float32)),
             "rh2m": (("time", "lat", "lon"), np.full(shape, np.nan, dtype=np.float32)),
+            # Zero precipitation assumed in fallback (conservative: no rain).
+            "precip_24h": (("time", "lat", "lon"), np.zeros(shape, dtype=np.float32)),
             # DFMC is NaN in fallback — callers should treat as unknown moisture.
             "dfmc": (("time", "lat", "lon"), np.full(shape, np.nan, dtype=np.float32)),
         },

--- a/ml/tests/test_spread_features.py
+++ b/ml/tests/test_spread_features.py
@@ -73,8 +73,10 @@ def test_fallback_weather_creation(mock_window):
     assert dict(ds.sizes) == {"time": 2, "lat": 10, "lon": 10}
     assert "u10" in ds.data_vars
     assert "v10" in ds.data_vars
+    assert "precip_24h" in ds.data_vars
     assert (ds.u10.values == 0).all()
     assert (ds.v10.values == 0).all()
+    assert (ds.precip_24h.values == 0).all()
     assert np.isnan(ds.t2m.values).all()
 
     # Check coords
@@ -258,6 +260,43 @@ def test_load_weather_cube_remaps_host_absolute_storage_path(
     opened_path = Path(mock_open.call_args[0][0])
     assert opened_path == mapped_path
     assert out.attrs.get("weather_fallback_used") is False
+
+
+@patch("ml.spread_features.Path.exists", return_value=True)
+@patch("ml.spread_features._get_latest_weather_run")
+@patch("xarray.open_dataset")
+def test_load_weather_cube_renames_tp_to_precip_24h(mock_open, mock_get_run, _mock_exists, mock_window):
+    """Weather ingest stores 'tp'; spread contract expects 'precip_24h'. Verify rename."""
+    ref_time = datetime(2025, 12, 26, 12, 0, 0, tzinfo=timezone.utc)
+    mock_get_run.return_value = {"id": 456, "storage_path": "fake.nc", "run_time": ref_time}
+
+    target_times = [
+        np.datetime64("2025-12-27T12:00:00", "ns"),
+        np.datetime64("2025-12-28T12:00:00", "ns"),
+    ]
+
+    w_ds = xr.Dataset(
+        data_vars={
+            "u10": (("time", "lat", "lon"), np.ones((2, 10, 10), dtype=np.float32)),
+            "v10": (("time", "lat", "lon"), np.ones((2, 10, 10), dtype=np.float32)),
+            "t2m": (("time", "lat", "lon"), np.full((2, 10, 10), 290.0, dtype=np.float32)),
+            "rh2m": (("time", "lat", "lon"), np.full((2, 10, 10), 50.0, dtype=np.float32)),
+            "tp": (("time", "lat", "lon"), np.full((2, 10, 10), 2.5, dtype=np.float32)),
+        },
+        coords={"time": target_times, "lat": mock_window.lat, "lon": mock_window.lon},
+    )
+    mock_open.return_value = w_ds
+
+    out = _load_weather_cube(
+        ref_time=ref_time,
+        window=mock_window,
+        horizons_hours=[24, 48],
+        bbox=(0, 0, 1, 1),
+    )
+
+    assert "precip_24h" in out.data_vars, "tp should be renamed to precip_24h"
+    assert "tp" not in out.data_vars, "original tp variable should be gone after rename"
+    assert float(out["precip_24h"].values[0, 0, 0]) == pytest.approx(2.5)
 
 
 @patch("ml.spread_features._get_latest_weather_run")


### PR DESCRIPTION
## Changes

- **Weather cube loading**: Rename ingest-native `tp` variable to contract-expected `precip_24h` variable to maintain compatibility between data sources and downstream consumers
- **Fallback weather creation**: Add `precip_24h` channel with zero values (conservative assumption: no precipitation in fallback scenarios)
- **Tests**: Add comprehensive test coverage for the `tp` → `precip_24h` rename and verify fallback weather dataset includes the precipitation channel with expected values