### PR TITLE
refactor(exports): simplify GeoPackage writer and test helpers

### DIFF
--- a/api/routes/exports.py
+++ b/api/routes/exports.py
@@ -93,8 +93,8 @@ def _write_gpkg(features: list[dict], layer_name: str, prop_names: list[str]) ->
     try:
         con = sqlite3.connect(tmp.name)
         con.executescript(
-            f"PRAGMA application_id = 1196444487;"  # 0x47504b47
-            f"PRAGMA user_version = 10300;"          # GeoPackage 1.3
+            "PRAGMA application_id = 1196444487;"  # 0x47504b47
+            "PRAGMA user_version = 10300;"          # GeoPackage 1.3
             + _GPKG_SCHEMA_SQL
         )
         con.execute(

--- a/api/routes/exports.py
+++ b/api/routes/exports.py
@@ -69,6 +69,8 @@ CREATE TABLE gpkg_geometry_columns (
 );
 """
 
+_DEFAULT_SRID = 4326
+
 _WGS84_WKT = (
     'GEOGCS["WGS 84",DATUM["WGS_1984",'
     'SPHEROID["WGS 84",6378137,298.257223563]],'
@@ -76,7 +78,7 @@ _WGS84_WKT = (
     'UNIT["degree",0.0174532925199433]]'
 )
 # Constant GPKG binary header: magic(GP) + version(0) + flags(0x01=LE,no-envelope) + srs_id(int32LE)
-_GPKG_GEOM_HEADER = struct.pack("<2sBBI", b"GP", 0, 0x01, 4326)
+_GPKG_GEOM_HEADER = struct.pack("<2sBBI", b"GP", 0, 0x01, _DEFAULT_SRID)
 
 
 def _gpkg_geom_bytes(geojson_geom: dict) -> bytes:
@@ -90,12 +92,14 @@ def _write_gpkg(features: list[dict], layer_name: str, prop_names: list[str]) ->
     tmp.close()
     try:
         con = sqlite3.connect(tmp.name)
-        con.execute("PRAGMA application_id = 1196444487")  # 0x47504b47
-        con.execute("PRAGMA user_version = 10300")  # GeoPackage 1.3
-        con.executescript(_GPKG_SCHEMA_SQL)
+        con.executescript(
+            f"PRAGMA application_id = 1196444487;"  # 0x47504b47
+            f"PRAGMA user_version = 10300;"          # GeoPackage 1.3
+            + _GPKG_SCHEMA_SQL
+        )
         con.execute(
             "INSERT INTO gpkg_spatial_ref_sys VALUES (?,?,?,?,?,?)",
-            ("WGS 84", 4326, "EPSG", 4326, _WGS84_WKT, "WGS 84 geographic 2D CRS"),
+            ("WGS 84", _DEFAULT_SRID, "EPSG", _DEFAULT_SRID, _WGS84_WKT, "WGS 84 geographic 2D CRS"),
         )
         col_extra = (", " + ", ".join(f'"{p}" TEXT' for p in prop_names)) if prop_names else ""
         con.execute(
@@ -103,11 +107,11 @@ def _write_gpkg(features: list[dict], layer_name: str, prop_names: list[str]) ->
         )
         con.execute(
             "INSERT INTO gpkg_contents (table_name, data_type, identifier, srs_id) VALUES (?,?,?,?)",
-            (layer_name, "features", layer_name, 4326),
+            (layer_name, "features", layer_name, _DEFAULT_SRID),
         )
         con.execute(
             "INSERT INTO gpkg_geometry_columns VALUES (?,?,?,?,?,?)",
-            (layer_name, "geom", "GEOMETRY", 4326, 0, 0),
+            (layer_name, "geom", "GEOMETRY", _DEFAULT_SRID, 0, 0),
         )
         if prop_names:
             col_list = ", ".join(f'"{p}"' for p in prop_names)
@@ -116,11 +120,12 @@ def _write_gpkg(features: list[dict], layer_name: str, prop_names: list[str]) ->
         else:
             insert_sql = f'INSERT INTO "{layer_name}" (geom) VALUES (?)'
         try:
-            for feat in features:
-                geom_bytes = _gpkg_geom_bytes(feat["geometry"]) if feat.get("geometry") else None
-                props = feat.get("properties") or {}
-                row = [geom_bytes] + ["" if (v := props.get(p)) is None else str(v) for p in prop_names]
-                con.execute(insert_sql, row)
+            rows = [
+                [_gpkg_geom_bytes(feat["geometry"]) if feat.get("geometry") else None]
+                + ["" if (v := (feat.get("properties") or {}).get(p)) is None else str(v) for p in prop_names]
+                for feat in features
+            ]
+            con.executemany(insert_sql, rows)
             con.commit()
         finally:
             con.close()

--- a/api/tests/test_exports.py
+++ b/api/tests/test_exports.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import os
 import sqlite3
+import struct
+import tempfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -97,9 +101,24 @@ def _is_valid_gpkg(data: bytes) -> bool:
     if not data.startswith(b"SQLite format 3\x00"):
         return False
     # application_id at offset 68 (big-endian int32) must be 0x47504b47
-    import struct
     app_id = struct.unpack(">I", data[68:72])[0]
     return app_id == 0x47504B47
+
+
+@contextmanager
+def _gpkg_db(data: bytes):
+    """Write GeoPackage bytes to a temp file and yield an open sqlite3 connection."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".gpkg", delete=False)
+    tmp.write(data)
+    tmp.close()
+    try:
+        con = sqlite3.connect(tmp.name)
+        try:
+            yield con
+        finally:
+            con.close()
+    finally:
+        os.unlink(tmp.name)
 
 
 def test_export_fires_gpkg_returns_valid_geopackage(monkeypatch):
@@ -117,18 +136,9 @@ def test_export_fires_gpkg_layer_has_expected_rows(monkeypatch):
     resp = client.get("/fires/export", params={**_BBOX_PARAMS, "format": "gpkg"})
     assert resp.status_code == 200
 
-    import tempfile
-    import os
-    tmp = tempfile.NamedTemporaryFile(suffix=".gpkg", delete=False)
-    tmp.write(resp.content)
-    tmp.close()
-    try:
-        con = sqlite3.connect(tmp.name)
+    with _gpkg_db(resp.content) as con:
         rows = con.execute("SELECT * FROM fire_detections").fetchall()
-        con.close()
-        assert len(rows) == 2
-    finally:
-        os.unlink(tmp.name)
+    assert len(rows) == 2
 
 
 def test_export_fires_gpkg_has_gpkg_contents_row(monkeypatch):
@@ -136,18 +146,9 @@ def test_export_fires_gpkg_has_gpkg_contents_row(monkeypatch):
     resp = client.get("/fires/export", params={**_BBOX_PARAMS, "format": "gpkg"})
     assert resp.status_code == 200
 
-    import tempfile
-    import os
-    tmp = tempfile.NamedTemporaryFile(suffix=".gpkg", delete=False)
-    tmp.write(resp.content)
-    tmp.close()
-    try:
-        con = sqlite3.connect(tmp.name)
+    with _gpkg_db(resp.content) as con:
         rows = con.execute("SELECT table_name, data_type FROM gpkg_contents").fetchall()
-        con.close()
-        assert any(r[0] == "fire_detections" and r[1] == "features" for r in rows)
-    finally:
-        os.unlink(tmp.name)
+    assert any(r[0] == "fire_detections" and r[1] == "features" for r in rows)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Changes

### api/routes/exports.py
- Extract `_DEFAULT_SRID = 4326` constant to reduce magic numbers
- Consolidate PRAGMA statements into single `executescript()` call
- Replace explicit loop with list comprehension for building feature rows
- Use `executemany()` for batch insert instead of individual `execute()` calls

### api/tests/test_exports.py
- Add `_gpkg_db()` context manager to eliminate duplicated temp file handling logic
- Simplify test functions by using the new context manager
- Add missing imports (os, struct, tempfile, contextmanager)
- Reduce code duplication across test cases