### PR TITLE
Add REST endpoints for model promotion and rollback

### DIFF
--- a/api/model_registry.py
+++ b/api/model_registry.py
@@ -379,6 +379,47 @@ def resolve_active_model(family: str, *, engine: Engine | None = None) -> dict[s
     return payload
 
 
+def validate_gate_report(metrics_json: dict[str, Any] | None) -> tuple[bool, str]:
+    """Validate that a model's gate report passes before promotion.
+
+    Gate report is expected at ``metrics_json["gate_report"]`` with a ``"pass"`` boolean.
+    Returns ``(is_valid, reason)`` — reason is empty string on success.
+
+    Shared between the API and CLI promotion code paths.
+    """
+    if not metrics_json:
+        return False, "No metrics_json found on model"
+
+    gate_report = metrics_json.get("gate_report")
+    if gate_report is None:
+        return False, "No gate_report in metrics_json"
+
+    if not isinstance(gate_report, dict):
+        return False, "gate_report must be a JSON object"
+
+    if not gate_report.get("pass"):
+        reason = gate_report.get("reason") or gate_report.get("failure_reason") or "gate_report.pass is false"
+        return False, str(reason)
+
+    return True, ""
+
+
+def validate_model_gate(family: str, model_id: str, *, engine: Engine | None = None) -> None:
+    """Assert that a model exists and its gate report passes promotion criteria.
+
+    Raises ``ValueError`` on any failure — invalid family, missing model, or
+    gate report not passing.  Shared pre-condition for API and CLI promotion flows.
+    """
+    family_norm = _normalize_family(family)
+    db = engine or get_engine()
+    row = _get_registry_row(family=family_norm, model_id=model_id, engine=db)
+    if row is None:
+        raise ValueError(f"Model not found for family={family_norm}: {model_id}")
+    is_valid, reason = validate_gate_report(row.get("metrics_json"))
+    if not is_valid:
+        raise ValueError(f"Gate report validation failed: {reason}")
+
+
 def list_active_models(*, engine: Engine | None = None) -> dict[str, dict[str, Any]]:
     """Return active promoted models keyed by family."""
     db = engine or get_engine()

--- a/api/routes/internal.py
+++ b/api/routes/internal.py
@@ -1,12 +1,18 @@
 from datetime import datetime, timezone
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from api.config import settings
 from api.data_status import build_data_status_snapshot
 from api.db_health import build_db_size_snapshot, read_orchestrator_dashboard
-from api.model_registry import list_active_models
+from api.model_registry import (
+    list_active_models,
+    promote_model,
+    resolve_active_model,
+    rollback_model,
+    validate_model_gate,
+)
 from api.terrain.features_repo import list_terrain_coverage_inventory
 from api.fires.repo import (
     get_latest_denoiser_gate_report,
@@ -23,6 +29,17 @@ internal_router = APIRouter(tags=["internal"])
 class DenoiserReviewResolveRequest(BaseModel):
     resolved_by: str = "system"
     resolved_notes: str | None = None
+
+
+class PromoteModelRequest(BaseModel):
+    model_id: str
+    promoted_by: str | None = None
+    notes: str | None = None
+
+
+class RollbackModelRequest(BaseModel):
+    promoted_by: str | None = None
+    notes: str | None = None
 
 
 @internal_router.get("/health")
@@ -169,6 +186,62 @@ async def active_models() -> dict:
         return {"as_of": as_of, "models": {}, "error": str(exc)}
 
     return {"as_of": as_of, "models": models}
+
+
+@internal_router.get("/internal/models/{family}/active")
+async def family_active_model(family: str) -> dict:
+    """Return currently promoted model for a specific family."""
+    as_of = datetime.now(timezone.utc).isoformat()
+    try:
+        active = resolve_active_model(family)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        return {"as_of": as_of, "model": None, "error": str(exc)}
+    return {"as_of": as_of, "model": active}
+
+
+@internal_router.post("/internal/models/{family}/promote")
+async def promote_family_model(family: str, request: PromoteModelRequest) -> dict:
+    """Promote a registered model to active champion after gate report validation.
+
+    Returns 422 if the family is invalid, the model does not exist, or the
+    model's ``metrics_json.gate_report.pass`` is not ``true``.
+    """
+    as_of = datetime.now(timezone.utc).isoformat()
+    try:
+        validate_model_gate(family, request.model_id)
+        active = promote_model(
+            family=family,
+            model_id=request.model_id,
+            promoted_by=request.promoted_by,
+            notes=request.notes,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    return {"as_of": as_of, "action": "promote", "active": active}
+
+
+@internal_router.post("/internal/models/{family}/rollback")
+async def rollback_family_model(family: str, request: RollbackModelRequest) -> dict:
+    """Rollback to the previously promoted model for a family.
+
+    Returns 422 if the family is invalid or no rollback target is recorded.
+    Rollback bypasses gate report validation — it restores a previously
+    gate-approved model.
+    """
+    as_of = datetime.now(timezone.utc).isoformat()
+    try:
+        active = rollback_model(
+            family=family,
+            promoted_by=request.promoted_by,
+            notes=request.notes,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    return {"as_of": as_of, "action": "rollback", "active": active}
 
 
 @internal_router.get("/internal/denoiser/gates/latest")

--- a/api/tests/test_model_registry_routes.py
+++ b/api/tests/test_model_registry_routes.py
@@ -1,0 +1,284 @@
+"""Tests for model registry REST endpoints.
+
+Covers:
+  GET  /internal/models/{family}/active
+  POST /internal/models/{family}/promote
+  POST /internal/models/{family}/rollback
+"""
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.model_registry import validate_gate_report, validate_model_gate
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# validate_gate_report unit tests (shared validation logic)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_gate_report_passes_on_true() -> None:
+    ok, reason = validate_gate_report({"gate_report": {"pass": True}})
+    assert ok is True
+    assert reason == ""
+
+
+def test_validate_gate_report_fails_on_false_with_reason() -> None:
+    ok, reason = validate_gate_report({"gate_report": {"pass": False, "reason": "accuracy too low"}})
+    assert ok is False
+    assert "accuracy too low" in reason
+
+
+def test_validate_gate_report_fails_on_false_no_reason() -> None:
+    ok, reason = validate_gate_report({"gate_report": {"pass": False}})
+    assert ok is False
+    assert reason  # some non-empty reason
+
+
+def test_validate_gate_report_fails_on_missing_gate_report() -> None:
+    ok, reason = validate_gate_report({"some": "data"})
+    assert ok is False
+    assert "gate_report" in reason
+
+
+def test_validate_gate_report_fails_on_none_metrics() -> None:
+    ok, reason = validate_gate_report(None)
+    assert ok is False
+    assert reason
+
+
+def test_validate_gate_report_fails_on_empty_metrics() -> None:
+    ok, reason = validate_gate_report({})
+    assert ok is False
+
+
+def test_validate_gate_report_fails_on_non_dict_gate_report() -> None:
+    ok, reason = validate_gate_report({"gate_report": "yes"})
+    assert ok is False
+    assert "JSON object" in reason
+
+
+def test_validate_gate_report_uses_failure_reason_field() -> None:
+    ok, reason = validate_gate_report({"gate_report": {"pass": False, "failure_reason": "f1 too low"}})
+    assert ok is False
+    assert "f1 too low" in reason
+
+
+# ---------------------------------------------------------------------------
+# GET /internal/models/{family}/active
+# ---------------------------------------------------------------------------
+
+
+def test_active_model_returns_promoted_model(monkeypatch) -> None:
+    expected = {
+        "model_id": "spread-run-123",
+        "family": "spread",
+        "artifact_uri": "models/spread/run_123",
+        "metrics_json": {"gate_report": {"pass": True}},
+        "status": "promoted",
+    }
+    monkeypatch.setattr("api.routes.internal.resolve_active_model", lambda family, **_: expected)
+
+    response = client.get("/internal/models/spread/active")
+    assert response.status_code == 200
+    body = response.json()
+    assert "as_of" in body
+    assert body["model"] == expected
+
+
+def test_active_model_returns_none_when_no_promotion(monkeypatch) -> None:
+    monkeypatch.setattr("api.routes.internal.resolve_active_model", lambda family, **_: None)
+
+    response = client.get("/internal/models/spread/active")
+    assert response.status_code == 200
+    assert response.json()["model"] is None
+
+
+def test_active_model_denoiser_family(monkeypatch) -> None:
+    expected = {"model_id": "denoiser-run-1", "family": "denoiser", "status": "promoted"}
+    monkeypatch.setattr("api.routes.internal.resolve_active_model", lambda family, **_: expected)
+
+    response = client.get("/internal/models/denoiser/active")
+    assert response.status_code == 200
+    assert response.json()["model"]["family"] == "denoiser"
+
+
+def test_active_model_invalid_family_returns_422() -> None:
+    response = client.get("/internal/models/unknown_family/active")
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# validate_model_gate unit tests (public pre-promotion gate check)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_model_gate_raises_on_invalid_family() -> None:
+    try:
+        validate_model_gate("badFamily", "some-model")
+        assert False, "expected ValueError"
+    except ValueError as exc:
+        assert "Unsupported model family" in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# POST /internal/models/{family}/promote
+# ---------------------------------------------------------------------------
+
+
+def test_promote_returns_200_on_valid_gate_report(monkeypatch) -> None:
+    promoted = {"model_id": "spread-run-123", "family": "spread", "status": "promoted"}
+    monkeypatch.setattr("api.routes.internal.validate_model_gate", lambda family, model_id, **_: None)
+    monkeypatch.setattr("api.routes.internal.promote_model", lambda **_: promoted)
+
+    response = client.post(
+        "/internal/models/spread/promote",
+        json={"model_id": "spread-run-123", "promoted_by": "operator", "notes": "prod release"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["action"] == "promote"
+    assert body["active"] == promoted
+    assert "as_of" in body
+
+
+def test_promote_returns_422_on_failed_gate_report(monkeypatch) -> None:
+    def _gate_fail(family, model_id, **_):
+        raise ValueError("Gate report validation failed: accuracy too low")
+
+    monkeypatch.setattr("api.routes.internal.validate_model_gate", _gate_fail)
+
+    response = client.post(
+        "/internal/models/spread/promote",
+        json={"model_id": "spread-run-123"},
+    )
+    assert response.status_code == 422
+    body = response.json()
+    assert "Gate report validation failed" in body["message"]
+    assert "accuracy too low" in body["message"]
+
+
+def test_promote_returns_422_on_missing_gate_report(monkeypatch) -> None:
+    def _gate_fail(family, model_id, **_):
+        raise ValueError("Gate report validation failed: No gate_report in metrics_json")
+
+    monkeypatch.setattr("api.routes.internal.validate_model_gate", _gate_fail)
+
+    response = client.post(
+        "/internal/models/spread/promote",
+        json={"model_id": "spread-run-123"},
+    )
+    assert response.status_code == 422
+    assert "gate_report" in response.json()["message"]
+
+
+def test_promote_returns_422_when_model_not_found(monkeypatch) -> None:
+    def _gate_fail(family, model_id, **_):
+        raise ValueError(f"Model not found for family={family}: {model_id}")
+
+    monkeypatch.setattr("api.routes.internal.validate_model_gate", _gate_fail)
+
+    response = client.post(
+        "/internal/models/spread/promote",
+        json={"model_id": "nonexistent-model"},
+    )
+    assert response.status_code == 422
+    assert "not found" in response.json()["message"]
+
+
+def test_promote_invalid_family_returns_422() -> None:
+    response = client.post(
+        "/internal/models/badFamily/promote",
+        json={"model_id": "some-model"},
+    )
+    assert response.status_code == 422
+    assert "Unsupported model family" in response.json()["message"]
+
+
+def test_promote_works_for_denoiser_family(monkeypatch) -> None:
+    promoted = {"model_id": "denoiser-run-1", "family": "denoiser", "status": "promoted"}
+    monkeypatch.setattr("api.routes.internal.validate_model_gate", lambda family, model_id, **_: None)
+    monkeypatch.setattr("api.routes.internal.promote_model", lambda **_: promoted)
+
+    response = client.post(
+        "/internal/models/denoiser/promote",
+        json={"model_id": "denoiser-run-1"},
+    )
+    assert response.status_code == 200
+    assert response.json()["active"]["family"] == "denoiser"
+
+
+def test_promote_missing_model_id_returns_422() -> None:
+    response = client.post("/internal/models/spread/promote", json={})
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /internal/models/{family}/rollback
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_returns_200_and_previous_model(monkeypatch) -> None:
+    previous = {"model_id": "spread-run-100", "family": "spread", "status": "promoted"}
+    monkeypatch.setattr("api.routes.internal.rollback_model", lambda **_: previous)
+
+    response = client.post(
+        "/internal/models/spread/rollback",
+        json={"promoted_by": "operator", "notes": "bad metrics"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["action"] == "rollback"
+    assert body["active"] == previous
+    assert "as_of" in body
+
+
+def test_rollback_returns_422_when_no_rollback_target(monkeypatch) -> None:
+    def _no_rollback(**kwargs):
+        raise ValueError("No rollback target recorded for family=spread")
+
+    monkeypatch.setattr("api.routes.internal.rollback_model", _no_rollback)
+
+    response = client.post("/internal/models/spread/rollback", json={})
+    assert response.status_code == 422
+    assert "No rollback target" in response.json()["message"]
+
+
+def test_rollback_returns_422_when_no_promotion_exists(monkeypatch) -> None:
+    def _no_promotion(**kwargs):
+        raise ValueError("No promotion exists for family=spread")
+
+    monkeypatch.setattr("api.routes.internal.rollback_model", _no_promotion)
+
+    response = client.post("/internal/models/spread/rollback", json={})
+    assert response.status_code == 422
+
+
+def test_rollback_works_for_denoiser_family(monkeypatch) -> None:
+    previous = {"model_id": "denoiser-run-0", "family": "denoiser", "status": "promoted"}
+    monkeypatch.setattr("api.routes.internal.rollback_model", lambda **_: previous)
+
+    response = client.post("/internal/models/denoiser/rollback", json={})
+    assert response.status_code == 200
+    assert response.json()["active"]["family"] == "denoiser"
+
+
+def test_rollback_accepts_empty_body(monkeypatch) -> None:
+    """Rollback body is fully optional."""
+    previous = {"model_id": "spread-run-0", "family": "spread", "status": "promoted"}
+    monkeypatch.setattr("api.routes.internal.rollback_model", lambda **_: previous)
+
+    response = client.post("/internal/models/spread/rollback", json={})
+    assert response.status_code == 200
+
+
+def test_rollback_invalid_family_returns_422(monkeypatch) -> None:
+    def _bad_family(**kwargs):
+        raise ValueError("Unsupported model family: badFamily")
+
+    monkeypatch.setattr("api.routes.internal.rollback_model", _bad_family)
+
+    response = client.post("/internal/models/badFamily/rollback", json={})
+    assert response.status_code == 422

--- a/scripts/model_registry.py
+++ b/scripts/model_registry.py
@@ -19,6 +19,7 @@ from api.model_registry import (  # noqa: E402
     register_model,
     rollback_model,
     update_model_metrics_json,
+    validate_model_gate,
 )
 
 
@@ -128,6 +129,11 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.command == "promote":
         promoted_by = args.by or os.getenv("USER") or os.getenv("USERNAME")
+        try:
+            validate_model_gate(args.family, args.model_id)
+        except ValueError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            raise SystemExit(1)
         active = promote_model(
             family=args.family,
             model_id=args.model_id,


### PR DESCRIPTION
## Changes

Adds three new REST endpoints for model registry operations with gate validation:

- `GET /internal/models/{family}/active` — Retrieve the currently promoted model for a family
- `POST /internal/models/{family}/promote` — Promote a registered model after validating its gate report passes
- `POST /internal/models/{family}/rollback` — Rollback to the previously promoted model

## Implementation Details

### New validation functions in `model_registry.py`:
- `validate_gate_report()` — Validates that `metrics_json.gate_report.pass == true`
- `validate_model_gate()` — Asserts model exists and gate report passes (shared between API and CLI)

### New request/response models:
- `PromoteModelRequest` — model_id, promoted_by, notes
- `RollbackModelRequest` — promoted_by, notes

Both endpoints return `422` status with detailed error messages on validation failures (invalid family, missing model, gate report not passing).

### CLI integration:
Updates `scripts/model_registry.py` to use `validate_model_gate()` before promotion, ensuring consistency between API and CLI code paths.

### Comprehensive test coverage:
284 lines of tests covering happy paths, error cases, and edge cases for all new endpoints and validation logic.