### PR TITLE
Add per-variable weather staleness tracking to data-freshness

### DIFF
--- a/api/data_status.py
+++ b/api/data_status.py
@@ -173,20 +173,31 @@ def _fetch_latest_firms_status(conn) -> dict[str, Any]:
 
 
 def _fetch_latest_weather_status(conn) -> dict[str, Any]:
+    # Single pass over completed runs: latest row fields + per-variable MAX timestamps.
     latest = conn.execute(
         text(
             """
             SELECT
-                id,
-                model,
-                run_time,
-                created_at,
-                horizon_hours,
-                step_hours
+                (array_agg(id            ORDER BY run_time DESC, id DESC))[1] AS id,
+                (array_agg(model         ORDER BY run_time DESC, id DESC))[1] AS model,
+                (array_agg(run_time      ORDER BY run_time DESC, id DESC))[1] AS run_time,
+                (array_agg(horizon_hours ORDER BY run_time DESC, id DESC))[1] AS horizon_hours,
+                (array_agg(step_hours    ORDER BY run_time DESC, id DESC))[1] AS step_hours,
+                MAX(run_time) FILTER (
+                    WHERE metadata->'variables' @> '"u10"'::jsonb
+                       OR metadata->'variables' @> '"v10"'::jsonb
+                ) AS latest_wind,
+                MAX(run_time) FILTER (
+                    WHERE metadata->'variables' @> '"t2m"'::jsonb
+                ) AS latest_temperature,
+                MAX(run_time) FILTER (
+                    WHERE metadata->'variables' @> '"rh2m"'::jsonb
+                ) AS latest_humidity,
+                MAX(run_time) FILTER (
+                    WHERE metadata->'variables' @> '"tp"'::jsonb
+                ) AS latest_precipitation
             FROM weather_runs
             WHERE status = 'completed'
-            ORDER BY run_time DESC, id DESC
-            LIMIT 1
             """
         )
     ).mappings().first()
@@ -212,16 +223,23 @@ def _fetch_latest_weather_status(conn) -> dict[str, Any]:
         else None
     )
 
+    row = latest or {}
     return {
-        "last_seen_at": _as_utc((latest or {}).get("run_time")),
+        "last_seen_at": _as_utc(row.get("run_time")),
+        "variables_last_seen": {
+            "wind": _as_utc(row.get("latest_wind")),
+            "temperature": _as_utc(row.get("latest_temperature")),
+            "humidity": _as_utc(row.get("latest_humidity")),
+            "precipitation": _as_utc(row.get("latest_precipitation")),
+        },
         "idempotency": {
-            "latest_run_id": (latest or {}).get("id"),
-            "latest_model": (latest or {}).get("model"),
-            "latest_run_time": _as_utc((latest or {}).get("run_time")).isoformat()
-            if (latest or {}).get("run_time")
+            "latest_run_id": row.get("id"),
+            "latest_model": row.get("model"),
+            "latest_run_time": _as_utc(row.get("run_time")).isoformat()
+            if row.get("run_time")
             else None,
-            "horizon_hours": (latest or {}).get("horizon_hours"),
-            "step_hours": (latest or {}).get("step_hours"),
+            "horizon_hours": row.get("horizon_hours"),
+            "step_hours": row.get("step_hours"),
             "completed_runs_last_24h": total_runs_24h,
             "unique_run_times_last_24h": unique_runs_24h,
             "duplicate_run_ratio_last_24h": round(duplicate_ratio_24h, 4)
@@ -358,6 +376,35 @@ def build_data_status_snapshot(
         perimeters = _fetch_latest_perimeters_status(conn)
         lfmc = _fetch_latest_lfmc_status(conn)
 
+    weather_status = _source_status(
+        name="weather",
+        last_seen_at=weather["last_seen_at"],
+        threshold_minutes=settings.data_stale_weather_minutes,
+        now=now_utc,
+    )
+    # Per-variable breakdown — fall back to aggregate last_seen_at when absent (e.g. in tests).
+    variables_last_seen: dict[str, Any] = weather.get("variables_last_seen") or {
+        var: weather["last_seen_at"]
+        for var in ("wind", "temperature", "humidity", "precipitation")
+    }
+    weather_variable_status = {
+        var_name: _source_status(
+            name=f"weather.{var_name}",
+            last_seen_at=last_seen_at,
+            threshold_minutes=settings.data_stale_weather_minutes,
+            now=now_utc,
+        )
+        for var_name, last_seen_at in variables_last_seen.items()
+    }
+    any_variable_stale = any(v["is_stale"] for v in weather_variable_status.values())
+    weather_status["variables"] = weather_variable_status
+    weather_status["any_variable_stale"] = any_variable_stale
+    # Escalate aggregate state when a specific variable is stale but the latest run appeared fresh.
+    if any_variable_stale:
+        weather_status["is_stale"] = True
+        if weather_status["state"] == "fresh":
+            weather_status["state"] = "stale"
+
     sources = {
         "firms": _source_status(
             name="firms",
@@ -365,12 +412,7 @@ def build_data_status_snapshot(
             threshold_minutes=settings.data_stale_firms_minutes,
             now=now_utc,
         ),
-        "weather": _source_status(
-            name="weather",
-            last_seen_at=weather["last_seen_at"],
-            threshold_minutes=settings.data_stale_weather_minutes,
-            now=now_utc,
-        ),
+        "weather": weather_status,
         "terrain": _source_status(
             name="terrain",
             last_seen_at=terrain["last_seen_at"],

--- a/api/tests/test_data_status.py
+++ b/api/tests/test_data_status.py
@@ -46,6 +46,8 @@ _FRESH_DEFAULTS: dict[str, dict[str, Any]] = {
     "lfmc": {"last_seen_at_offset": 60, "idempotency": {"completed_runs_last_24h": 3, "failed_runs_last_24h": 0}},
 }
 
+_WEATHER_VARIABLES = ("wind", "temperature", "humidity", "precipitation")
+
 _FETCH_FUNCTIONS = {
     "firms": "api.data_status._fetch_latest_firms_status",
     "weather": "api.data_status._fetch_latest_weather_status",
@@ -66,13 +68,27 @@ def _stub_all_sources(
         offset = override.get("last_seen_at_offset", defaults["last_seen_at_offset"])
         last_seen_at = override.get("last_seen_at", now - timedelta(minutes=offset))
         idempotency = override.get("idempotency", defaults["idempotency"])
-        monkeypatch.setattr(
-            _FETCH_FUNCTIONS[source],
-            lambda _conn, ls=last_seen_at, idem=idempotency: {
-                "last_seen_at": ls,
-                "idempotency": idem,
-            },
-        )
+
+        if source == "weather":
+            # Per-variable last_seen defaults: same as aggregate unless overridden.
+            default_vars = {v: last_seen_at for v in _WEATHER_VARIABLES}
+            variables_last_seen = override.get("variables_last_seen", default_vars)
+            monkeypatch.setattr(
+                _FETCH_FUNCTIONS[source],
+                lambda _conn, ls=last_seen_at, idem=idempotency, vls=variables_last_seen: {
+                    "last_seen_at": ls,
+                    "variables_last_seen": vls,
+                    "idempotency": idem,
+                },
+            )
+        else:
+            monkeypatch.setattr(
+                _FETCH_FUNCTIONS[source],
+                lambda _conn, ls=last_seen_at, idem=idempotency: {
+                    "last_seen_at": ls,
+                    "idempotency": idem,
+                },
+            )
 
 
 def test_build_data_status_snapshot_marks_stale_and_critical(monkeypatch):
@@ -159,3 +175,102 @@ def test_fetch_latest_firms_status_prefers_watermark_acq_time():
 
     assert payload["last_seen_at"] == now - timedelta(hours=6)
     assert payload["idempotency"]["latest_watermark_acq_time"] == (now - timedelta(hours=6)).isoformat()
+
+
+def test_weather_per_variable_staleness(monkeypatch):
+    """Per-variable staleness is reported independently; any stale variable flags the weather source."""
+    now = datetime(2026, 2, 11, 12, 0, tzinfo=timezone.utc)
+    threshold = 360  # DATA_STALE_WEATHER_MINUTES default
+
+    fresh_ts = now - timedelta(minutes=30)
+    stale_ts = now - timedelta(minutes=threshold + 60)
+
+    _stub_all_sources(
+        monkeypatch,
+        now,
+        weather={
+            "last_seen_at_offset": 30,  # aggregate appears fresh
+            "variables_last_seen": {
+                "wind": fresh_ts,
+                "temperature": fresh_ts,
+                "humidity": fresh_ts,
+                "precipitation": stale_ts,  # precipitation run is old
+            },
+            "idempotency": {"completed_runs_last_24h": 4},
+        },
+    )
+
+    snapshot = build_data_status_snapshot(now=now, engine=DummyEngine(), include_internal=True)
+
+    weather = snapshot["sources"]["weather"]
+
+    # Per-variable status present for all four canonical variables.
+    assert set(weather["variables"].keys()) == {"wind", "temperature", "humidity", "precipitation"}
+
+    assert weather["variables"]["wind"]["state"] == "fresh"
+    assert weather["variables"]["temperature"]["state"] == "fresh"
+    assert weather["variables"]["humidity"]["state"] == "fresh"
+    assert weather["variables"]["precipitation"]["state"] == "stale"
+    assert weather["variables"]["precipitation"]["is_stale"] is True
+
+    # Aggregate weather is flagged stale because precipitation is stale.
+    assert weather["any_variable_stale"] is True
+    assert weather["is_stale"] is True
+    assert weather["state"] == "stale"
+
+    # Overall snapshot is degraded/critical.
+    assert snapshot["overall_state"] in {"degraded", "critical"}
+
+
+def test_weather_all_variables_fresh(monkeypatch):
+    """When all variables are within threshold, weather source stays fresh."""
+    now = datetime(2026, 2, 11, 12, 0, tzinfo=timezone.utc)
+    fresh_ts = now - timedelta(minutes=30)
+
+    _stub_all_sources(
+        monkeypatch,
+        now,
+        weather={
+            "last_seen_at_offset": 30,
+            "variables_last_seen": {v: fresh_ts for v in _WEATHER_VARIABLES},
+            "idempotency": {"completed_runs_last_24h": 4},
+        },
+    )
+
+    snapshot = build_data_status_snapshot(now=now, engine=DummyEngine(), include_internal=True)
+
+    weather = snapshot["sources"]["weather"]
+    assert weather["state"] == "fresh"
+    assert weather["any_variable_stale"] is False
+    assert weather["is_stale"] is False
+    for var in _WEATHER_VARIABLES:
+        assert weather["variables"][var]["state"] == "fresh"
+
+
+def test_weather_missing_variable_flags_stale(monkeypatch):
+    """A variable with no data (None) is reported as missing and flags the weather source stale."""
+    now = datetime(2026, 2, 11, 12, 0, tzinfo=timezone.utc)
+    fresh_ts = now - timedelta(minutes=30)
+
+    _stub_all_sources(
+        monkeypatch,
+        now,
+        weather={
+            "last_seen_at_offset": 30,
+            "variables_last_seen": {
+                "wind": fresh_ts,
+                "temperature": fresh_ts,
+                "humidity": fresh_ts,
+                "precipitation": None,  # never ingested
+            },
+            "idempotency": {"completed_runs_last_24h": 4},
+        },
+    )
+
+    snapshot = build_data_status_snapshot(now=now, engine=DummyEngine(), include_internal=True)
+
+    weather = snapshot["sources"]["weather"]
+    assert weather["variables"]["precipitation"]["state"] == "missing"
+    assert weather["variables"]["precipitation"]["is_stale"] is True
+    assert weather["any_variable_stale"] is True
+    assert weather["is_stale"] is True


### PR DESCRIPTION
## Changes

- **Enhanced weather status query**: Modified `_fetch_latest_weather_status()` to track the latest `run_time` for each weather variable (wind, temperature, humidity, precipitation) independently using PostgreSQL `MAX()` with `FILTER` clauses
- **Per-variable status reporting**: Extended weather source status object with a new `variables` dict containing staleness state for each variable and an `any_variable_stale` flag
- **Escalation logic**: When any individual variable is stale but the aggregate latest run appears fresh, the weather source is escalated to stale state
- **Test coverage**: Added comprehensive tests for per-variable staleness scenarios:
  - One variable stale while others remain fresh
  - All variables fresh
  - Missing variables (null timestamps) flagged as missing/stale

## Technical Details

- Single-pass SQL query using `array_agg()` for latest metadata and per-variable `MAX(run_time)` filters
- Graceful fallback in snapshot building for backward compatibility (tests without per-variable data)
- Overall snapshot state correctly degraded when any variable is stale