### PR TITLE
feat(ui): add denoiser review queue panel for operator triage

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -25,6 +25,7 @@ import FireDetailsPanel from "./components/FireDetailsPanel";
 import FireMap from "./components/FireMap";
 import ForecastNotification from "./components/ForecastNotification";
 import RegionFilter from "./components/RegionFilter";
+import ReviewQueuePanel from "./components/ReviewQueuePanel";
 import SafetyStatusBar from "./components/SafetyStatusBar";
 import { useArchiveData } from "./hooks/useArchiveData";
 import { useEmbedMode } from "./hooks/useEmbedMode";
@@ -666,6 +667,11 @@ export default function App(): JSX.Element {
             <Box sx={{ flex: "0 0 auto", minHeight: { xs: 360, lg: 0 } }}>
               <FireDetailsPanel visibleEvents={filteredEvents} />
             </Box>
+            {!isArchiveMode && (
+              <Box sx={{ flex: "0 0 auto" }}>
+                <ReviewQueuePanel visibleEvents={filteredEvents} />
+              </Box>
+            )}
             {!isArchiveMode && (
               <Box sx={{ flex: 1, minHeight: 320 }}>
                 <AIChatAssistant />

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -9,6 +9,8 @@ import type {
   JitCreateResponse,
   JitForecastStatus,
   ReverseGeocodeResponse,
+  ReviewQueueResponse,
+  ResolveReviewResponse,
   RiskFeatureCollection
 } from "../types/api";
 
@@ -391,6 +393,24 @@ export async function triggerArchiveIngest(
   timeframe: string
 ): Promise<ArchiveIngestResponse> {
   return postJson<ArchiveIngestResponse>("/fires/archive/ingest", { date, timeframe }, 202);
+}
+
+export async function getDenoiserReviewQueue(): Promise<ReviewQueueResponse> {
+  return getJson<ReviewQueueResponse>("/internal/denoiser/review-queue", { limit: 200, status: "open" });
+}
+
+export async function resolveDenoiserReviewItem(args: {
+  eventId: string;
+  resolvedBy: string;
+  resolvedNotes?: string;
+}): Promise<ResolveReviewResponse> {
+  return postJson<ResolveReviewResponse>(
+    `/internal/denoiser/review-queue/${args.eventId}/resolve`,
+    {
+      resolved_by: args.resolvedBy,
+      resolved_notes: args.resolvedNotes ?? null
+    }
+  );
 }
 
 export function buildEventKey(event: FireEvent, lat: number, lon: number): string {

--- a/ui/src/components/ReviewQueuePanel.tsx
+++ b/ui/src/components/ReviewQueuePanel.tsx
@@ -1,0 +1,347 @@
+import { useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  Stack,
+  Tooltip,
+  Typography
+} from "@mui/material";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import DoNotDisturbOnIcon from "@mui/icons-material/DoNotDisturbOn";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { ApiUnavailableError, getDenoiserReviewQueue, resolveDenoiserReviewItem } from "../api/client";
+import { safeFloat } from "../map/layerUtils";
+import { useAppStore } from "../state/store";
+import type { DenoiserReviewItem, FireEvent } from "../types/api";
+
+type ResolutionNote = "confirmed_fire" | "marked_noise";
+
+interface ReviewQueuePanelProps {
+  visibleEvents: FireEvent[];
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit"
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatFrp(value: unknown): string {
+  const num = safeFloat(value);
+  return num === null ? "n/a" : `${num.toFixed(0)} MW`;
+}
+
+function formatConfidence(value: unknown): string {
+  const num = safeFloat(value);
+  return num === null ? "n/a" : `${(num * 100).toFixed(0)}%`;
+}
+
+function ReasonChip({ reason }: { reason: string }) {
+  const label = reason === "fail_closed_hard_bypass" ? "Hard Bypass" : "Uncertainty";
+  const color = reason === "fail_closed_hard_bypass" ? "#ef4444" : "#f97316";
+  return (
+    <Box
+      component="span"
+      sx={{
+        px: 0.75,
+        py: 0.2,
+        borderRadius: 0.8,
+        fontSize: 9,
+        fontWeight: 700,
+        letterSpacing: "0.1em",
+        textTransform: "uppercase",
+        bgcolor: `${color}22`,
+        border: `1px solid ${color}55`,
+        color
+      }}
+    >
+      {label}
+    </Box>
+  );
+}
+
+interface ReviewItemRowProps {
+  item: DenoiserReviewItem;
+  matchedEvent: FireEvent | null;
+  onResolve: (eventId: string, notes: ResolutionNote) => void;
+  isResolving: boolean;
+}
+
+function ReviewItemRow({ item, matchedEvent, onResolve, isResolving }: ReviewItemRowProps) {
+  const focusMapOnPoint = useAppStore((s) => s.focusMapOnPoint);
+
+  const frp = item.payload_json?.frp_max;
+  const confidence = item.payload_json?.confidence_max;
+  const sensor = matchedEvent?.sensor ?? null;
+  const time = matchedEvent?.end_time ?? item.created_at;
+
+  function handleFocus() {
+    const lat = safeFloat(matchedEvent?.lat);
+    const lon = safeFloat(matchedEvent?.lon);
+    if (lat !== null && lon !== null) {
+      focusMapOnPoint(lat, lon, 9);
+    }
+  }
+
+  const canFocus = safeFloat(matchedEvent?.lat) !== null;
+
+  return (
+    <Box
+      sx={{
+        p: 1.25,
+        borderRadius: 1.5,
+        bgcolor: "#0d1117",
+        border: "1px solid rgba(251,146,60,0.25)",
+        cursor: canFocus ? "pointer" : "default",
+        transition: "border-color 0.15s",
+        "&:hover": canFocus ? { borderColor: "rgba(251,146,60,0.55)" } : {}
+      }}
+      onClick={handleFocus}
+    >
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", mb: 0.75 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, flexWrap: "wrap" }}>
+          <ReasonChip reason={item.reason} />
+          {sensor && (
+            <Typography sx={{ fontSize: 10, color: "#6b7280", fontWeight: 600 }}>
+              {sensor}
+            </Typography>
+          )}
+        </Box>
+        <Typography sx={{ fontSize: 10, color: "#4b5563", whiteSpace: "nowrap", ml: 1 }}>
+          {formatTimestamp(time)}
+        </Typography>
+      </Box>
+
+      <Box sx={{ display: "flex", gap: 2, mb: 1 }}>
+        <Box>
+          <Typography sx={{ fontSize: 9, color: "#4b5563", textTransform: "uppercase", letterSpacing: "0.1em", fontWeight: 700 }}>
+            FRP
+          </Typography>
+          <Typography sx={{ fontSize: 13, color: "#e5e7eb", fontWeight: 700 }}>
+            {formatFrp(frp)}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography sx={{ fontSize: 9, color: "#4b5563", textTransform: "uppercase", letterSpacing: "0.1em", fontWeight: 700 }}>
+            Confidence
+          </Typography>
+          <Typography sx={{ fontSize: 13, color: "#e5e7eb", fontWeight: 700 }}>
+            {formatConfidence(confidence)}
+          </Typography>
+        </Box>
+        {item.payload_json?.event_score != null && (
+          <Box>
+            <Typography sx={{ fontSize: 9, color: "#4b5563", textTransform: "uppercase", letterSpacing: "0.1em", fontWeight: 700 }}>
+              Score
+            </Typography>
+            <Typography sx={{ fontSize: 13, color: "#e5e7eb", fontWeight: 700 }}>
+              {item.payload_json.event_score.toFixed(3)}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+
+      <Box
+        sx={{ display: "flex", gap: 0.75 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Tooltip title="Confirm this detection as a real fire">
+          <span>
+            <Button
+              size="small"
+              disabled={isResolving}
+              startIcon={isResolving ? <CircularProgress size={12} /> : <CheckCircleOutlineIcon />}
+              onClick={() => onResolve(item.event_id, "confirmed_fire")}
+              sx={{
+                fontSize: 10,
+                fontWeight: 700,
+                py: 0.4,
+                px: 1,
+                color: "#4ade80",
+                borderColor: "rgba(74,222,128,0.35)",
+                border: "1px solid",
+                borderRadius: 1,
+                textTransform: "none",
+                "&:hover": { bgcolor: "rgba(74,222,128,0.1)", borderColor: "rgba(74,222,128,0.6)" },
+                "&:disabled": { opacity: 0.4 }
+              }}
+            >
+              Confirm Fire
+            </Button>
+          </span>
+        </Tooltip>
+        <Tooltip title="Mark this detection as noise / false positive">
+          <span>
+            <Button
+              size="small"
+              disabled={isResolving}
+              startIcon={isResolving ? <CircularProgress size={12} /> : <DoNotDisturbOnIcon />}
+              onClick={() => onResolve(item.event_id, "marked_noise")}
+              sx={{
+                fontSize: 10,
+                fontWeight: 700,
+                py: 0.4,
+                px: 1,
+                color: "#9ca3af",
+                borderColor: "rgba(156,163,175,0.3)",
+                border: "1px solid",
+                borderRadius: 1,
+                textTransform: "none",
+                "&:hover": { bgcolor: "rgba(156,163,175,0.08)", borderColor: "rgba(156,163,175,0.5)" },
+                "&:disabled": { opacity: 0.4 }
+              }}
+            >
+              Mark as Noise
+            </Button>
+          </span>
+        </Tooltip>
+      </Box>
+    </Box>
+  );
+}
+
+export default function ReviewQueuePanel({ visibleEvents }: ReviewQueuePanelProps) {
+  const queryClient = useQueryClient();
+  const [resolvingIds, setResolvingIds] = useState<Set<string>>(new Set());
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["denoiser-review-queue"],
+    queryFn: getDenoiserReviewQueue,
+    refetchInterval: 15_000,
+    staleTime: 15_000
+  });
+
+  const resolveMutation = useMutation({
+    mutationFn: resolveDenoiserReviewItem,
+    onMutate: ({ eventId }) => {
+      setResolvingIds((prev) => new Set(prev).add(eventId));
+    },
+    onSettled: (_data, _err, { eventId }) => {
+      setResolvingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(eventId);
+        return next;
+      });
+      void queryClient.invalidateQueries({ queryKey: ["denoiser-review-queue"] });
+    }
+  });
+
+  const visibleEventIndex = useMemo(
+    () =>
+      new Map<string, FireEvent>(
+        visibleEvents
+          .filter((e) => e.event_id != null)
+          .map((e) => [String(e.event_id), e])
+      ),
+    [visibleEvents]
+  );
+
+  const rows = data?.rows ?? [];
+  const count = rows.length;
+
+  function handleResolve(eventId: string, notes: ResolutionNote) {
+    resolveMutation.mutate({ eventId, resolvedBy: "operator", resolvedNotes: notes });
+  }
+
+  return (
+    <Box
+      sx={{
+        bgcolor: "#010409",
+        border: "1px solid rgba(251,146,60,0.2)",
+        borderRadius: 2.5,
+        overflow: "hidden"
+      }}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          px: 2,
+          py: 1.25,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          borderBottom: "1px solid rgba(255,255,255,0.05)"
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <WarningAmberIcon sx={{ fontSize: 15, color: "#fb923c" }} />
+          <Typography
+            sx={{
+              fontSize: 11,
+              fontWeight: 800,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: "#d1d5db"
+            }}
+          >
+            Review Queue
+          </Typography>
+        </Box>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          {isLoading && <CircularProgress size={12} sx={{ color: "#6b7280" }} />}
+          <Chip
+            label={count}
+            size="small"
+            sx={{
+              height: 18,
+              fontSize: 10,
+              fontWeight: 800,
+              bgcolor: count > 0 ? "rgba(251,146,60,0.15)" : "rgba(107,114,128,0.15)",
+              color: count > 0 ? "#fb923c" : "#6b7280",
+              border: count > 0 ? "1px solid rgba(251,146,60,0.3)" : "1px solid rgba(107,114,128,0.2)",
+              "& .MuiChip-label": { px: 0.75 }
+            }}
+          />
+        </Box>
+      </Box>
+
+      {/* Body */}
+      <Box sx={{ maxHeight: 400, overflowY: "auto", p: 1.5 }}>
+        {isError && (
+          <Alert
+            severity="warning"
+            sx={{ fontSize: 11, bgcolor: "transparent", color: "#f97316", "& .MuiAlert-icon": { color: "#f97316" } }}
+          >
+            {error instanceof ApiUnavailableError ? "API unavailable" : "Failed to load review queue"}
+          </Alert>
+        )}
+
+        {!isLoading && !isError && count === 0 && (
+          <Typography sx={{ fontSize: 12, color: "#4b5563", textAlign: "center", py: 2 }}>
+            No flagged detections pending review
+          </Typography>
+        )}
+
+        {count > 0 && (
+          <Stack
+            spacing={1}
+            divider={<Divider sx={{ borderColor: "rgba(255,255,255,0.04)" }} />}
+          >
+            {rows.map((item) => (
+              <ReviewItemRow
+                key={item.event_id}
+                item={item}
+                matchedEvent={visibleEventIndex.get(item.event_id) ?? null}
+                onResolve={handleResolve}
+                isResolving={resolvingIds.has(item.event_id)}
+              />
+            ))}
+          </Stack>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/ui/src/map/layerUtils.ts
+++ b/ui/src/map/layerUtils.ts
@@ -24,7 +24,9 @@ export const FIRE_COLORS = {
   veryLowFill: [253, 224, 71, 180],
   unscoredFill: [128, 128, 128, 150],
   outlineHigh: [255, 107, 53, 200],
-  outlineDefault: [255, 255, 255, 100]
+  outlineDefault: [255, 255, 255, 100],
+  reviewFill: [251, 146, 60, 220],
+  reviewOutline: [253, 186, 116, 255]
 } as const;
 
 export interface RenderEvent extends FireEvent {
@@ -138,8 +140,8 @@ export function toRenderEvent(event: FireEvent): RenderEvent | null {
     return null;
   }
   const severity = eventSeverity(event);
-  const fill = fireFillRgba(severity);
-  const line = fireLineRgba(severity);
+  const fill = event.review_required ? [...FIRE_COLORS.reviewFill] : fireFillRgba(severity);
+  const line = event.review_required ? [...FIRE_COLORS.reviewOutline] : fireLineRgba(severity);
   const detectionCount = safeFloat(event.detection_count);
   return {
     ...event,

--- a/ui/src/tests/review-queue.test.ts
+++ b/ui/src/tests/review-queue.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { FIRE_COLORS, toRenderEvent } from "../map/layerUtils";
+import type { FireEvent } from "../types/api";
+
+describe("review queue visual style", () => {
+  const baseEvent: FireEvent = {
+    event_id: "evt-1",
+    lat: 34.5,
+    lon: -118.2,
+    event_score: 0.9,
+    denoiser_decision: "pass",
+    review_required: false,
+    detection_count: 5
+  };
+
+  it("renders normal high-severity event with red fill", () => {
+    const rendered = toRenderEvent(baseEvent);
+    expect(rendered).not.toBeNull();
+    // High severity → red fill (veryHighFill[0] = 220)
+    expect(rendered!.fill_r).toBe(FIRE_COLORS.veryHighFill[0]);
+    expect(rendered!.review_required).toBe(false);
+  });
+
+  it("renders review_required event with amber fill", () => {
+    const reviewEvent: FireEvent = { ...baseEvent, review_required: true };
+    const rendered = toRenderEvent(reviewEvent);
+    expect(rendered).not.toBeNull();
+    expect(rendered!.fill_r).toBe(FIRE_COLORS.reviewFill[0]);
+    expect(rendered!.fill_g).toBe(FIRE_COLORS.reviewFill[1]);
+    expect(rendered!.fill_b).toBe(FIRE_COLORS.reviewFill[2]);
+  });
+
+  it("renders review_required event with amber outline", () => {
+    const reviewEvent: FireEvent = { ...baseEvent, review_required: true };
+    const rendered = toRenderEvent(reviewEvent);
+    expect(rendered).not.toBeNull();
+    expect(rendered!.line_r).toBe(FIRE_COLORS.reviewOutline[0]);
+    expect(rendered!.line_g).toBe(FIRE_COLORS.reviewOutline[1]);
+    expect(rendered!.line_b).toBe(FIRE_COLORS.reviewOutline[2]);
+  });
+
+  it("review amber fill differs from normal high-severity fill", () => {
+    expect(FIRE_COLORS.reviewFill[0]).not.toBe(FIRE_COLORS.veryHighFill[0]);
+  });
+
+  it("returns null for event missing lat/lon", () => {
+    const noCoords: FireEvent = { event_id: "evt-x", review_required: true };
+    expect(toRenderEvent(noCoords)).toBeNull();
+  });
+
+  it("preserves review_required flag on rendered event", () => {
+    const reviewEvent: FireEvent = { ...baseEvent, review_required: true };
+    const rendered = toRenderEvent(reviewEvent);
+    expect(rendered!.review_required).toBe(true);
+  });
+
+  it("low-severity review event still gets amber color, not severity-based color", () => {
+    const lowReview: FireEvent = {
+      ...baseEvent,
+      event_score: 0.1,
+      review_required: true
+    };
+    const rendered = toRenderEvent(lowReview);
+    expect(rendered).not.toBeNull();
+    // Should be amber, not the low-severity veryLowFill
+    expect(rendered!.fill_r).toBe(FIRE_COLORS.reviewFill[0]);
+    expect(rendered!.fill_r).not.toBe(FIRE_COLORS.veryLowFill[0]);
+  });
+});

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -137,3 +137,36 @@ export interface ActiveModelsResponse {
 export interface RiskFeatureCollection extends FeatureCollection {
   features: Array<Feature<Polygon | MultiPolygon, { risk_score?: number; [key: string]: unknown }>>;
 }
+
+export interface DenoiserReviewPayload {
+  event_score?: number;
+  frp_max?: number;
+  confidence_max?: number;
+  fail_closed_hard_bypass?: boolean;
+}
+
+export interface DenoiserReviewItem {
+  id: number;
+  event_id: string;
+  fire_detection_id?: number | null;
+  reason: string;
+  severity: string;
+  status: string;
+  payload_json?: DenoiserReviewPayload | null;
+  resolved_by?: string | null;
+  resolved_notes?: string | null;
+  resolved_at?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ReviewQueueResponse {
+  as_of: string;
+  rows: DenoiserReviewItem[];
+}
+
+export interface ResolveReviewResponse {
+  as_of: string;
+  event_id: string;
+  updated: number;
+}


### PR DESCRIPTION
## Changes

Add a new **Review Queue Panel** component that allows operators to triage flagged fire detections from the denoiser model.

### New Features
- **ReviewQueuePanel component**: Displays detections flagged for review with real-time polling (15s interval)
- **Resolution actions**: Operators can confirm detections as real fires or mark them as noise/false positives
- **Visual indicators**: Shows FRP (MW), confidence, and event scores for each detection
- **Map integration**: Click-to-focus functionality to view detection location on map
- **Reason tagging**: Displays why each detection was flagged (hard bypass vs uncertainty)

### API Additions
- `getDenoiserReviewQueue()`: Fetch open review items with limit/status filters
- `resolveDenoiserReviewItem()`: Submit operator triage decision (confirmed_fire or marked_noise)

### Type Definitions
- `DenoiserReviewItem`: Review queue item with payload, status, and metadata
- `ReviewQueueResponse`: API response with review items
- `ResolveReviewResponse`: Response from resolution endpoint

### Visual Enhancements
- New amber color scheme for review-required events on map (`reviewFill`, `reviewOutline`)
- Events with `review_required=true` render in amber instead of severity-based colors

### Tests
- Added test suite for review event styling and color rendering
