### PR TITLE
feat: add iframe embedding support for earth-tools.org

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,17 @@ POSTGRES_DB=wildfire
 # GEMINI_API_BASE_URL=https://generativelanguage.googleapis.com/v1beta
 
 # =============================================================================
+# Iframe Embedding / Security Headers
+# =============================================================================
+# CSP frame-ancestors: space-separated list of origins allowed to embed this app.
+# "'self'" allows same-origin framing; "'none'" blocks all framing.
+# FRAME_ANCESTORS='self' https://earth-tools.org
+
+# Comma-separated list of origins the UI will accept postMessage events from.
+# Defaults to https://earth-tools.org when unset.
+# VITE_EMBED_ALLOW_ORIGINS=https://earth-tools.org
+
+# =============================================================================
 # Optional: FIRMS Ingest Settings
 # =============================================================================
 # FIRMS_SOURCES=VIIRS_SNPP_NRT,VIIRS_NOAA20_NRT

--- a/api/config.py
+++ b/api/config.py
@@ -121,6 +121,13 @@ class AppSettings(BaseSettings):
         validation_alias="CORS_ALLOW_ORIGINS",
     )
 
+    # CSP frame-ancestors: space-separated list of origins allowed to embed this app.
+    # Use "'self'" to allow same-origin framing, or "'none'" to block all framing.
+    frame_ancestors: str = Field(
+        default="'self' https://earth-tools.org",
+        validation_alias="FRAME_ANCESTORS",
+    )
+
     # Export settings
     exports_dir: Path = Field(
         default=REPO_ROOT / "data" / "exports",

--- a/api/main.py
+++ b/api/main.py
@@ -30,6 +30,17 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+# Pre-computed once at startup — settings are static.
+_CSP_HEADER = f"frame-ancestors {settings.frame_ancestors}"
+
+
+@app.middleware("http")
+async def _add_csp_header(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["Content-Security-Policy"] = _CSP_HEADER
+    return response
+
 @app.on_event("startup")
 async def startup():
     try:

--- a/api/tests/test_csp_headers.py
+++ b/api/tests/test_csp_headers.py
@@ -1,0 +1,28 @@
+"""Tests for Content-Security-Policy frame-ancestors header (iframe embedding)."""
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+
+def test_csp_frame_ancestors_present_on_health():
+    resp = client.get("/health")
+    assert "content-security-policy" in resp.headers
+
+
+def test_csp_frame_ancestors_restricts_to_earth_tools():
+    resp = client.get("/health")
+    csp = resp.headers["content-security-policy"]
+    assert "frame-ancestors" in csp
+    assert "earth-tools.org" in csp
+
+
+def test_csp_frame_ancestors_present_on_fires():
+    resp = client.get("/fires")
+    assert "frame-ancestors" in resp.headers.get("content-security-policy", "")
+
+
+def test_csp_frame_ancestors_present_on_data_status():
+    resp = client.get("/data-status")
+    assert "frame-ancestors" in resp.headers.get("content-security-policy", "")

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -27,8 +27,10 @@ import ForecastNotification from "./components/ForecastNotification";
 import RegionFilter from "./components/RegionFilter";
 import SafetyStatusBar from "./components/SafetyStatusBar";
 import { useArchiveData } from "./hooks/useArchiveData";
+import { useEmbedMode } from "./hooks/useEmbedMode";
 import { useForecastPolling } from "./hooks/useForecastPolling";
 import { useGeolocation } from "./hooks/useGeolocation";
+import { useParentFrame } from "./hooks/useParentFrame";
 import { useSafetyMetrics } from "./hooks/useSafetyMetrics";
 import { useAppStore } from "./state/store";
 import type { FireEvent } from "./types/api";
@@ -142,6 +144,9 @@ export default function App(): JSX.Element {
   const focusMapOnPoint = useAppStore((s) => s.focusMapOnPoint);
   const setMapView = useAppStore((s) => s.setMapView);
   const mapView = useAppStore((s) => s.mapView);
+
+  const isEmbedded = useEmbedMode();
+  useParentFrame(isEmbedded);
 
   const isArchiveMode = archive.viewMode === "archive";
   const isSafetyMode = safety.enabled;
@@ -329,6 +334,17 @@ export default function App(): JSX.Element {
   ];
 
   const stats: StatCard[] = isSafetyMode ? safetyStats : isArchiveMode ? archiveStats : liveStats;
+
+  if (isEmbedded) {
+    return (
+      <Box sx={{ width: "100%", height: "100vh", overflow: "hidden", bgcolor: "#010409" }}>
+        <FireMap
+          onVisibleEventsChange={setVisibleEvents}
+          confidenceFilter={confidenceFilter}
+        />
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ minHeight: "100vh", bgcolor: "#010409", color: "#d1d5db" }}>

--- a/ui/src/hooks/useEmbedMode.ts
+++ b/ui/src/hooks/useEmbedMode.ts
@@ -1,0 +1,20 @@
+// Computed once at module load — the page cannot dynamically move in or out of
+// an iframe, so this value is constant for the entire session.
+const _isEmbedded = (() => {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get("embed") === "true") return true;
+  try {
+    return window.self !== window.top;
+  } catch {
+    // Cross-origin access throws — we are definitely inside an iframe.
+    return true;
+  }
+})();
+
+/**
+ * Returns true when the app is running inside an iframe or when the
+ * `?embed=true` query parameter is present (useful for local testing).
+ */
+export function useEmbedMode(): boolean {
+  return _isEmbedded;
+}

--- a/ui/src/hooks/useParentFrame.ts
+++ b/ui/src/hooks/useParentFrame.ts
@@ -43,8 +43,8 @@ export function useParentFrame(
 
     sendToParent({ type: "ready" });
 
-    const handler = onMessage;
-    if (!handler) return;
+    if (!onMessage) return;
+    const handler = onMessage;  // type is now (msg: ParentMessage) => void
 
     function handleMessage(event: MessageEvent): void {
       if (!ALLOWED_ORIGINS.has(event.origin)) return;

--- a/ui/src/hooks/useParentFrame.ts
+++ b/ui/src/hooks/useParentFrame.ts
@@ -43,7 +43,8 @@ export function useParentFrame(
 
     sendToParent({ type: "ready" });
 
-    if (!onMessage) return;
+    const handler = onMessage;
+    if (!handler) return;
 
     function handleMessage(event: MessageEvent): void {
       if (!ALLOWED_ORIGINS.has(event.origin)) return;
@@ -54,7 +55,7 @@ export function useParentFrame(
       ) {
         return;
       }
-      onMessage(event.data as ParentMessage);
+      handler(event.data as ParentMessage);
     }
 
     window.addEventListener("message", handleMessage);

--- a/ui/src/hooks/useParentFrame.ts
+++ b/ui/src/hooks/useParentFrame.ts
@@ -1,0 +1,63 @@
+import { useEffect } from "react";
+
+/**
+ * Comma-separated list of origins that are allowed to send postMessage events
+ * to this app. Defaults to earth-tools.org (production embedding host).
+ */
+const ALLOWED_ORIGINS: ReadonlySet<string> = new Set(
+  (import.meta.env.VITE_EMBED_ALLOW_ORIGINS ?? "https://earth-tools.org")
+    .split(",")
+    .map((o: string) => o.trim())
+    .filter(Boolean)
+);
+
+export interface ParentMessage {
+  type: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Posts a message to the parent frame. No-ops when not embedded.
+ */
+export function sendToParent(message: ParentMessage): void {
+  if (window.self === window.top) return;
+  try {
+    window.parent.postMessage(message, "*");
+  } catch {
+    // Swallow cross-origin errors — parent may have navigated away.
+  }
+}
+
+/**
+ * When `isEmbedded` is true:
+ *  - Sends a `{ type: "ready" }` message to the parent frame on mount.
+ *  - Attaches a `message` listener that validates the sender origin before
+ *    forwarding the event to `onMessage`.
+ */
+export function useParentFrame(
+  isEmbedded: boolean,
+  onMessage?: (msg: ParentMessage) => void
+): void {
+  useEffect(() => {
+    if (!isEmbedded) return;
+
+    sendToParent({ type: "ready" });
+
+    if (!onMessage) return;
+
+    function handleMessage(event: MessageEvent): void {
+      if (!ALLOWED_ORIGINS.has(event.origin)) return;
+      if (
+        typeof event.data !== "object" ||
+        event.data === null ||
+        typeof (event.data as Record<string, unknown>).type !== "string"
+      ) {
+        return;
+      }
+      onMessage(event.data as ParentMessage);
+    }
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [isEmbedded, onMessage]);
+}


### PR DESCRIPTION
## Changes

Adds iframe embedding capability to the application with proper security headers and bidirectional messaging support.

### Backend (API)
- Add `FRAME_ANCESTORS` environment variable for CSP header configuration
- Implement HTTP middleware to inject `Content-Security-Policy: frame-ancestors` header on all responses
- Default allows embedding from `'self'` and `https://earth-tools.org`
- Add test suite for CSP header validation

### Frontend (UI)
- **`useEmbedMode` hook**: Detects if app is running in iframe via `window.self !== window.top` or `?embed=true` query param
- **`useParentFrame` hook**: Handles secure postMessage communication with parent frame
  - Validates sender origin against `VITE_EMBED_ALLOW_ORIGINS` allowlist
  - Sends `{ type: "ready" }` message on mount
  - Provides `sendToParent()` utility for app-to-parent messaging
- **App component**: Renders map-only UI when embedded (hides sidebar and stats)

### Configuration
- `.env.example`: Document new embedding and CSP settings