### PR TITLE
Add LFMC graceful degradation with stale fuel tracking

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -147,6 +147,9 @@ class AppSettings(BaseSettings):
     data_stale_perimeters_minutes: int = Field(
         default=4320, validation_alias="DATA_STALE_PERIMETERS_MINUTES"
     )
+    data_stale_lfmc_minutes: int = Field(
+        default=480, validation_alias="DATA_STALE_LFMC_MINUTES"
+    )
     data_status_critical_sources: str = Field(
         default="firms,weather",
         validation_alias="DATA_STATUS_CRITICAL_SOURCES",

--- a/api/data_status.py
+++ b/api/data_status.py
@@ -266,6 +266,50 @@ def _fetch_latest_terrain_status(conn) -> dict[str, Any]:
     }
 
 
+def _fetch_latest_lfmc_status(conn) -> dict[str, Any]:
+    latest = conn.execute(
+        text(
+            """
+            SELECT id, run_time, status, provider, created_at
+            FROM fuel_moisture_runs
+            WHERE status = 'completed'
+            ORDER BY run_time DESC, id DESC
+            LIMIT 1
+            """
+        )
+    ).mappings().first()
+
+    counts = conn.execute(
+        text(
+            """
+            SELECT
+                COUNT(*) FILTER (WHERE status = 'completed') AS completed_runs,
+                COUNT(*) FILTER (WHERE status = 'failed') AS failed_runs,
+                MAX(created_at) FILTER (WHERE status = 'failed') AS last_failure_at
+            FROM fuel_moisture_runs
+            WHERE created_at >= NOW() - INTERVAL '24 hours'
+            """
+        )
+    ).mappings().first()
+
+    latest_row = latest or {}
+    counts_row = counts or {}
+    run_time = _as_utc(latest_row.get("run_time"))
+    last_failure = _as_utc(counts_row.get("last_failure_at"))
+
+    return {
+        "last_seen_at": run_time,
+        "idempotency": {
+            "latest_run_id": latest_row.get("id"),
+            "latest_provider": latest_row.get("provider"),
+            "latest_run_time": run_time.isoformat() if run_time else None,
+            "completed_runs_last_24h": int(counts_row.get("completed_runs") or 0),
+            "failed_runs_last_24h": int(counts_row.get("failed_runs") or 0),
+            "last_failure_at": last_failure.isoformat() if last_failure else None,
+        },
+    }
+
+
 def _fetch_latest_perimeters_status(conn) -> dict[str, Any]:
     stats = conn.execute(
         text(
@@ -312,6 +356,7 @@ def build_data_status_snapshot(
         weather = _fetch_latest_weather_status(conn)
         terrain = _fetch_latest_terrain_status(conn)
         perimeters = _fetch_latest_perimeters_status(conn)
+        lfmc = _fetch_latest_lfmc_status(conn)
 
     sources = {
         "firms": _source_status(
@@ -336,6 +381,12 @@ def build_data_status_snapshot(
             name="perimeters",
             last_seen_at=perimeters["last_seen_at"],
             threshold_minutes=settings.data_stale_perimeters_minutes,
+            now=now_utc,
+        ),
+        "lfmc": _source_status(
+            name="lfmc",
+            last_seen_at=lfmc["last_seen_at"],
+            threshold_minutes=settings.data_stale_lfmc_minutes,
             now=now_utc,
         ),
     }
@@ -422,5 +473,6 @@ def build_data_status_snapshot(
             "weather": weather["idempotency"],
             "terrain": terrain["idempotency"],
             "perimeters": perimeters["idempotency"],
+            "lfmc": lfmc["idempotency"],
         }
     return snapshot

--- a/api/tests/test_data_status.py
+++ b/api/tests/test_data_status.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from api.data_status import _fetch_latest_firms_status, build_data_status_snapshot
 
@@ -37,36 +38,52 @@ class _DummyFirmsConn:
         raise AssertionError(f"Unexpected SQL in test: {sql}")
 
 
+_FRESH_DEFAULTS: dict[str, dict[str, Any]] = {
+    "firms": {"last_seen_at_offset": 5, "idempotency": {"records_fetched": 10, "records_skipped_duplicates": 0}},
+    "weather": {"last_seen_at_offset": 30, "idempotency": {"completed_runs_last_24h": 4}},
+    "terrain": {"last_seen_at_offset": 30, "idempotency": {"total_rows": 1}},
+    "perimeters": {"last_seen_at_offset": 60, "idempotency": {"total_rows": 5}},
+    "lfmc": {"last_seen_at_offset": 60, "idempotency": {"completed_runs_last_24h": 3, "failed_runs_last_24h": 0}},
+}
+
+_FETCH_FUNCTIONS = {
+    "firms": "api.data_status._fetch_latest_firms_status",
+    "weather": "api.data_status._fetch_latest_weather_status",
+    "terrain": "api.data_status._fetch_latest_terrain_status",
+    "perimeters": "api.data_status._fetch_latest_perimeters_status",
+    "lfmc": "api.data_status._fetch_latest_lfmc_status",
+}
+
+
+def _stub_all_sources(
+    monkeypatch,
+    now: datetime,
+    **overrides: dict[str, Any],
+) -> None:
+    """Patch all data-status fetch functions with sensible defaults, applying overrides."""
+    for source, defaults in _FRESH_DEFAULTS.items():
+        override = overrides.get(source, {})
+        offset = override.get("last_seen_at_offset", defaults["last_seen_at_offset"])
+        last_seen_at = override.get("last_seen_at", now - timedelta(minutes=offset))
+        idempotency = override.get("idempotency", defaults["idempotency"])
+        monkeypatch.setattr(
+            _FETCH_FUNCTIONS[source],
+            lambda _conn, ls=last_seen_at, idem=idempotency: {
+                "last_seen_at": ls,
+                "idempotency": idem,
+            },
+        )
+
+
 def test_build_data_status_snapshot_marks_stale_and_critical(monkeypatch):
     now = datetime(2026, 2, 11, 12, 0, tzinfo=timezone.utc)
 
-    monkeypatch.setattr(
-        "api.data_status._fetch_latest_firms_status",
-        lambda _conn: {
-            "last_seen_at": now - timedelta(minutes=5),
-            "idempotency": {"records_fetched": 10, "records_skipped_duplicates": 2},
-        },
-    )
-    monkeypatch.setattr(
-        "api.data_status._fetch_latest_weather_status",
-        lambda _conn: {
-            "last_seen_at": now - timedelta(minutes=500),
-            "idempotency": {"completed_runs_last_24h": 2},
-        },
-    )
-    monkeypatch.setattr(
-        "api.data_status._fetch_latest_terrain_status",
-        lambda _conn: {
-            "last_seen_at": now - timedelta(minutes=30),
-            "idempotency": {"total_rows": 1},
-        },
-    )
-    monkeypatch.setattr(
-        "api.data_status._fetch_latest_perimeters_status",
-        lambda _conn: {
-            "last_seen_at": None,
-            "idempotency": {"total_rows": 0},
-        },
+    _stub_all_sources(
+        monkeypatch,
+        now,
+        firms={"idempotency": {"records_fetched": 10, "records_skipped_duplicates": 2}},
+        weather={"last_seen_at_offset": 500, "idempotency": {"completed_runs_last_24h": 2}},
+        perimeters={"last_seen_at": None, "idempotency": {"total_rows": 0}},
     )
 
     snapshot = build_data_status_snapshot(now=now, engine=DummyEngine(), include_internal=True)
@@ -74,11 +91,51 @@ def test_build_data_status_snapshot_marks_stale_and_critical(monkeypatch):
     assert snapshot["sources"]["firms"]["state"] == "fresh"
     assert snapshot["sources"]["weather"]["state"] == "stale"
     assert snapshot["sources"]["perimeters"]["state"] == "missing"
+    assert snapshot["sources"]["lfmc"]["state"] == "fresh"
     assert snapshot["overall_state"] == "critical"
     assert "weather" in snapshot["critical_stale_sources"]
     assert snapshot["stale_behavior"]["mode"] == "degraded"
     assert snapshot["forecast_gate"]["can_run"] is False
     assert "weather_stale_or_missing" in snapshot["forecast_gate"]["reasons"]
+
+
+def test_lfmc_stale_when_api_unavailable(monkeypatch):
+    """LFMC reports stale when last successful run exceeds threshold."""
+    now = datetime(2026, 2, 11, 12, 0, tzinfo=timezone.utc)
+
+    _stub_all_sources(
+        monkeypatch,
+        now,
+        lfmc={
+            "last_seen_at_offset": 600,
+            "idempotency": {"completed_runs_last_24h": 0, "failed_runs_last_24h": 4},
+        },
+    )
+
+    snapshot = build_data_status_snapshot(now=now, engine=DummyEngine(), include_internal=True)
+
+    assert snapshot["sources"]["lfmc"]["state"] == "stale"
+    assert snapshot["sources"]["lfmc"]["is_stale"] is True
+    assert "lfmc" in snapshot["stale_sources"]
+
+
+def test_lfmc_missing_when_no_runs(monkeypatch):
+    """LFMC reports missing when no completed runs exist."""
+    now = datetime(2026, 2, 11, 12, 0, tzinfo=timezone.utc)
+
+    _stub_all_sources(
+        monkeypatch,
+        now,
+        lfmc={
+            "last_seen_at": None,
+            "idempotency": {"completed_runs_last_24h": 0, "failed_runs_last_24h": 0},
+        },
+    )
+
+    snapshot = build_data_status_snapshot(now=now, engine=DummyEngine(), include_internal=True)
+
+    assert snapshot["sources"]["lfmc"]["state"] == "missing"
+    assert snapshot["sources"]["lfmc"]["is_stale"] is True
 
 
 def test_fetch_latest_firms_status_prefers_watermark_acq_time():

--- a/ingest/lfmc_ecland_ingest.py
+++ b/ingest/lfmc_ecland_ingest.py
@@ -204,7 +204,7 @@ def ingest_lfmc_ecland_for_bbox(
     run_time: datetime | None = None,
     output_dir: Path | None = None,
     poll_seconds: int = 300,
-    timeout_seconds: int = 7200,
+    timeout_seconds: int = 1800,
 ) -> dict[str, Any]:
     resolved_time = (run_time or datetime.now(timezone.utc)).astimezone(timezone.utc)
     api_url = _require_api_url()
@@ -262,7 +262,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--run-time", type=str, default=None, help="ISO8601 reference time (default: current UTC hour).")
     parser.add_argument("--output-dir", type=Path, default=Path("data/fuels/lfmc_ecland"))
     parser.add_argument("--poll-seconds", type=int, default=300, help="Job polling interval in seconds.")
-    parser.add_argument("--timeout-seconds", type=int, default=7200, help="Max end-to-end job wait time.")
+    parser.add_argument("--timeout-seconds", type=int, default=1800, help="Max end-to-end job wait time (seconds).")
     return parser.parse_args()
 
 

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -9,6 +9,7 @@ import os
 import signal
 import sys
 import time
+import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -504,8 +505,14 @@ def _run_lfmc(args: argparse.Namespace) -> int:
     try:
         ingest_lfmc_ecland_for_bbox(bbox=bbox, timeout_seconds=args.lfmc_timeout_seconds)
     except Exception as exc:
+        tracking_id = uuid.uuid4().hex[:12]
         LOGGER.warning(
-            "LFMC ingest failed (timeout_seconds=%s): %s — pipeline continues",
+            "[tracking_id=%s] LFMC ingest failed (timeout_seconds=%s): %s "
+            "— skipping job, next cycle will retry. "
+            "Fuel data may be stale until successful ingest. "
+            "Mitigation: next-cycle retry (mvp_operational); "
+            "target: science_grade auto-alerting.",
+            tracking_id,
             args.lfmc_timeout_seconds,
             exc,
         )

--- a/ingest/tests/test_orchestrator.py
+++ b/ingest/tests/test_orchestrator.py
@@ -537,8 +537,12 @@ class TestFuelJobs(unittest.TestCase):
 
         self.assertEqual(1, code)
         self.assertTrue(
-            any("pipeline continues" in line for line in log_ctx.output),
-            f"Expected 'pipeline continues' in warning log, got: {log_ctx.output}",
+            any("tracking_id=" in line for line in log_ctx.output),
+            f"Expected 'tracking_id=' in warning log, got: {log_ctx.output}",
+        )
+        self.assertTrue(
+            any("next cycle will retry" in line for line in log_ctx.output),
+            f"Expected 'next cycle will retry' in warning log, got: {log_ctx.output}",
         )
 
     def test_run_lfmc_api_error_returns_one(self):


### PR DESCRIPTION
## Changes

- **Config**: Add `DATA_STALE_LFMC_MINUTES` setting (default 480 minutes) to configure LFMC staleness threshold
- **Data Status**: 
  - Add `_fetch_latest_lfmc_status()` function to track fuel moisture run metrics including completion status and failures in last 24h
  - Include LFMC in data status snapshot with fresh/stale/missing state detection
  - Track LFMC idempotency data (run IDs, providers, failure timestamps)
- **LFMC Ingest**:
  - Reduce default timeout from 7200s to 1800s (30 minutes)
  - Implement graceful error handling: failures no longer halt pipeline but log warnings with tracking IDs
- **Orchestrator**: 
  - Add tracking IDs to LFMC failures for better observability
  - Improve error messages to indicate next-cycle retry behavior and potential fuel data staleness
  - Document mitigation strategy
- **Tests**:
  - Add helper `_stub_all_sources()` to reduce test boilerplate
  - Add tests for LFMC stale/missing state detection
  - Update existing tests to verify LFMC inclusion in status snapshot