### PR TITLE
Add startup configuration validation for API and ingest

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -11,6 +11,7 @@ from redis.asyncio import Redis
 from api.config import settings
 from api.errors import ErrorResponse
 from api.routes import archive_router, assistant_router, internal_router, fires_router, forecast_router, aois_router, tiles_router, exports_router, risk_router
+from api.startup_check import StartupError, run_api_startup_checks
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +33,12 @@ app.add_middleware(
 
 @app.on_event("startup")
 async def startup():
+    try:
+        run_api_startup_checks(settings)
+    except StartupError as exc:
+        LOGGER.critical("STARTUP CONFIG ERROR: %s", exc)
+        raise SystemExit(f"Startup check failed: {exc}") from exc
+
     try:
         redis = Redis.from_url(
             f"redis://{os.getenv('REDIS_HOST', 'localhost')}:{os.getenv('REDIS_PORT', '6379')}",

--- a/api/startup_check.py
+++ b/api/startup_check.py
@@ -1,0 +1,115 @@
+"""Startup configuration validation for the API.
+
+Called from the FastAPI startup handler. Raises StartupError for fatal
+misconfigurations that would cause cryptic failures later; logs WARNING
+for optional config whose absence degrades features but doesn't break the API.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+from api.config import AppSettings
+
+LOGGER = logging.getLogger(__name__)
+
+
+class StartupError(RuntimeError):
+    """Raised when required configuration is missing or invalid at startup."""
+
+
+def validate_database_url(database_url: str) -> None:
+    """Check that the resolved database URL is a structurally valid postgresql:// URL."""
+    if not database_url or not database_url.strip():
+        raise StartupError(
+            "DATABASE_URL is not set. "
+            "Provide DATABASE_URL (or DATABASE_PRIVATE_URL) or set "
+            "POSTGRES_HOST / POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB."
+        )
+    url = database_url.strip()
+    try:
+        parsed = urlparse(url)
+    except Exception as exc:
+        raise StartupError(f"DATABASE_URL is malformed: {exc}") from exc
+
+    valid_schemes = {
+        "postgresql",
+        "postgresql+asyncpg",
+        "postgresql+psycopg2",
+        "postgresql+psycopg",
+    }
+    if parsed.scheme not in valid_schemes:
+        raise StartupError(
+            f"DATABASE_URL has unsupported scheme '{parsed.scheme}'. "
+            f"Expected postgresql:// (e.g., postgresql://user:pass@host:5432/db). "
+            f"Got: {url!r}"
+        )
+    if not parsed.hostname:
+        raise StartupError(
+            f"DATABASE_URL is missing a hostname: {url!r}. "
+            "Expected format: postgresql://user:pass@host:5432/db."
+        )
+    db_name = (parsed.path or "").lstrip("/")
+    if not db_name:
+        raise StartupError(
+            f"DATABASE_URL is missing a database name: {url!r}. "
+            "Expected format: postgresql://user:pass@host:5432/db."
+        )
+
+
+def validate_spread_model_artifact_paths() -> None:
+    """If SPREAD_MODEL_CATALOG_JSON is set, verify any referenced artifact dirs exist.
+
+    JSON parse errors are intentionally not raised here — they surface with a
+    clearer message when get_spread_model_catalog() is first called.
+    """
+    raw = os.getenv("SPREAD_MODEL_CATALOG_JSON")
+    if not raw or not raw.strip():
+        return
+
+    try:
+        catalog = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return  # deferred to catalog load
+
+    if not isinstance(catalog, dict):
+        return
+
+    for model_id, entry in catalog.items():
+        if not isinstance(entry, dict):
+            continue
+        params = entry.get("model_params")
+        if not isinstance(params, dict):
+            continue
+        for key in ("model_run_dir", "calibrator_run_dir"):
+            path_str = params.get(key)
+            if path_str and isinstance(path_str, str):
+                if not Path(path_str).is_dir():
+                    raise StartupError(
+                        f"Spread model artifact path for model_id={model_id!r} "
+                        f"({key}={path_str!r}) does not exist or is not a directory. "
+                        "Check SPREAD_MODEL_CATALOG_JSON and ensure model artifacts are mounted."
+                    )
+
+
+def warn_optional_config(gemini_api_key: str) -> None:
+    """Log warnings for optional config that won't block startup."""
+    if not gemini_api_key or not gemini_api_key.strip():
+        LOGGER.warning(
+            "GEMINI_API_KEY is not set; the AI assistant (/assistant) endpoint will be "
+            "unavailable. Set GEMINI_API_KEY to enable it."
+        )
+
+
+def run_api_startup_checks(settings: AppSettings) -> None:
+    """Run all API startup checks.
+
+    Raises StartupError on fatal misconfiguration.
+    Logs WARNING for optional missing config.
+    """
+    validate_database_url(settings.database_url)
+    validate_spread_model_artifact_paths()
+    warn_optional_config(settings.gemini_api_key)

--- a/api/tests/test_startup_check.py
+++ b/api/tests/test_startup_check.py
@@ -1,0 +1,195 @@
+"""Tests for api.startup_check — startup configuration validation."""
+import json
+import logging
+import types
+
+import pytest
+
+from api.startup_check import (
+    StartupError,
+    run_api_startup_checks,
+    validate_database_url,
+    validate_spread_model_artifact_paths,
+    warn_optional_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_database_url
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDatabaseUrl:
+    def test_valid_postgresql_url(self):
+        validate_database_url("postgresql://user:pass@localhost:5432/mydb")
+
+    def test_valid_postgresql_asyncpg(self):
+        validate_database_url("postgresql+asyncpg://user:pass@localhost:5432/mydb")
+
+    def test_valid_postgresql_psycopg2(self):
+        validate_database_url("postgresql+psycopg2://user:pass@localhost:5432/mydb")
+
+    def test_empty_string_raises(self):
+        with pytest.raises(StartupError, match="DATABASE_URL is not set"):
+            validate_database_url("")
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(StartupError, match="DATABASE_URL is not set"):
+            validate_database_url("   ")
+
+    def test_sqlite_scheme_raises(self):
+        with pytest.raises(StartupError, match="unsupported scheme 'sqlite'"):
+            validate_database_url("sqlite:///test.db")
+
+    def test_mysql_scheme_raises(self):
+        with pytest.raises(StartupError, match="unsupported scheme 'mysql'"):
+            validate_database_url("mysql://user:pass@localhost:3306/db")
+
+    def test_bare_string_raises(self):
+        with pytest.raises(StartupError, match="unsupported scheme"):
+            validate_database_url("not-a-url")
+
+    def test_missing_hostname_raises(self):
+        with pytest.raises(StartupError, match="missing a hostname"):
+            validate_database_url("postgresql:///mydb")
+
+    def test_missing_dbname_raises(self):
+        with pytest.raises(StartupError, match="missing a database name"):
+            validate_database_url("postgresql://user:pass@localhost/")
+
+    def test_default_built_url_passes(self):
+        """The URL built from POSTGRES_* defaults is always structurally valid."""
+        validate_database_url("postgresql://wildfire:wildfire@localhost:5432/wildfire")
+
+
+# ---------------------------------------------------------------------------
+# validate_spread_model_artifact_paths
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSpreadModelArtifactPaths:
+    def test_no_env_var_passes(self, monkeypatch):
+        monkeypatch.delenv("SPREAD_MODEL_CATALOG_JSON", raising=False)
+        validate_spread_model_artifact_paths()  # must not raise
+
+    def test_empty_env_var_passes(self, monkeypatch):
+        monkeypatch.setenv("SPREAD_MODEL_CATALOG_JSON", "")
+        validate_spread_model_artifact_paths()
+
+    def test_invalid_json_passes_silently(self, monkeypatch):
+        monkeypatch.setenv("SPREAD_MODEL_CATALOG_JSON", "not-valid-json{{")
+        validate_spread_model_artifact_paths()  # deferred to catalog load
+
+    def test_catalog_without_artifact_paths_passes(self, monkeypatch):
+        catalog = {"v0_default": {"model_name": "HeuristicSpreadModelV0", "model_params": {}}}
+        monkeypatch.setenv("SPREAD_MODEL_CATALOG_JSON", json.dumps(catalog))
+        validate_spread_model_artifact_paths()
+
+    def test_existing_model_run_dir_passes(self, monkeypatch, tmp_path):
+        model_dir = tmp_path / "run_001"
+        model_dir.mkdir()
+        catalog = {
+            "v1": {
+                "model_name": "LearnedSpreadModelV1",
+                "model_params": {"model_run_dir": str(model_dir)},
+            }
+        }
+        monkeypatch.setenv("SPREAD_MODEL_CATALOG_JSON", json.dumps(catalog))
+        validate_spread_model_artifact_paths()
+
+    def test_missing_model_run_dir_raises(self, monkeypatch):
+        catalog = {
+            "v1": {
+                "model_name": "LearnedSpreadModelV1",
+                "model_params": {"model_run_dir": "/nonexistent/path/run_001"},
+            }
+        }
+        monkeypatch.setenv("SPREAD_MODEL_CATALOG_JSON", json.dumps(catalog))
+        with pytest.raises(StartupError, match="does not exist"):
+            validate_spread_model_artifact_paths()
+
+    def test_missing_calibrator_run_dir_raises(self, monkeypatch, tmp_path):
+        model_dir = tmp_path / "run_001"
+        model_dir.mkdir()
+        catalog = {
+            "v1": {
+                "model_name": "LearnedSpreadModelV1",
+                "model_params": {
+                    "model_run_dir": str(model_dir),
+                    "calibrator_run_dir": "/nonexistent/calibrator",
+                },
+            }
+        }
+        monkeypatch.setenv("SPREAD_MODEL_CATALOG_JSON", json.dumps(catalog))
+        with pytest.raises(StartupError, match="does not exist"):
+            validate_spread_model_artifact_paths()
+
+    def test_error_message_includes_model_id(self, monkeypatch):
+        catalog = {
+            "my_special_model": {
+                "model_name": "LearnedSpreadModelV1",
+                "model_params": {"model_run_dir": "/does/not/exist"},
+            }
+        }
+        monkeypatch.setenv("SPREAD_MODEL_CATALOG_JSON", json.dumps(catalog))
+        with pytest.raises(StartupError, match="my_special_model"):
+            validate_spread_model_artifact_paths()
+
+
+# ---------------------------------------------------------------------------
+# warn_optional_config
+# ---------------------------------------------------------------------------
+
+
+class TestWarnOptionalConfig:
+    def test_key_set_no_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="api.startup_check"):
+            warn_optional_config("my-real-gemini-key")
+        assert "GEMINI_API_KEY" not in caplog.text
+
+    def test_empty_key_logs_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="api.startup_check"):
+            warn_optional_config("")
+        assert "GEMINI_API_KEY" in caplog.text
+
+    def test_whitespace_key_logs_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="api.startup_check"):
+            warn_optional_config("   ")
+        assert "GEMINI_API_KEY" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# run_api_startup_checks (integration of all checks)
+# ---------------------------------------------------------------------------
+
+
+def _make_settings(database_url: str, gemini_api_key: str = "key") -> object:
+    return types.SimpleNamespace(database_url=database_url, gemini_api_key=gemini_api_key)
+
+
+class TestRunApiStartupChecks:
+    def test_valid_config_passes(self, monkeypatch):
+        monkeypatch.delenv("SPREAD_MODEL_CATALOG_JSON", raising=False)
+        run_api_startup_checks(_make_settings("postgresql://u:p@localhost:5432/db"))
+
+    def test_bad_database_url_raises(self, monkeypatch):
+        monkeypatch.delenv("SPREAD_MODEL_CATALOG_JSON", raising=False)
+        with pytest.raises(StartupError, match="unsupported scheme"):
+            run_api_startup_checks(_make_settings("sqlite:///test.db"))
+
+    def test_missing_gemini_key_warns_but_does_not_raise(self, monkeypatch, caplog):
+        monkeypatch.delenv("SPREAD_MODEL_CATALOG_JSON", raising=False)
+        with caplog.at_level(logging.WARNING, logger="api.startup_check"):
+            run_api_startup_checks(_make_settings("postgresql://u:p@localhost:5432/db", gemini_api_key=""))
+        assert "GEMINI_API_KEY" in caplog.text
+
+    def test_missing_spread_artifact_path_raises(self, monkeypatch):
+        catalog = {
+            "v1": {
+                "model_name": "LearnedSpreadModelV1",
+                "model_params": {"model_run_dir": "/no/such/path"},
+            }
+        }
+        monkeypatch.setenv("SPREAD_MODEL_CATALOG_JSON", json.dumps(catalog))
+        with pytest.raises(StartupError, match="does not exist"):
+            run_api_startup_checks(_make_settings("postgresql://u:p@localhost:5432/db"))

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Sequence
 
 from ingest.config import REPO_ROOT
 from ingest.dem_preprocess import DemIngestSettings, ingest_terrain_for_bbox
+from ingest.startup_check import StartupError, run_ingest_startup_checks
 from ingest.firms_ingest import run_firms_ingest
 from ingest.industrial_sources_ingest import run_industrial_ingest
 from ingest.nifc_perimeters_ingest import fetch_nifc_perimeters, ingest_perimeters
@@ -1071,6 +1072,13 @@ def run_scheduler(
 
 def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
+
+    try:
+        run_ingest_startup_checks()
+    except StartupError as exc:
+        LOGGER.critical("STARTUP CONFIG ERROR: %s", exc)
+        raise SystemExit(f"Startup check failed: {exc}") from exc
+
     jobs = build_jobs(args)
     dashboard_path = Path(args.dashboard_path)
 

--- a/ingest/startup_check.py
+++ b/ingest/startup_check.py
@@ -1,0 +1,73 @@
+"""Startup configuration validation for the ingest orchestrator.
+
+Called from orchestrator.main() before any jobs are built or run. Raises
+StartupError for fatal misconfigurations; logs WARNING for optional issues.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+LOGGER = logging.getLogger("ingest_orchestrator")
+
+
+class StartupError(RuntimeError):
+    """Raised when required configuration is missing or invalid at startup."""
+
+
+def validate_firms_map_key() -> None:
+    """Check that FIRMS_MAP_KEY is present and non-empty."""
+    key = os.getenv("FIRMS_MAP_KEY", "").strip()
+    if not key:
+        raise StartupError(
+            "FIRMS_MAP_KEY is not set. "
+            "Obtain an API key from https://firms.modaps.eosdis.nasa.gov/api/area/ "
+            "and set FIRMS_MAP_KEY in your .env file."
+        )
+
+
+def validate_denoiser_model_path() -> None:
+    """If DENOISER_ENABLED=true, verify DENOISER_MODEL_RUN_DIR is set and exists.
+
+    Fatal (StartupError) when DENOISER_REQUIRED=true.
+    Warning-only when DENOISER_REQUIRED=false so the orchestrator can still run
+    without the denoiser on initial bootstrap.
+    """
+    enabled = os.getenv("DENOISER_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+    if not enabled:
+        return
+
+    required = os.getenv("DENOISER_REQUIRED", "true").strip().lower() in ("1", "true", "yes")
+    run_dir = os.getenv("DENOISER_MODEL_RUN_DIR", "").strip()
+
+    if not run_dir:
+        msg = (
+            "DENOISER_MODEL_RUN_DIR is not set but DENOISER_ENABLED=true. "
+            "Set DENOISER_MODEL_RUN_DIR to the trained model artifact directory, "
+            "or set DENOISER_REQUIRED=false to run without the denoiser."
+        )
+        if required:
+            raise StartupError(msg)
+        LOGGER.warning("%s Denoiser will be skipped (DENOISER_REQUIRED=false).", msg)
+        return
+
+    path = Path(run_dir)
+    if not path.is_dir():
+        msg = (
+            f"DENOISER_MODEL_RUN_DIR={run_dir!r} does not exist or is not a directory. "
+            "Ensure the model artifact directory is present before starting ingest."
+        )
+        if required:
+            raise StartupError(msg)
+        LOGGER.warning("%s Denoiser will be skipped (DENOISER_REQUIRED=false).", msg)
+
+
+def run_ingest_startup_checks() -> None:
+    """Run all ingest orchestrator startup checks.
+
+    Raises StartupError on fatal misconfiguration.
+    Logs WARNING for optional missing config.
+    """
+    validate_firms_map_key()
+    validate_denoiser_model_path()

--- a/ingest/tests/test_startup_check.py
+++ b/ingest/tests/test_startup_check.py
@@ -1,0 +1,144 @@
+"""Tests for ingest.startup_check — startup configuration validation."""
+import logging
+
+import pytest
+
+from ingest.startup_check import (
+    StartupError,
+    run_ingest_startup_checks,
+    validate_denoiser_model_path,
+    validate_firms_map_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_firms_map_key
+# ---------------------------------------------------------------------------
+
+
+class TestValidateFirmsMapKey:
+    def test_key_present_passes(self, monkeypatch):
+        monkeypatch.setenv("FIRMS_MAP_KEY", "my-api-key")
+        validate_firms_map_key()
+
+    def test_key_missing_raises(self, monkeypatch):
+        monkeypatch.delenv("FIRMS_MAP_KEY", raising=False)
+        with pytest.raises(StartupError, match="FIRMS_MAP_KEY"):
+            validate_firms_map_key()
+
+    def test_empty_key_raises(self, monkeypatch):
+        monkeypatch.setenv("FIRMS_MAP_KEY", "")
+        with pytest.raises(StartupError, match="FIRMS_MAP_KEY"):
+            validate_firms_map_key()
+
+    def test_whitespace_only_key_raises(self, monkeypatch):
+        monkeypatch.setenv("FIRMS_MAP_KEY", "   ")
+        with pytest.raises(StartupError, match="FIRMS_MAP_KEY"):
+            validate_firms_map_key()
+
+    def test_error_message_mentions_nasa_url(self, monkeypatch):
+        monkeypatch.delenv("FIRMS_MAP_KEY", raising=False)
+        with pytest.raises(StartupError, match="firms.modaps.eosdis.nasa.gov"):
+            validate_firms_map_key()
+
+
+# ---------------------------------------------------------------------------
+# validate_denoiser_model_path
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDenoiserModelPath:
+    def test_denoiser_disabled_skips_all_checks(self, monkeypatch):
+        monkeypatch.setenv("DENOISER_ENABLED", "false")
+        monkeypatch.delenv("DENOISER_MODEL_RUN_DIR", raising=False)
+        validate_denoiser_model_path()  # must not raise
+
+    def test_denoiser_disabled_false_variant(self, monkeypatch):
+        monkeypatch.setenv("DENOISER_ENABLED", "0")
+        validate_denoiser_model_path()
+
+    def test_denoiser_enabled_required_no_dir_raises(self, monkeypatch):
+        monkeypatch.setenv("DENOISER_ENABLED", "true")
+        monkeypatch.setenv("DENOISER_REQUIRED", "true")
+        monkeypatch.setenv("DENOISER_MODEL_RUN_DIR", "")
+        with pytest.raises(StartupError, match="DENOISER_MODEL_RUN_DIR"):
+            validate_denoiser_model_path()
+
+    def test_denoiser_enabled_required_dir_unset_raises(self, monkeypatch):
+        monkeypatch.setenv("DENOISER_ENABLED", "true")
+        monkeypatch.setenv("DENOISER_REQUIRED", "true")
+        monkeypatch.delenv("DENOISER_MODEL_RUN_DIR", raising=False)
+        with pytest.raises(StartupError, match="DENOISER_MODEL_RUN_DIR"):
+            validate_denoiser_model_path()
+
+    def test_denoiser_enabled_required_existing_path_passes(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("DENOISER_ENABLED", "true")
+        monkeypatch.setenv("DENOISER_REQUIRED", "true")
+        monkeypatch.setenv("DENOISER_MODEL_RUN_DIR", str(tmp_path))
+        validate_denoiser_model_path()
+
+    def test_denoiser_enabled_required_missing_path_raises(self, monkeypatch):
+        monkeypatch.setenv("DENOISER_ENABLED", "true")
+        monkeypatch.setenv("DENOISER_REQUIRED", "true")
+        monkeypatch.setenv("DENOISER_MODEL_RUN_DIR", "/nonexistent/run_001")
+        with pytest.raises(StartupError, match="does not exist"):
+            validate_denoiser_model_path()
+
+    def test_denoiser_enabled_not_required_missing_dir_warns(self, monkeypatch, caplog):
+        monkeypatch.setenv("DENOISER_ENABLED", "true")
+        monkeypatch.setenv("DENOISER_REQUIRED", "false")
+        monkeypatch.setenv("DENOISER_MODEL_RUN_DIR", "")
+        with caplog.at_level(logging.WARNING, logger="ingest_orchestrator"):
+            validate_denoiser_model_path()  # must not raise
+        assert "DENOISER_MODEL_RUN_DIR" in caplog.text
+
+    def test_denoiser_enabled_not_required_missing_path_warns(self, monkeypatch, caplog):
+        monkeypatch.setenv("DENOISER_ENABLED", "true")
+        monkeypatch.setenv("DENOISER_REQUIRED", "false")
+        monkeypatch.setenv("DENOISER_MODEL_RUN_DIR", "/nonexistent/run_001")
+        with caplog.at_level(logging.WARNING, logger="ingest_orchestrator"):
+            validate_denoiser_model_path()  # must not raise
+        assert "does not exist" in caplog.text
+
+    def test_denoiser_enabled_true_variants(self, monkeypatch, tmp_path):
+        """'1', 'yes', 'true' all count as enabled."""
+        for val in ("1", "yes", "YES", "True"):
+            monkeypatch.setenv("DENOISER_ENABLED", val)
+            monkeypatch.setenv("DENOISER_REQUIRED", "true")
+            monkeypatch.setenv("DENOISER_MODEL_RUN_DIR", str(tmp_path))
+            validate_denoiser_model_path()
+
+
+# ---------------------------------------------------------------------------
+# run_ingest_startup_checks (integration of all checks)
+# ---------------------------------------------------------------------------
+
+
+class TestRunIngestStartupChecks:
+    def test_valid_config_passes(self, monkeypatch):
+        monkeypatch.setenv("FIRMS_MAP_KEY", "test-key-abc")
+        monkeypatch.setenv("DENOISER_ENABLED", "false")
+        run_ingest_startup_checks()
+
+    def test_missing_firms_key_raises(self, monkeypatch):
+        monkeypatch.setenv("FIRMS_MAP_KEY", "")
+        monkeypatch.setenv("DENOISER_ENABLED", "false")
+        with pytest.raises(StartupError, match="FIRMS_MAP_KEY"):
+            run_ingest_startup_checks()
+
+    def test_denoiser_required_missing_path_raises(self, monkeypatch):
+        monkeypatch.setenv("FIRMS_MAP_KEY", "test-key-abc")
+        monkeypatch.setenv("DENOISER_ENABLED", "true")
+        monkeypatch.setenv("DENOISER_REQUIRED", "true")
+        monkeypatch.setenv("DENOISER_MODEL_RUN_DIR", "/no/such/path")
+        with pytest.raises(StartupError, match="does not exist"):
+            run_ingest_startup_checks()
+
+    def test_denoiser_not_required_missing_path_passes(self, monkeypatch, caplog):
+        monkeypatch.setenv("FIRMS_MAP_KEY", "test-key-abc")
+        monkeypatch.setenv("DENOISER_ENABLED", "true")
+        monkeypatch.setenv("DENOISER_REQUIRED", "false")
+        monkeypatch.setenv("DENOISER_MODEL_RUN_DIR", "/no/such/path")
+        with caplog.at_level(logging.WARNING, logger="ingest_orchestrator"):
+            run_ingest_startup_checks()  # must not raise
+        assert "does not exist" in caplog.text


### PR DESCRIPTION
## Overview
Implements fail-fast startup checks for both the FastAPI application and the ingest orchestrator. Missing or invalid configuration now raises `StartupError` during application startup rather than causing cryptic failures later.

## Changes

### API (`api/startup_check.py` + `api/main.py`)
- **`validate_database_url()`**: Ensures `DATABASE_URL` is set and uses a valid PostgreSQL scheme/format
- **`validate_spread_model_artifact_paths()`**: Verifies spread model artifact directories referenced in `SPREAD_MODEL_CATALOG_JSON` exist
- **`warn_optional_config()`**: Logs warnings for optional config (e.g., missing `GEMINI_API_KEY`)
- **`run_api_startup_checks()`**: Orchestrates all API checks in the FastAPI startup handler

### Ingest (`ingest/startup_check.py` + `ingest/orchestrator.py`)
- **`validate_firms_map_key()`**: Ensures required `FIRMS_MAP_KEY` is set
- **`validate_denoiser_model_path()`**: Checks denoiser configuration; fatal if `DENOISER_REQUIRED=true` and path missing, warns only if `DENOISER_REQUIRED=false`
- **`run_ingest_startup_checks()`**: Orchestrates all ingest checks before job building

### Tests
- Comprehensive unit tests for both modules (195 lines for API, 144 for ingest)
- Coverage includes valid configs, missing/invalid inputs, edge cases, and error messaging

## Benefits
- **Early failure detection**: Configuration errors caught at startup, not buried in cryptic runtime errors
- **Clear error messages**: Actionable guidance for fixing missing/invalid config
- **Optional vs. fatal**: Gracefully degrades on optional missing config while preventing startup on fatal issues