### PR TITLE
fix(api): move Gemini API key from URL param to header

### DIFF
--- a/api/routes/assistant.py
+++ b/api/routes/assistant.py
@@ -33,11 +33,14 @@ async def proxy_chat(body: dict) -> dict:
     url = (
         f"{settings.gemini_api_base_url}/models/"
         f"{settings.gemini_model}:generateContent"
-        f"?key={settings.gemini_api_key}"
     )
 
     async with httpx.AsyncClient(timeout=60.0) as client:
-        resp = await client.post(url, json=body)
+        resp = await client.post(
+            url,
+            json=body,
+            headers={"x-goog-api-key": settings.gemini_api_key},
+        )
 
     if not resp.is_success:
         raise HTTPException(status_code=resp.status_code, detail=resp.text)


### PR DESCRIPTION
## Changes

- Remove Gemini API key from URL query parameter
- Pass API key via `x-goog-api-key` request header instead
- Improves security by keeping sensitive credentials out of URLs

## Details

Moved the API key from the URL construction to the request headers when making calls to the Gemini API. This prevents the key from being exposed in logs, browser history, or other URL-tracking mechanisms.