### PR TITLE
Wire LFMC into spread features with DFMC fallback

### DIFF
--- a/ml/spread/runtime_contract.py
+++ b/ml/spread/runtime_contract.py
@@ -16,7 +16,7 @@ Usage at inference time:
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -25,6 +25,29 @@ import numpy as np
 # ---------------------------------------------------------------------------
 # Canonical channel definitions
 # ---------------------------------------------------------------------------
+
+#: Per-channel metadata recorded in the runtime contract for documentation and
+#: downstream tooling.  The ``lfmc`` entry captures the fallback strategy so that
+#: calibration pipelines know when to distrust live-fuel moisture observations.
+CANONICAL_CHANNEL_METADATA: dict[str, dict[str, str]] = {
+    "lfmc": {
+        "description": (
+            "Live fuel moisture content from ECMWF ecLand reanalysis (kg/kg or %). "
+            "Sourced from fuel_moisture_runs (provider=ecmwf_ecland_lfmc). "
+            "When unavailable or stale (per DATA_STALE_LFMC_MINUTES), the DFMC "
+            "heuristic is substituted and lfmc_fallback_used=True is set on SpreadInputs."
+        ),
+        "fallback_channel": "dfmc",
+        "fallback_flag": "lfmc_fallback_used",
+    },
+    "dfmc": {
+        "description": (
+            "Dead fuel moisture content (10-hr, fraction in [0, 0.40]) computed from "
+            "the Nelson (1984) NFDRS equilibrium formula using T2m and RH2m. "
+            "Always present; NaN only when weather is unavailable."
+        ),
+    },
+}
 
 #: Authoritative channel list and order for v2/v3 spatial spread models.
 #: This tuple is imported by both hindcast_dataset.py (training) and
@@ -66,18 +89,32 @@ CANONICAL_CHANNELS_BY_MODEL: dict[str, tuple[str, ...]] = {
 
 @dataclass(frozen=True)
 class SpreadRuntimeContract:
-    """Immutable specification of the feature tensor a model was trained on."""
+    """Immutable specification of the feature tensor a model was trained on.
+
+    ``channel_metadata`` is optional documentation attached at write time.
+    It does not affect channel validation — only ``channels``, ``dtype``, and
+    ``layout`` are load-bearing.  The ``lfmc`` entry describes the fallback
+    strategy used when live-fuel observations are unavailable at inference time.
+    """
 
     channels: tuple[str, ...]
     dtype: str = "float32"
     layout: str = "CHW"  # channel-first spatial tensor
+    channel_metadata: dict[str, dict[str, str]] = field(default_factory=dict)
 
     @property
     def n_channels(self) -> int:
         return len(self.channels)
 
     def to_dict(self) -> dict[str, Any]:
-        return {"channels": list(self.channels), "dtype": self.dtype, "layout": self.layout}
+        d: dict[str, Any] = {
+            "channels": list(self.channels),
+            "dtype": self.dtype,
+            "layout": self.layout,
+        }
+        if self.channel_metadata:
+            d["channel_metadata"] = self.channel_metadata
+        return d
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "SpreadRuntimeContract":
@@ -85,6 +122,7 @@ class SpreadRuntimeContract:
             channels=tuple(d["channels"]),
             dtype=d.get("dtype", "float32"),
             layout=d.get("layout", "CHW"),
+            channel_metadata=d.get("channel_metadata", {}),
         )
 
 

--- a/ml/spread_features.py
+++ b/ml/spread_features.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -40,6 +41,9 @@ class SpreadInputs:
     # Metadata flags for error handling and observability
     weather_fallback_used: bool = False
     terrain_fallback_used: bool = False
+    # True when real LFMC data was unavailable/stale and the DFMC heuristic was
+    # substituted for the lfmc channel.  Propagate to forecasts for calibration.
+    lfmc_fallback_used: bool = False
     # Fire state snapshots at prior time windows.
     # fire_history_t6h: detections from [ref_time - 12h, ref_time - 6h]
     # fire_history_t12h: detections from [ref_time - 18h, ref_time - 12h]
@@ -325,6 +329,8 @@ def _load_weather_cube(
         )
         # Attach equilibrium DFMC derived from T/RH.
         ds_final = _add_dfmc_to_weather(ds_final)
+        # Attach LFMC from ecLand (or DFMC fallback if unavailable/stale).
+        ds_final, _ = _add_lfmc_to_weather(ds_final, window, ref_time, bbox)
         # Mark as not using fallback when successfully loaded
         ds_final.attrs["weather_fallback_used"] = False
         ds_final.attrs["weather_run_id"] = run.get("id")
@@ -401,6 +407,212 @@ def _add_dfmc_to_weather(ds: xr.Dataset) -> xr.Dataset:
     return ds
 
 
+# ---------------------------------------------------------------------------
+# LFMC loading
+# ---------------------------------------------------------------------------
+
+#: Provider tag that identifies ECMWF ecLand LFMC runs in fuel_moisture_runs.
+#: Must match ``LFMC_PROVIDER`` in ``ingest/lfmc_ecland_ingest.py`` — the ingest
+#: module is not imported here because it calls ``logging.basicConfig`` at import time.
+_LFMC_PROVIDER = "ecmwf_ecland_lfmc"
+
+#: Environment variable that mirrors the API config staleness threshold.
+#: "Unavailable" for the spread model includes stale/out-of-coverage cases
+#: per the same rules used by the data-freshness API (C2 stale signaling).
+_LFMC_STALE_MINUTES_ENV = "DATA_STALE_LFMC_MINUTES"
+_LFMC_STALE_MINUTES_DEFAULT = 480  # 8 hours, matches api.config default
+
+
+def _get_lfmc_stale_minutes() -> int:
+    raw = os.getenv(_LFMC_STALE_MINUTES_ENV, "").strip()
+    try:
+        return max(1, int(raw))
+    except (ValueError, TypeError):
+        return _LFMC_STALE_MINUTES_DEFAULT
+
+
+def _get_latest_lfmc_run(
+    ref_time: datetime,
+    bbox: tuple[float, float, float, float],
+    *,
+    stale_minutes: int | None = None,
+) -> dict | None:
+    """Find the most recent fresh LFMC run covering the AOI at or before ref_time.
+
+    A run is considered stale (and therefore equivalent to unavailable) when its
+    run_time is older than ``stale_minutes`` before ``ref_time``.  This aligns with
+    the C2 data-freshness signal defined by ``DATA_STALE_LFMC_MINUTES``.
+    """
+    if stale_minutes is None:
+        stale_minutes = _get_lfmc_stale_minutes()
+    min_lon, min_lat, max_lon, max_lat = bbox
+    earliest_valid = ref_time - timedelta(minutes=stale_minutes)
+    stmt = sa.text(
+        """
+        SELECT id, storage_path, run_time
+        FROM fuel_moisture_runs
+        WHERE status = 'completed'
+          AND provider = :provider
+          AND run_time >= :earliest_valid
+          AND run_time <= :ref_time
+          AND COALESCE(bbox_min_lon, -180.0) <= :min_lon
+          AND COALESCE(bbox_max_lon,  180.0) >= :max_lon
+          AND COALESCE(bbox_min_lat,  -90.0) <= :min_lat
+          AND COALESCE(bbox_max_lat,   90.0) >= :max_lat
+        ORDER BY run_time DESC, id DESC
+        LIMIT 1
+        """
+    )
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            stmt,
+            {
+                "provider": _LFMC_PROVIDER,
+                "earliest_valid": earliest_valid,
+                "ref_time": ref_time,
+                "min_lon": min_lon,
+                "max_lon": max_lon,
+                "min_lat": min_lat,
+                "max_lat": max_lat,
+            },
+        ).mappings().first()
+    return dict(row) if row else None
+
+
+def _load_lfmc_raster_for_window(path: Path, window: GridWindow) -> np.ndarray | None:
+    """Load and align an LFMC raster to the analysis window.
+
+    Returns a float32 array of shape (lat, lon) aligned to the window grid,
+    or None when loading or alignment fails.
+    """
+    try:
+        with xr.open_dataset(path) as ds:
+            if "lfmc" not in ds.data_vars:
+                LOGGER.warning("LFMC file %s missing 'lfmc' variable.", path)
+                return None
+            da = ds["lfmc"]
+            # Squeeze time dimension — LFMC is a single-snapshot product.
+            if "time" in da.dims:
+                da = da.isel(time=0)
+            # Detect coordinate names (ingest may write lat/lon or latitude/longitude).
+            lat_coord = "lat" if "lat" in da.coords else "latitude"
+            lon_coord = "lon" if "lon" in da.coords else "longitude"
+            if lat_coord not in da.coords or lon_coord not in da.coords:
+                LOGGER.warning("LFMC file %s missing spatial coords.", path)
+                return None
+            try:
+                aligned = da.sel(
+                    {lat_coord: window.lat, lon_coord: window.lon},
+                    method="nearest",
+                )
+            except Exception:
+                LOGGER.warning("Cannot align LFMC raster to analysis window from %s.", path)
+                return None
+            arr = np.asarray(aligned.values, dtype=np.float32)
+            if arr.shape != (len(window.lat), len(window.lon)):
+                LOGGER.warning(
+                    "LFMC raster shape %s does not match window (%d, %d).",
+                    arr.shape,
+                    len(window.lat),
+                    len(window.lon),
+                )
+                return None
+            return arr
+    except Exception:
+        LOGGER.exception("Failed to load LFMC raster from %s.", path)
+        return None
+
+
+def _add_lfmc_to_weather(
+    ds: xr.Dataset,
+    window: GridWindow,
+    ref_time: datetime,
+    bbox: tuple[float, float, float, float],
+) -> tuple[xr.Dataset, bool]:
+    """Attach the ``lfmc`` variable to the weather cube.
+
+    Attempts to load real LFMC from the most recent completed ECMWF ecLand run.
+    When real LFMC is unavailable or stale (per ``DATA_STALE_LFMC_MINUTES``), falls
+    back to the DFMC heuristic already present in the cube and sets the
+    ``lfmc_fallback_used`` attribute.
+
+    Returns
+    -------
+    (updated_ds, lfmc_fallback_used)
+        ``lfmc_fallback_used`` is True whenever the DFMC heuristic was substituted
+        for real LFMC.  Callers should propagate this flag for downstream calibration
+        and debugging.
+    """
+    stale_minutes = _get_lfmc_stale_minutes()
+    run = None
+    try:
+        run = _get_latest_lfmc_run(ref_time, bbox, stale_minutes=stale_minutes)
+    except Exception:
+        LOGGER.exception(
+            "Error querying LFMC runs for ref_time=%s bbox=%s; will use fallback.",
+            ref_time,
+            bbox,
+        )
+
+    lfmc_arr: np.ndarray | None = None
+
+    if run is not None:
+        raw_path = str(run["storage_path"])
+        path = _resolve_storage_path(raw_path)
+        # Attempt to load; _load_lfmc_raster_for_window handles file-not-found gracefully.
+        lfmc_arr = _load_lfmc_raster_for_window(path, window)
+        if lfmc_arr is None:
+            LOGGER.warning(
+                "LFMC run %s raster unavailable at %s (raw=%s); using fallback.",
+                run["id"],
+                path,
+                raw_path,
+            )
+    else:
+        LOGGER.warning(
+            "No fresh LFMC run found for ref_time=%s bbox=%s "
+            "(stale_threshold=%d min); using DFMC heuristic as fallback.",
+            ref_time,
+            bbox,
+            stale_minutes,
+        )
+
+    if lfmc_arr is not None:
+        # Broadcast the 2-D spatial snapshot over the time dimension.
+        nt = ds.sizes.get("time", 1)
+        lfmc_3d = np.broadcast_to(
+            lfmc_arr[np.newaxis, :, :], (nt, len(window.lat), len(window.lon))
+        ).astype(np.float32)
+        ref_var = "u10" if "u10" in ds else next(iter(ds.data_vars), None)
+        dims = ds[ref_var].dims if ref_var else ("time", "lat", "lon")
+        ds = ds.assign(lfmc=(dims, lfmc_3d))
+        ds.attrs["lfmc_fallback_used"] = False
+        return ds, False
+
+    # Fallback: substitute DFMC as a proxy for the lfmc channel.
+    # DFMC (dead fuel moisture from T/RH) is the best real-data-derived moisture
+    # signal available when live-fuel observations are absent.
+    if "dfmc" in ds.data_vars:
+        ds = ds.assign(lfmc=(ds["dfmc"].dims, ds["dfmc"].values.copy()))
+        LOGGER.warning(
+            "lfmc_fallback_used=True for ref_time=%s: DFMC heuristic substituted. "
+            "Downstream calibration should account for this.",
+            ref_time,
+        )
+    else:
+        # Defensive: DFMC absent (e.g. fallback weather cube with NaN T/RH).
+        shape = tuple(ds.sizes[d] for d in ("time", "lat", "lon") if d in ds.dims)
+        fill = np.full(shape, np.nan, dtype=np.float32) if shape else np.array([], dtype=np.float32)
+        ds = ds.assign(lfmc=(list(ds.dims), fill))
+        LOGGER.warning(
+            "lfmc_fallback_used=True for ref_time=%s: both LFMC and DFMC unavailable; "
+            "lfmc channel set to NaN.",
+            ref_time,
+        )
+    ds.attrs["lfmc_fallback_used"] = True
+    return ds, True
+
+
 def _create_fallback_weather(
     window: GridWindow,
     ref_time: datetime,
@@ -427,8 +639,9 @@ def _create_fallback_weather(
             "rh2m": (("time", "lat", "lon"), np.full(shape, np.nan, dtype=np.float32)),
             # Zero precipitation assumed in fallback (conservative: no rain).
             "precip_24h": (("time", "lat", "lon"), np.zeros(shape, dtype=np.float32)),
-            # DFMC is NaN in fallback — callers should treat as unknown moisture.
+            # DFMC and LFMC are NaN in fallback — callers should treat as unknown moisture.
             "dfmc": (("time", "lat", "lon"), np.full(shape, np.nan, dtype=np.float32)),
+            "lfmc": (("time", "lat", "lon"), np.full(shape, np.nan, dtype=np.float32)),
         },
         coords=coords
     )
@@ -676,6 +889,9 @@ def build_spread_inputs(
             getattr(weather, "attrs", {}).get("weather_fallback_reason", "unknown"),
         )
 
+    # Check if LFMC fallback was used (set by _add_lfmc_to_weather via weather cube attrs).
+    lfmc_fallback_used = bool(getattr(weather, "attrs", {}).get("lfmc_fallback_used", True))
+
     return SpreadInputs(
         grid=grid,
         window=window,
@@ -686,6 +902,7 @@ def build_spread_inputs(
         horizons_hours=horizons_hours,
         weather_fallback_used=weather_fallback_used,
         terrain_fallback_used=terrain_fallback_used,
+        lfmc_fallback_used=lfmc_fallback_used,
         fire_history_t6h=fire_history_t6h,
         fire_history_t12h=fire_history_t12h,
     )

--- a/ml/tests/test_spread_features.py
+++ b/ml/tests/test_spread_features.py
@@ -14,7 +14,9 @@ from api.terrain.window import TerrainWindow
 from ml.spread_features import (
     SpreadInputs,
     assert_grid_alignment,
+    _add_lfmc_to_weather,
     _create_fallback_weather,
+    _load_lfmc_raster_for_window,
     _load_weather_cube,
     build_spread_inputs,
 )
@@ -419,3 +421,159 @@ def test_build_spread_inputs_hard_stop_on_misaligned_cell_size(mock_get_window, 
             bbox=(5.0, 35.0, 5.25, 35.25),
             forecast_reference_time=datetime(2025, 1, 1, tzinfo=timezone.utc),
         )
+
+
+# ---------------------------------------------------------------------------
+# LFMC loading and fallback tests
+# ---------------------------------------------------------------------------
+
+def _make_weather_with_dfmc(window: GridWindow, horizons: list[int] = None) -> xr.Dataset:
+    """Helper: weather cube that includes DFMC but not LFMC."""
+    if horizons is None:
+        horizons = [6, 12]
+    nt, ny, nx = len(horizons), len(window.lat), len(window.lon)
+    shape = (nt, ny, nx)
+    t2m = np.full(shape, 300.0, dtype=np.float32)
+    rh2m = np.full(shape, 40.0, dtype=np.float32)
+    # Compute expected DFMC via the NFDRS piecewise formula (for assertions).
+    # Use a simple value: at 300K / 40% RH dfmc should be non-zero.
+    dfmc = np.full(shape, 0.10, dtype=np.float32)
+    return xr.Dataset(
+        data_vars={
+            "u10": (("time", "lat", "lon"), np.zeros(shape, dtype=np.float32)),
+            "v10": (("time", "lat", "lon"), np.zeros(shape, dtype=np.float32)),
+            "t2m": (("time", "lat", "lon"), t2m),
+            "rh2m": (("time", "lat", "lon"), rh2m),
+            "precip_24h": (("time", "lat", "lon"), np.zeros(shape, dtype=np.float32)),
+            "dfmc": (("time", "lat", "lon"), dfmc),
+        },
+        coords={
+            "time": [np.datetime64(f"2026-03-01T{h:02d}:00:00", "ns") for h in range(nt)],
+            "lat": window.lat,
+            "lon": window.lon,
+        },
+    )
+
+
+def test_add_lfmc_to_weather_uses_real_lfmc_when_available(mock_window, tmp_path):
+    """When a fresh LFMC file is found, _add_lfmc_to_weather should attach real values."""
+    ref_time = datetime(2026, 3, 1, 0, 0, tzinfo=timezone.utc)
+    bbox = (5.0, 35.0, 5.2, 35.2)
+    ds = _make_weather_with_dfmc(mock_window)
+
+    # Write a synthetic LFMC NetCDF with distinct values (e.g. 0.75).
+    lfmc_vals = np.full((len(mock_window.lat), len(mock_window.lon)), 0.75, dtype=np.float32)
+    lfmc_ds = xr.Dataset(
+        {"lfmc": (("lat", "lon"), lfmc_vals)},
+        coords={"lat": mock_window.lat, "lon": mock_window.lon},
+    )
+    nc_path = tmp_path / "lfmc.nc"
+    lfmc_ds.to_netcdf(nc_path)
+
+    fake_run = {"id": 42, "storage_path": str(nc_path), "run_time": ref_time}
+
+    with patch("ml.spread_features._get_latest_lfmc_run", return_value=fake_run):
+        out_ds, fallback_used = _add_lfmc_to_weather(ds, mock_window, ref_time, bbox)
+
+    assert not fallback_used
+    assert "lfmc" in out_ds.data_vars
+    assert float(out_ds["lfmc"].values[0, 0, 0]) == pytest.approx(0.75)
+    assert out_ds.attrs.get("lfmc_fallback_used") is False
+
+
+def test_add_lfmc_to_weather_falls_back_to_dfmc_when_no_run(mock_window):
+    """When no LFMC run is found, the DFMC values should be copied into the lfmc channel."""
+    ref_time = datetime(2026, 3, 1, 0, 0, tzinfo=timezone.utc)
+    bbox = (5.0, 35.0, 5.2, 35.2)
+    ds = _make_weather_with_dfmc(mock_window)
+
+    with patch("ml.spread_features._get_latest_lfmc_run", return_value=None):
+        out_ds, fallback_used = _add_lfmc_to_weather(ds, mock_window, ref_time, bbox)
+
+    assert fallback_used
+    assert "lfmc" in out_ds.data_vars
+    # LFMC channel should mirror DFMC when fallback is used.
+    assert np.allclose(out_ds["lfmc"].values, out_ds["dfmc"].values)
+    assert out_ds.attrs.get("lfmc_fallback_used") is True
+
+
+def test_add_lfmc_to_weather_falls_back_when_file_missing(mock_window, tmp_path):
+    """When the LFMC run file is absent, fall back to DFMC and flag it."""
+    ref_time = datetime(2026, 3, 1, 0, 0, tzinfo=timezone.utc)
+    bbox = (5.0, 35.0, 5.2, 35.2)
+    ds = _make_weather_with_dfmc(mock_window)
+
+    missing_path = tmp_path / "nonexistent_lfmc.nc"
+    fake_run = {"id": 99, "storage_path": str(missing_path), "run_time": ref_time}
+
+    with patch("ml.spread_features._get_latest_lfmc_run", return_value=fake_run):
+        out_ds, fallback_used = _add_lfmc_to_weather(ds, mock_window, ref_time, bbox)
+
+    assert fallback_used
+    assert "lfmc" in out_ds.data_vars
+    assert out_ds.attrs.get("lfmc_fallback_used") is True
+
+
+def test_load_lfmc_raster_for_window_aligns_to_window(mock_window, tmp_path):
+    """_load_lfmc_raster_for_window should align and return a (lat, lon) float32 array."""
+    # Write LFMC NetCDF on a slightly wider grid to test alignment.
+    wider_lat = np.linspace(34.0, 36.5, 50)
+    wider_lon = np.linspace(4.0, 6.5, 50)
+    data = np.random.default_rng(0).random((len(wider_lat), len(wider_lon))).astype(np.float32)
+    ds = xr.Dataset(
+        {"lfmc": (("lat", "lon"), data)},
+        coords={"lat": wider_lat, "lon": wider_lon},
+    )
+    nc_path = tmp_path / "lfmc_wide.nc"
+    ds.to_netcdf(nc_path)
+
+    result = _load_lfmc_raster_for_window(nc_path, mock_window)
+
+    assert result is not None
+    assert result.shape == (len(mock_window.lat), len(mock_window.lon))
+    assert result.dtype == np.float32
+
+
+def test_load_lfmc_raster_returns_none_on_missing_variable(mock_window, tmp_path):
+    """Return None when the NetCDF doesn't contain the 'lfmc' variable."""
+    ds = xr.Dataset(
+        {"other_var": (("lat", "lon"), np.zeros((10, 10), dtype=np.float32))},
+        coords={"lat": mock_window.lat, "lon": mock_window.lon},
+    )
+    nc_path = tmp_path / "bad_lfmc.nc"
+    ds.to_netcdf(nc_path)
+
+    result = _load_lfmc_raster_for_window(nc_path, mock_window)
+    assert result is None
+
+
+def test_fallback_weather_includes_lfmc_nan(mock_window):
+    """_create_fallback_weather must include an lfmc NaN field."""
+    ref_time = datetime(2026, 3, 1, 0, 0, tzinfo=timezone.utc)
+    ds = _create_fallback_weather(mock_window, ref_time, [6, 12])
+
+    assert "lfmc" in ds.data_vars
+    assert np.isnan(ds["lfmc"].values).all()
+
+
+@patch("ml.spread_features._get_latest_weather_run")
+@patch("ml.spread_features._get_latest_lfmc_run")
+@patch("ml.spread_features.get_fire_cells_heatmap")
+def test_build_spread_inputs_propagates_lfmc_fallback_flag(
+    mock_fires, mock_lfmc_run, mock_weather_run, mock_grid, mock_window
+):
+    """SpreadInputs.lfmc_fallback_used must reflect LFMC unavailability."""
+    mock_weather_run.return_value = None  # triggers weather fallback (all-NaN)
+    mock_lfmc_run.return_value = None     # no LFMC run → fallback
+    mock_fires.return_value = FireHeatmapWindow(mock_grid, mock_window, np.zeros((10, 10)))
+
+    with (
+        patch("ml.spread_features.get_region_grid_spec", return_value=mock_grid),
+        patch("ml.spread_features.get_grid_window_for_bbox", return_value=mock_window),
+        patch("ml.spread_features.load_terrain_window") as mock_terrain,
+    ):
+        mock_terrain.return_value = TerrainWindow(mock_window, np.zeros((10, 10)), np.zeros((10, 10)))
+        ref_time = datetime(2026, 3, 1, 0, 0, tzinfo=timezone.utc)
+        inputs = build_spread_inputs("region", (5.055, 35.055, 5.145, 35.145), ref_time)
+
+    assert inputs.lfmc_fallback_used is True

--- a/ml/train_spread_v2.py
+++ b/ml/train_spread_v2.py
@@ -24,7 +24,7 @@ from ml.spread.hindcast_dataset import (
     V2_TENSOR_CHANNELS,
     build_hindcast_tensor_dataset,
 )
-from ml.spread.runtime_contract import SpreadRuntimeContract, write_contract
+from ml.spread.runtime_contract import CANONICAL_CHANNEL_METADATA, SpreadRuntimeContract, write_contract
 
 LOGGER = logging.getLogger("train_spread_v2")
 
@@ -434,7 +434,13 @@ def train_spread_v2(config: dict[str, Any]) -> Path:
         json.dumps(feature_schema, indent=2) + "\n",
         encoding="utf-8",
     )
-    write_contract(run_dir / "runtime_contract.json", SpreadRuntimeContract(channels=tuple(channel_names)))
+    write_contract(
+        run_dir / "runtime_contract.json",
+        SpreadRuntimeContract(
+            channels=tuple(channel_names),
+            channel_metadata=CANONICAL_CHANNEL_METADATA,
+        ),
+    )
     (run_dir / "config_resolved.yaml").write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
 
     metadata = {


### PR DESCRIPTION
## Summary

Integrates live fuel moisture content (LFMC) from ECMWF ecLand into the spread model's weather features, with automatic fallback to the DFMC heuristic when LFMC is unavailable or stale.

## Changes

### Core Features
- **LFMC Loading**: Added `_get_latest_lfmc_run()` and `_load_lfmc_raster_for_window()` to query and load LFMC data from `fuel_moisture_runs` table
- **Staleness Handling**: Implemented configurable staleness threshold via `DATA_STALE_LFMC_MINUTES` environment variable (defaults to 480 minutes/8 hours)
- **Automatic Fallback**: `_add_lfmc_to_weather()` automatically substitutes DFMC when real LFMC is unavailable, stale, or unloadable
- **Fallback Flag**: Added `lfmc_fallback_used` field to `SpreadInputs` to track when the heuristic was substituted for calibration and debugging

### Metadata & Documentation
- Added `CANONICAL_CHANNEL_METADATA` dict to document LFMC and DFMC channels with fallback strategy
- Updated `SpreadRuntimeContract` to carry optional channel metadata for downstream tooling
- Enhanced contract serialization to preserve metadata in `to_dict()` / `from_dict()`

### Testing
- Added comprehensive test suite for LFMC loading, alignment, and fallback behavior
- Tests cover: real LFMC success, missing runs, missing files, alignment, missing variables
- Verified fallback weather includes NaN LFMC field
- Confirmed `SpreadInputs.lfmc_fallback_used` is properly propagated

### Robustness
- Graceful error handling with detailed logging throughout LFMC pipeline
- Defensive fallback when both LFMC and DFMC unavailable (NaN channel)
- Fallback weather cube updated to include LFMC (as NaN)