### PR TITLE
Add consolidated ingest health dashboard endpoint

### DIFF
--- a/api/db_health.py
+++ b/api/db_health.py
@@ -76,6 +76,10 @@ _DEFAULT_CLEANUP_INTERVAL_MINUTES = float(
 
 DEFAULT_DASHBOARD_PATH = REPO_ROOT / "data" / "ingest" / "orchestrator_dashboard.json"
 
+# Sentinel used to distinguish "caller did not provide a pre-read dashboard" from
+# "caller already read the dashboard and got None (file absent)".
+_UNSET: object = object()
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -92,15 +96,28 @@ def _read_dashboard(dashboard_path: Path) -> dict | None:
     return None
 
 
-def _get_cleanup_status(dashboard_path: Path) -> dict:
+def read_orchestrator_dashboard(dashboard_path: Path | None = None) -> dict | None:
+    """Return parsed orchestrator dashboard JSON, or None if unavailable.
+
+    Public helper consumed by the consolidated health dashboard endpoint so it
+    can surface per-job metrics without duplicating the read logic.
+    """
+    return _read_dashboard(dashboard_path or DEFAULT_DASHBOARD_PATH)
+
+
+def _get_cleanup_status(dashboard_path: Path, *, dashboard: dict | None = _UNSET) -> dict:
     """Derive last-run timestamp and next-scheduled estimate from dashboard file.
 
     Returns a dict with numeric/string fields so monitors can scrape them directly.
     ``source`` explains the data provenance; consumers should check it when
     ``last_run_at`` is None.
+
+    Pass a pre-read ``dashboard`` dict to skip a redundant file read (e.g. when
+    the caller has already read the dashboard for other purposes).
     """
     interval_minutes = _DEFAULT_CLEANUP_INTERVAL_MINUTES
-    dashboard = _read_dashboard(dashboard_path)
+    if dashboard is _UNSET:
+        dashboard = _read_dashboard(dashboard_path)
 
     if dashboard is None:
         return {
@@ -199,6 +216,8 @@ def _query_db_sizes() -> dict:
 
 def build_db_size_snapshot(
     dashboard_path: Path | None = None,
+    *,
+    dashboard: object = _UNSET,
 ) -> dict:
     """Return per-table row counts, total DB size, and retention/cleanup status.
 
@@ -209,6 +228,10 @@ def build_db_size_snapshot(
     Args:
         dashboard_path: Path to orchestrator dashboard JSON.  Defaults to
             ``data/ingest/orchestrator_dashboard.json`` relative to repo root.
+        dashboard: Pre-parsed orchestrator dashboard dict (or ``None`` when the
+            file was already read and found to be absent).  Pass this when the
+            caller has already read the dashboard to avoid a second file read.
+            Omit to let the function read the file itself.
 
     Returns:
         Structured dict with ``as_of``, ``database``, ``tables``,
@@ -220,7 +243,7 @@ def build_db_size_snapshot(
 
     as_of = datetime.now(timezone.utc).isoformat()
     db_data = _query_db_sizes()
-    cleanup_status = _get_cleanup_status(resolved_path)
+    cleanup_status = _get_cleanup_status(resolved_path, dashboard=dashboard)
 
     return {
         "as_of": as_of,

--- a/api/routes/internal.py
+++ b/api/routes/internal.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 from api.config import settings
 from api.data_status import build_data_status_snapshot
-from api.db_health import build_db_size_snapshot
+from api.db_health import build_db_size_snapshot, read_orchestrator_dashboard
 from api.model_registry import list_active_models
 from api.terrain.features_repo import list_terrain_coverage_inventory
 from api.fires.repo import (
@@ -265,6 +265,62 @@ async def db_size_health() -> dict:
             },
             "error": str(exc),
         }
+
+
+@internal_router.get("/internal/health/dashboard")
+async def ingest_health_dashboard() -> dict:
+    """Return consolidated operational snapshot: per-job metrics, data freshness, DB size, and cleanup status.
+
+    Assembles in a single response what would otherwise require cross-referencing:
+    - ``GET /internal/health/data-freshness`` (source freshness)
+    - ``GET /internal/health/db-size`` (DB size + cleanup timing)
+    - The raw orchestrator dashboard JSON (per-job success/failure timestamps)
+
+    All section helpers are reused directly — no duplicate business logic.
+
+    Schema is additive; individual sub-endpoints remain available for targeted queries.
+    """
+    as_of = datetime.now(timezone.utc).isoformat()
+
+    # --- per-job metrics from orchestrator dashboard file ---
+    raw = read_orchestrator_dashboard()
+    jobs_section = raw.get("metrics") if raw else None
+    orchestrator_generated_at = raw.get("generated_at") if raw else None
+
+    # --- data freshness (reuse shared helper; include internal idempotency fields) ---
+    try:
+        freshness_snapshot = build_data_status_snapshot(include_internal=True)
+        freshness_section = {
+            "overall_state": freshness_snapshot.get("overall_state"),
+            "forecast_inputs_ready": freshness_snapshot.get("forecast_inputs_ready"),
+            "sources": freshness_snapshot.get("sources", {}),
+        }
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        freshness_section = {"overall_state": "unknown", "forecast_inputs_ready": False, "sources": {}, "error": str(exc)}
+
+    # --- DB size + cleanup (reuse shared helper; pass pre-read dashboard to avoid a second file read) ---
+    try:
+        db_snapshot = build_db_size_snapshot(dashboard=raw)
+        db_section = {
+            "database": db_snapshot.get("database"),
+            "tables": db_snapshot.get("tables"),
+            "retention_policy": db_snapshot.get("retention_policy"),
+        }
+        cleanup_section = db_snapshot.get("cleanup")
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        db_section = {"database": {"size_bytes": None, "size_pretty": None}, "tables": {}, "retention_policy": {}, "error": str(exc)}
+        cleanup_section = {"last_run_at": None, "last_outcome": None, "next_run_at": None, "interval_minutes": None, "source": "error"}
+
+    return {
+        "as_of": as_of,
+        "orchestrator": {
+            "generated_at": orchestrator_generated_at,
+            "jobs": jobs_section,
+        },
+        "data_freshness": freshness_section,
+        "db_size": db_section,
+        "cleanup": cleanup_section,
+    }
 
 
 @internal_router.post("/internal/denoiser/review-queue/{event_id}/resolve")

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -336,6 +336,50 @@ def test_db_size_health_null_cleanup_when_dashboard_missing(monkeypatch) -> None
     assert cleanup["source"] == "dashboard_unavailable"
 
 
+# ---------------------------------------------------------------------------
+# /internal/health/dashboard
+# ---------------------------------------------------------------------------
+
+
+def _make_consolidated_mocks(monkeypatch) -> None:
+    """Wire up all three helpers used by the consolidated dashboard endpoint."""
+    raw_dashboard = {
+        "generated_at": "2026-03-26T06:00:00+00:00",
+        "metrics": {
+            "firms": {
+                "attempts": 10, "successes": 9, "failures": 1, "retries": 0, "skipped_fresh": 0,
+                "last_exit_code": 0, "last_outcome": "success",
+                "last_started_at": "2026-03-26T05:59:00+00:00",
+                "last_finished_at": "2026-03-26T06:00:00+00:00",
+                "last_success_at": "2026-03-26T06:00:00+00:00",
+                "last_failure_at": "2026-03-25T12:00:00+00:00",
+            },
+            "cleanup": {
+                "attempts": 1, "successes": 1, "failures": 0, "retries": 0, "skipped_fresh": 0,
+                "last_exit_code": 0, "last_outcome": "success",
+                "last_started_at": "2026-03-26T05:00:00+00:00",
+                "last_finished_at": "2026-03-26T05:01:00+00:00",
+                "last_success_at": "2026-03-26T05:01:00+00:00",
+                "last_failure_at": None,
+            },
+        },
+    }
+    monkeypatch.setattr("api.routes.internal.read_orchestrator_dashboard", lambda: raw_dashboard)
+    monkeypatch.setattr(
+        "api.routes.internal.build_data_status_snapshot",
+        lambda include_internal=False: {
+            "overall_state": "healthy",
+            "forecast_inputs_ready": True,
+            "sources": {"firms": {"state": "fresh", "age_minutes": 15.0}},
+            "idempotency_dashboard": {},
+        },
+    )
+    monkeypatch.setattr(
+        "api.routes.internal.build_db_size_snapshot",
+        lambda **_: _make_db_size_snapshot(),
+    )
+
+
 def test_db_size_health_fallback_on_db_error(monkeypatch) -> None:
     """Endpoint must return a structured fallback dict, not a 500, on DB errors."""
 
@@ -351,3 +395,84 @@ def test_db_size_health_fallback_on_db_error(monkeypatch) -> None:
     assert body["database"]["size_bytes"] is None
     assert body["tables"] == {}
     assert body["cleanup"]["source"] == "error"
+
+
+def test_consolidated_dashboard_top_level_keys(monkeypatch) -> None:
+    """Response must contain all four operational sections."""
+    _make_consolidated_mocks(monkeypatch)
+    response = client.get("/internal/health/dashboard")
+    assert response.status_code == 200
+    body = response.json()
+    assert "as_of" in body
+    assert "orchestrator" in body
+    assert "data_freshness" in body
+    assert "db_size" in body
+    assert "cleanup" in body
+
+
+def test_consolidated_dashboard_orchestrator_section(monkeypatch) -> None:
+    """orchestrator section must expose generated_at and per-job metrics."""
+    _make_consolidated_mocks(monkeypatch)
+    body = client.get("/internal/health/dashboard").json()
+
+    orch = body["orchestrator"]
+    assert orch["generated_at"] == "2026-03-26T06:00:00+00:00"
+    assert "firms" in orch["jobs"]
+
+    firms = orch["jobs"]["firms"]
+    assert firms["last_success_at"] == "2026-03-26T06:00:00+00:00"
+    assert firms["last_failure_at"] == "2026-03-25T12:00:00+00:00"
+    assert firms["last_outcome"] == "success"
+
+
+def test_consolidated_dashboard_data_freshness_section(monkeypatch) -> None:
+    """data_freshness section must surface overall_state and per-source entries."""
+    _make_consolidated_mocks(monkeypatch)
+    body = client.get("/internal/health/dashboard").json()
+
+    df = body["data_freshness"]
+    assert df["overall_state"] == "healthy"
+    assert df["forecast_inputs_ready"] is True
+    assert "firms" in df["sources"]
+
+
+def test_consolidated_dashboard_db_size_section(monkeypatch) -> None:
+    """db_size section must include database sizes and per-table row counts."""
+    _make_consolidated_mocks(monkeypatch)
+    body = client.get("/internal/health/dashboard").json()
+
+    db = body["db_size"]
+    assert db["database"]["size_bytes"] == 524288000
+    assert "fire_detections" in db["tables"]
+    assert "default_retention_days" in db["retention_policy"]
+
+
+def test_consolidated_dashboard_cleanup_section(monkeypatch) -> None:
+    """cleanup section must mirror db-size cleanup fields."""
+    _make_consolidated_mocks(monkeypatch)
+    body = client.get("/internal/health/dashboard").json()
+
+    cleanup = body["cleanup"]
+    assert cleanup["last_run_at"] == "2026-03-25T06:00:00+00:00"
+    assert cleanup["last_outcome"] == "success"
+    assert cleanup["next_run_at"] == "2026-03-26T06:00:00+00:00"
+    assert cleanup["source"] == "orchestrator_dashboard"
+
+
+def test_consolidated_dashboard_no_dashboard_file(monkeypatch) -> None:
+    """When orchestrator dashboard file is absent, jobs section is None but other sections still populate."""
+    monkeypatch.setattr("api.routes.internal.read_orchestrator_dashboard", lambda: None)
+    monkeypatch.setattr(
+        "api.routes.internal.build_data_status_snapshot",
+        lambda include_internal=False: {"overall_state": "healthy", "forecast_inputs_ready": True, "sources": {}},
+    )
+    monkeypatch.setattr(
+        "api.routes.internal.build_db_size_snapshot",
+        lambda **_: _make_db_size_snapshot(),
+    )
+
+    body = client.get("/internal/health/dashboard").json()
+    assert body["orchestrator"]["generated_at"] is None
+    assert body["orchestrator"]["jobs"] is None
+    assert body["data_freshness"]["overall_state"] == "healthy"
+    assert body["db_size"]["database"]["size_bytes"] == 524288000

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -70,6 +70,8 @@ class JobMetrics:
     last_outcome: str | None = None
     last_started_at: str | None = None
     last_finished_at: str | None = None
+    last_success_at: str | None = None
+    last_failure_at: str | None = None
 
 
 class ShutdownFlag:
@@ -905,11 +907,13 @@ def _run_job_with_retries(
         if code == 0:
             metric.successes += 1
             metric.last_outcome = "success"
+            metric.last_success_at = metric.last_finished_at
             return 0
 
         if attempts > max_retries:
             metric.failures += 1
             metric.last_outcome = "failed"
+            metric.last_failure_at = metric.last_finished_at
             return 1
 
         metric.retries += 1

--- a/ingest/tests/test_orchestrator.py
+++ b/ingest/tests/test_orchestrator.py
@@ -257,6 +257,66 @@ class TestOrchestrator(unittest.TestCase):
         self.assertEqual(0, calls["count"])
 
 
+class TestJobMetricsSuccessFailureTimestamps(unittest.TestCase):
+    """last_success_at and last_failure_at must be set independently of last_finished_at."""
+
+    def test_last_success_at_set_on_success(self):
+        calls = {"count": 0}
+
+        def _ok() -> int:
+            calls["count"] += 1
+            return 0
+
+        from ingest.orchestrator import JobMetrics, _run_job_with_retries
+
+        metric = JobMetrics()
+        job = ScheduledJob(name="firms", interval_seconds=60.0, runner=_ok)
+        _run_job_with_retries(job=job, metric=metric, max_retries=0, retry_backoff_seconds=0.0, sleep_fn=lambda _: None)
+
+        self.assertEqual("success", metric.last_outcome)
+        self.assertIsNotNone(metric.last_success_at)
+        self.assertEqual(metric.last_success_at, metric.last_finished_at)
+        self.assertIsNone(metric.last_failure_at)
+
+    def test_last_failure_at_set_on_failure(self):
+        def _fail() -> int:
+            return 1
+
+        from ingest.orchestrator import JobMetrics, _run_job_with_retries
+
+        metric = JobMetrics()
+        job = ScheduledJob(name="firms", interval_seconds=60.0, runner=_fail)
+        _run_job_with_retries(job=job, metric=metric, max_retries=0, retry_backoff_seconds=0.0, sleep_fn=lambda _: None)
+
+        self.assertEqual("failed", metric.last_outcome)
+        self.assertIsNotNone(metric.last_failure_at)
+        self.assertEqual(metric.last_failure_at, metric.last_finished_at)
+        self.assertIsNone(metric.last_success_at)
+
+    def test_last_success_at_preserved_after_subsequent_failure(self):
+        """Once a job has succeeded, last_success_at must survive a later failure."""
+        call_count = {"n": 0}
+
+        def _first_ok_then_fail() -> int:
+            call_count["n"] += 1
+            return 0 if call_count["n"] == 1 else 1
+
+        from ingest.orchestrator import JobMetrics, _run_job_with_retries
+
+        metric = JobMetrics()
+        job = ScheduledJob(name="firms", interval_seconds=60.0, runner=_first_ok_then_fail)
+
+        # First run: success
+        _run_job_with_retries(job=job, metric=metric, max_retries=0, retry_backoff_seconds=0.0, sleep_fn=lambda _: None)
+        saved_success_at = metric.last_success_at
+        self.assertIsNotNone(saved_success_at)
+
+        # Second run: failure
+        _run_job_with_retries(job=job, metric=metric, max_retries=0, retry_backoff_seconds=0.0, sleep_fn=lambda _: None)
+        self.assertEqual(saved_success_at, metric.last_success_at)
+        self.assertIsNotNone(metric.last_failure_at)
+
+
 class TestDriftJob(unittest.TestCase):
     def test_denoiser_drift_in_job_order(self):
         self.assertIn(JOB_DENOISER_DRIFT, JOB_ORDER)


### PR DESCRIPTION
## Summary
Adds a new `/internal/health/dashboard` endpoint that consolidates operational metrics from multiple sources into a single response, eliminating the need to cross-reference separate health checks.

## Changes

### API Changes
- **New endpoint**: `GET /internal/health/dashboard` returns unified health snapshot with:
  - Per-job metrics from orchestrator dashboard (success/failure timestamps, outcomes)
  - Data freshness status (source state, forecast readiness)
  - Database size and per-table row counts
  - Cleanup status (timing, next run estimate)

- **New helper**: `read_orchestrator_dashboard()` in `db_health.py` exposes dashboard parsing for reuse

### DB Health Improvements
- Enhanced `_get_cleanup_status()` and `build_db_size_snapshot()` to accept optional pre-read dashboard dict, avoiding redundant file reads when callers have already parsed the dashboard
- Added sentinel value `_UNSET` to distinguish "not provided" from "file absent" cases

### Ingest Metrics Tracking
- Extended `JobMetrics` with `last_success_at` and `last_failure_at` timestamps
- Updated `_run_job_with_retries()` to populate these fields independently from `last_finished_at`
- Ensures success timestamps survive subsequent failures for accurate health tracking

### Test Coverage
- 5 new tests for consolidated dashboard endpoint (top-level keys, each section, missing dashboard scenario)
- 3 new tests for success/failure timestamp tracking in job metrics
- All tests use mocked dependencies and existing snapshot builders