### PR TITLE
feat(api): expose fuel data freshness in data-status endpoint

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -150,6 +150,9 @@ class AppSettings(BaseSettings):
     data_stale_lfmc_minutes: int = Field(
         default=480, validation_alias="DATA_STALE_LFMC_MINUTES"
     )
+    data_stale_lulc_minutes: int = Field(
+        default=10080, validation_alias="DATA_STALE_LULC_MINUTES"
+    )
     data_status_critical_sources: str = Field(
         default="firms,weather",
         validation_alias="DATA_STATUS_CRITICAL_SOURCES",

--- a/api/data_status.py
+++ b/api/data_status.py
@@ -288,7 +288,7 @@ def _fetch_latest_lfmc_status(conn) -> dict[str, Any]:
     latest = conn.execute(
         text(
             """
-            SELECT id, run_time, status, provider, created_at
+            SELECT id, run_time, status, provider, created_at, coverage_fraction
             FROM fuel_moisture_runs
             WHERE status = 'completed'
             ORDER BY run_time DESC, id DESC
@@ -314,9 +314,12 @@ def _fetch_latest_lfmc_status(conn) -> dict[str, Any]:
     counts_row = counts or {}
     run_time = _as_utc(latest_row.get("run_time"))
     last_failure = _as_utc(counts_row.get("last_failure_at"))
+    raw_cf = latest_row.get("coverage_fraction")
+    coverage_fraction: float | None = round(float(raw_cf), 4) if raw_cf is not None else None
 
     return {
         "last_seen_at": run_time,
+        "coverage_fraction": coverage_fraction,
         "idempotency": {
             "latest_run_id": latest_row.get("id"),
             "latest_provider": latest_row.get("provider"),
@@ -324,6 +327,51 @@ def _fetch_latest_lfmc_status(conn) -> dict[str, Any]:
             "completed_runs_last_24h": int(counts_row.get("completed_runs") or 0),
             "failed_runs_last_24h": int(counts_row.get("failed_runs") or 0),
             "last_failure_at": last_failure.isoformat() if last_failure else None,
+        },
+    }
+
+
+def _fetch_latest_lulc_status(conn) -> dict[str, Any]:
+    """Return LULC freshness derived from fire_detections.
+
+    ``last_seen_at`` is the MAX ``created_at`` of any fire detection that has
+    been LULC-classified (``lulc_version IS NOT NULL``).  It is a lower-bound
+    on when the LULC backfill last ran — the actual ingest time is always at
+    least as recent.
+
+    ``coverage_ratio_last_7d`` is the fraction of recent detections that carry
+    a ``lulc_version`` label, useful for spotting partial-backfill gaps.
+
+    ``latest_version`` is the ``lulc_version`` of the most recently classified
+    row (by ``created_at``), not ``MAX(lulc_version)``, because the version
+    string (e.g. ``v200_2021``) does not sort lexicographically by recency.
+    """
+    row = conn.execute(
+        text(
+            """
+            SELECT
+                MAX(created_at) FILTER (WHERE lulc_version IS NOT NULL) AS last_lulc_at,
+                (array_agg(lulc_version ORDER BY created_at DESC)
+                    FILTER (WHERE lulc_version IS NOT NULL))[1]           AS latest_version,
+                COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '7 days'
+                                   AND lulc_version IS NOT NULL)          AS classified_last_7d,
+                COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '7 days') AS total_last_7d
+            FROM fire_detections
+            """
+        )
+    ).mappings().first()
+
+    r = row or {}
+    classified = int(r.get("classified_last_7d") or 0)
+    total = int(r.get("total_last_7d") or 0)
+
+    return {
+        "last_seen_at": _as_utc(r.get("last_lulc_at")),
+        "idempotency": {
+            "latest_version": r.get("latest_version"),
+            "classified_last_7d": classified,
+            "total_last_7d": total,
+            "coverage_ratio_last_7d": round(float(classified) / float(total), 4) if total > 0 else None,
         },
     }
 
@@ -375,6 +423,7 @@ def build_data_status_snapshot(
         terrain = _fetch_latest_terrain_status(conn)
         perimeters = _fetch_latest_perimeters_status(conn)
         lfmc = _fetch_latest_lfmc_status(conn)
+        lulc = _fetch_latest_lulc_status(conn)
 
     weather_status = _source_status(
         name="weather",
@@ -429,6 +478,12 @@ def build_data_status_snapshot(
             name="lfmc",
             last_seen_at=lfmc["last_seen_at"],
             threshold_minutes=settings.data_stale_lfmc_minutes,
+            now=now_utc,
+        ),
+        "lulc": _source_status(
+            name="lulc",
+            last_seen_at=lulc["last_seen_at"],
+            threshold_minutes=settings.data_stale_lulc_minutes,
             now=now_utc,
         ),
     }
@@ -508,6 +563,15 @@ def build_data_status_snapshot(
         "forecast_gate": forecast_gate,
         "stale_behavior": stale_behavior,
         "sources": sources,
+        # Fuel data summary — named fields operators need at a glance.
+        # lfmc_coverage_fraction: fraction of bounding-box grid cells with
+        # valid (non-NaN) LFMC values from the most recent completed run.
+        # Derived from fuel_moisture_runs.coverage_fraction (stored at ingest).
+        "fuel": {
+            "lfmc_last_updated": lfmc["last_seen_at"].isoformat() if lfmc["last_seen_at"] else None,
+            "lulc_last_updated": lulc["last_seen_at"].isoformat() if lulc["last_seen_at"] else None,
+            "lfmc_coverage_fraction": lfmc.get("coverage_fraction"),
+        },
     }
     if include_internal:
         snapshot["idempotency_dashboard"] = {
@@ -516,5 +580,6 @@ def build_data_status_snapshot(
             "terrain": terrain["idempotency"],
             "perimeters": perimeters["idempotency"],
             "lfmc": lfmc["idempotency"],
+            "lulc": lulc["idempotency"],
         }
     return snapshot

--- a/api/migrations/versions/20260326_add_lfmc_coverage_fraction.py
+++ b/api/migrations/versions/20260326_add_lfmc_coverage_fraction.py
@@ -1,0 +1,34 @@
+"""Add coverage_fraction to fuel_moisture_runs
+
+Fraction of grid cells (in the bounding box) with valid (non-NaN) LFMC
+values, computed from the downloaded NetCDF at ingest time.  Stored so the
+freshness endpoint can surface lfmc_coverage_fraction without reloading
+raster files at query time.
+
+Revision ID: 20260326_add_lfmc_coverage_fraction
+Revises: 20260325_add_lulc_version
+Create Date: 2026-03-26 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260326_add_lfmc_coverage_fraction"
+down_revision: Union[str, Sequence[str], None] = "20260325_add_lulc_version"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add coverage_fraction (0.0–1.0) column to fuel_moisture_runs."""
+    op.add_column(
+        "fuel_moisture_runs",
+        sa.Column("coverage_fraction", sa.Float(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("fuel_moisture_runs", "coverage_fraction")

--- a/api/migrations/versions/20260326_add_lulc_freshness_index.py
+++ b/api/migrations/versions/20260326_add_lulc_freshness_index.py
@@ -1,0 +1,39 @@
+"""Add partial index on fire_detections for LULC freshness queries
+
+The data-freshness endpoint scans fire_detections for:
+  - MAX(created_at) WHERE lulc_version IS NOT NULL (global)
+  - COUNT(*) WHERE created_at >= NOW() - INTERVAL '7 days' (with/without lulc_version)
+
+Without an index, both require a full sequential scan on a potentially large
+table. The partial composite index below covers both aggregates in one pass:
+  - Filters to classified rows only (partial: lulc_version IS NOT NULL)
+  - Supports created_at range queries via DESC ordering
+  - Includes lulc_version to avoid a heap fetch for the version value
+
+Revision ID: 20260326_add_lulc_freshness_index
+Revises: 20260326_add_lfmc_coverage_fraction
+Create Date: 2026-03-26 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260326_add_lulc_freshness_index"
+down_revision: Union[str, Sequence[str], None] = "20260326_add_lfmc_coverage_fraction"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_fire_detections_lulc_created_at",
+        "fire_detections",
+        ["created_at", "lulc_version"],
+        postgresql_where="lulc_version IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_fire_detections_lulc_created_at", table_name="fire_detections")

--- a/api/tests/test_data_status.py
+++ b/api/tests/test_data_status.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from api.data_status import _fetch_latest_firms_status, build_data_status_snapshot
+from api.data_status import _fetch_latest_firms_status, _fetch_latest_lulc_status, build_data_status_snapshot
 
 
 class DummyEngine:
@@ -44,6 +44,7 @@ _FRESH_DEFAULTS: dict[str, dict[str, Any]] = {
     "terrain": {"last_seen_at_offset": 30, "idempotency": {"total_rows": 1}},
     "perimeters": {"last_seen_at_offset": 60, "idempotency": {"total_rows": 5}},
     "lfmc": {"last_seen_at_offset": 60, "idempotency": {"completed_runs_last_24h": 3, "failed_runs_last_24h": 0}},
+    "lulc": {"last_seen_at_offset": 120, "idempotency": {"latest_version": "v200_2021", "classified_last_7d": 500, "total_last_7d": 500}},
 }
 
 _WEATHER_VARIABLES = ("wind", "temperature", "humidity", "precipitation")
@@ -54,6 +55,7 @@ _FETCH_FUNCTIONS = {
     "terrain": "api.data_status._fetch_latest_terrain_status",
     "perimeters": "api.data_status._fetch_latest_perimeters_status",
     "lfmc": "api.data_status._fetch_latest_lfmc_status",
+    "lulc": "api.data_status._fetch_latest_lulc_status",
 }
 
 
@@ -78,6 +80,16 @@ def _stub_all_sources(
                 lambda _conn, ls=last_seen_at, idem=idempotency, vls=variables_last_seen: {
                     "last_seen_at": ls,
                     "variables_last_seen": vls,
+                    "idempotency": idem,
+                },
+            )
+        elif source == "lfmc":
+            coverage_fraction = override.get("coverage_fraction", 0.92)
+            monkeypatch.setattr(
+                _FETCH_FUNCTIONS[source],
+                lambda _conn, ls=last_seen_at, idem=idempotency, cf=coverage_fraction: {
+                    "last_seen_at": ls,
+                    "coverage_fraction": cf,
                     "idempotency": idem,
                 },
             )
@@ -274,3 +286,107 @@ def test_weather_missing_variable_flags_stale(monkeypatch):
     assert weather["variables"]["precipitation"]["is_stale"] is True
     assert weather["any_variable_stale"] is True
     assert weather["is_stale"] is True
+
+
+def test_fuel_section_present_with_named_fields(monkeypatch):
+    """Snapshot always includes a 'fuel' section with the three operator fields."""
+    now = datetime(2026, 3, 26, 12, 0, tzinfo=timezone.utc)
+
+    lfmc_ts = now - timedelta(minutes=60)
+    lulc_ts = now - timedelta(hours=48)
+
+    _stub_all_sources(
+        monkeypatch,
+        now,
+        lfmc={"last_seen_at": lfmc_ts, "coverage_fraction": 0.87, "idempotency": {"completed_runs_last_24h": 2, "failed_runs_last_24h": 0}},
+        lulc={"last_seen_at": lulc_ts, "idempotency": {"latest_version": "v200_2021", "classified_last_7d": 400, "total_last_7d": 400}},
+    )
+
+    snapshot = build_data_status_snapshot(now=now, engine=DummyEngine())
+
+    fuel = snapshot["fuel"]
+    assert fuel["lfmc_last_updated"] == lfmc_ts.isoformat()
+    assert fuel["lulc_last_updated"] == lulc_ts.isoformat()
+    assert fuel["lfmc_coverage_fraction"] == 0.87
+
+
+def test_fuel_section_none_when_no_data(monkeypatch):
+    """fuel fields are None when LFMC/LULC have never run."""
+    now = datetime(2026, 3, 26, 12, 0, tzinfo=timezone.utc)
+
+    _stub_all_sources(
+        monkeypatch,
+        now,
+        lfmc={"last_seen_at": None, "coverage_fraction": None, "idempotency": {"completed_runs_last_24h": 0, "failed_runs_last_24h": 0}},
+        lulc={"last_seen_at": None, "idempotency": {"latest_version": None, "classified_last_7d": 0, "total_last_7d": 0}},
+    )
+
+    snapshot = build_data_status_snapshot(now=now, engine=DummyEngine())
+
+    fuel = snapshot["fuel"]
+    assert fuel["lfmc_last_updated"] is None
+    assert fuel["lulc_last_updated"] is None
+    assert fuel["lfmc_coverage_fraction"] is None
+
+
+def test_lulc_source_in_snapshot(monkeypatch):
+    """LULC appears as a source with freshness state."""
+    now = datetime(2026, 3, 26, 12, 0, tzinfo=timezone.utc)
+
+    _stub_all_sources(monkeypatch, now)
+
+    snapshot = build_data_status_snapshot(now=now, engine=DummyEngine(), include_internal=True)
+
+    assert "lulc" in snapshot["sources"]
+    assert snapshot["sources"]["lulc"]["state"] == "fresh"
+    assert "lulc" in snapshot["idempotency_dashboard"]
+
+
+def test_lulc_stale_when_old(monkeypatch):
+    """LULC reports stale when backfill exceeds the weekly threshold."""
+    now = datetime(2026, 3, 26, 12, 0, tzinfo=timezone.utc)
+
+    _stub_all_sources(
+        monkeypatch,
+        now,
+        lulc={
+            "last_seen_at_offset": 15000,  # > 10080 min (7 days)
+            "idempotency": {"latest_version": "v200_2021", "classified_last_7d": 0, "total_last_7d": 100},
+        },
+    )
+
+    snapshot = build_data_status_snapshot(now=now, engine=DummyEngine(), include_internal=True)
+
+    assert snapshot["sources"]["lulc"]["state"] == "stale"
+    assert snapshot["sources"]["lulc"]["is_stale"] is True
+    assert "lulc" in snapshot["stale_sources"]
+
+
+class _DummyLulcConn:
+    """Minimal conn stub for _fetch_latest_lulc_status unit test (single merged query)."""
+
+    def __init__(self, row):
+        self._row = row
+
+    def execute(self, stmt):
+        return _DummyMappingsResult(self._row)
+
+
+def test_fetch_latest_lulc_status_returns_expected_shape():
+    now = datetime(2026, 3, 26, 12, 0, tzinfo=timezone.utc)
+    conn = _DummyLulcConn(
+        row={
+            "last_lulc_at": now - timedelta(hours=12),
+            "latest_version": "v200_2021",
+            "classified_last_7d": 300,
+            "total_last_7d": 350,
+        },
+    )
+
+    result = _fetch_latest_lulc_status(conn)
+
+    assert result["last_seen_at"] == now - timedelta(hours=12)
+    assert result["idempotency"]["latest_version"] == "v200_2021"
+    assert result["idempotency"]["classified_last_7d"] == 300
+    assert result["idempotency"]["total_last_7d"] == 350
+    assert result["idempotency"]["coverage_ratio_last_7d"] == round(300 / 350, 4)

--- a/ingest/lfmc_ecland_ingest.py
+++ b/ingest/lfmc_ecland_ingest.py
@@ -111,11 +111,17 @@ def _create_run_record(
     return int(row["id"])
 
 
-def _finalize_run_record(*, run_id: int, status: str, storage_path: str) -> None:
+def _finalize_run_record(
+    *,
+    run_id: int,
+    status: str,
+    storage_path: str,
+    coverage_fraction: float | None = None,
+) -> None:
     stmt = sa.text(
         """
         UPDATE fuel_moisture_runs
-        SET status = :status, storage_path = :storage_path
+        SET status = :status, storage_path = :storage_path, coverage_fraction = :coverage_fraction
         WHERE id = :run_id
         """
     )
@@ -126,6 +132,7 @@ def _finalize_run_record(*, run_id: int, status: str, storage_path: str) -> None
                 "run_id": int(run_id),
                 "status": str(status),
                 "storage_path": str(storage_path),
+                "coverage_fraction": coverage_fraction,
             },
         )
 
@@ -214,6 +221,7 @@ def ingest_lfmc_ecland_for_bbox(
     out_name = f"lfmc_ecland_{resolved_time:%Y%m%dT%HZ}_bbox_{bbox[0]:.4f}_{bbox[1]:.4f}_{bbox[2]:.4f}_{bbox[3]:.4f}.nc"
     out_path = out_root / out_name
     run_id = _create_run_record(run_time=resolved_time, bbox=bbox, storage_path=f"pending://{out_name}")
+    coverage_fraction: float | None = None
 
     try:
         with httpx.Client(timeout=120.0) as client:
@@ -231,11 +239,20 @@ def ingest_lfmc_ecland_for_bbox(
         try:
             if "lfmc" not in ds.data_vars:
                 raise RuntimeError("Downloaded LFMC file does not contain variable 'lfmc'.")
+            arr = ds["lfmc"]
+            total = int(arr.size)
+            valid = int(arr.notnull().sum())
+            coverage_fraction = float(valid) / float(total) if total > 0 else None
         finally:
             ds.close()
-        _finalize_run_record(run_id=run_id, status="completed", storage_path=str(out_path))
+        _finalize_run_record(
+            run_id=run_id,
+            status="completed",
+            storage_path=str(out_path),
+            coverage_fraction=coverage_fraction,
+        )
     except Exception:
-        _finalize_run_record(run_id=run_id, status="failed", storage_path=str(out_path))
+        _finalize_run_record(run_id=run_id, status="failed", storage_path=str(out_path), coverage_fraction=None)
         raise
 
     result = {


### PR DESCRIPTION
## Summary
Expose LFMC and LULC freshness metrics in the data-status endpoint to help operators monitor fuel data quality at a glance.

## Changes

### API Changes
- Add `fuel` section to data-status snapshot with three operator-facing fields:
  - `lfmc_last_updated`: timestamp of most recent completed LFMC run
  - `lulc_last_updated`: timestamp of most recent LULC-classified fire detection
  - `lfmc_coverage_fraction`: fraction of valid (non-NaN) LFMC grid cells

- Add LULC as a tracked data source with freshness state (fresh/stale based on 7-day threshold)
- Add `data_stale_lulc_minutes` config (default 10080 = 7 days)

### Database Migrations
- Add `coverage_fraction` column to `fuel_moisture_runs` table (stores 0.0–1.0 fraction at ingest time)
- Add partial index on `fire_detections(created_at DESC, lulc_version)` where `lulc_version IS NOT NULL` for efficient LULC freshness queries

### LFMC Ingest
- Calculate coverage fraction from NetCDF array at ingest time (valid cells / total cells)
- Store coverage fraction in `fuel_moisture_runs` record

### Tests
- Add comprehensive test coverage for fuel section presence, None-handling, and LULC source stale detection
- Add unit test for `_fetch_latest_lulc_status()` query shape