### PR TITLE
fix(api): wire Cache-Control headers to /fires alias + Sprint 2 E2E verification

### DIFF
--- a/api/routes/fires.py
+++ b/api/routes/fires.py
@@ -87,7 +87,7 @@ def _list_detections(
     return {"count": len(detections), "detections": detections}
 
 
-@fires_router.get("", dependencies=[Depends(RateLimiter(times=30, seconds=60))])
+@fires_router.get("", dependencies=[Depends(RateLimiter(times=30, seconds=60)), Depends(cache_60)])
 async def get_fires(
     min_lon: float = Query(..., description="Minimum longitude (west boundary)"),
     min_lat: float = Query(..., description="Minimum latitude (south boundary)"),

--- a/api/tests/test_fires_endpoint.py
+++ b/api/tests/test_fires_endpoint.py
@@ -299,6 +299,42 @@ def test_get_fronts_endpoint_passthrough_geom_provenance(monkeypatch):
     assert front["authoritative_perimeter_id"] == 12345
 
 
+def test_detections_cache_control_header(monkeypatch):
+    """Verify /fires/detections sets Cache-Control: max-age=60 (E4)."""
+    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
+    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+
+    response = client.get(
+        "/fires/detections",
+        params={
+            "min_lon": 20.0, "min_lat": 40.0, "max_lon": 22.0, "max_lat": 43.0,
+            "start_time": "2025-01-01T00:00:00Z",
+            "end_time": "2025-01-02T00:00:00Z",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("cache-control") == "max-age=60"
+
+
+def test_fires_alias_cache_control_header(monkeypatch):
+    """Verify /fires alias also sets Cache-Control: max-age=60 (E4)."""
+    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
+    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+
+    response = client.get(
+        "/fires",
+        params={
+            "min_lon": 20.0, "min_lat": 40.0, "max_lon": 22.0, "max_lat": 43.0,
+            "start_time": "2025-01-01T00:00:00Z",
+            "end_time": "2025-01-02T00:00:00Z",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("cache-control") == "max-age=60"
+
+
 def test_get_reverse_geocode_endpoint(monkeypatch):
     """Test that /fires/reverse-geocode delegates to reverse_geocode_point."""
     mock_reverse = MagicMock(


### PR DESCRIPTION
## Summary

- Sprint 2 end-to-end verification sweep across all 10 checklist items
- **One gap found and fixed (E4):** the `/fires` alias route was missing `Depends(cache_60)`, so it never returned `Cache-Control: max-age=60` unlike its canonical sibling `/fires/detections`
- Added two tests asserting the header is present on both endpoints

## What was verified (all passing)

| Item | Feature | Result |
|------|---------|--------|
| B1+B2 | Precipitation channel (`precip_24h`) in weather cube + runtime contract | ✅ wired |
| C4 | LFMC loading with DFMC fallback + `lfmc_fallback_used` flag | ✅ wired |
| A2 | `JOB_CLEANUP` in orchestrator, `db_cleanup.cleanup()` importable | ✅ wired |
| A3 | Archive TTL (3d) vs NRT TTL (14d) differentiated in `_cleanup_fire_detections()` | ✅ wired |
| A5 | `/internal/health/db-size` returns per-table rows + cleanup timestamp | ✅ wired |
| B4 | Per-variable weather staleness in `/internal/health/data-freshness` | ✅ wired |
| C1 | `lfmc` + `lulc` in orchestrator `JOB_ORDER`, `--lfmc-timeout-seconds` arg | ✅ wired |
| D1 | Terrain fallback with `terrain_fallback_used: true` in `SpreadInputs` | ✅ wired |
| E1 | Watermark corruption → WARNING log + NULL reset | ✅ wired |
| E4 | `Cache-Control: max-age=60` on `/fires/detections` | ✅ **fixed** |

## Test plan

- [x] `api/tests/test_fires_endpoint.py::test_detections_cache_control_header` — asserts header on `/fires/detections`
- [x] `api/tests/test_fires_endpoint.py::test_fires_alias_cache_control_header` — asserts header on `/fires` alias
- [x] 221 Python tests pass, 23 UI tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)