### PR TITLE
feat(api): replace offset pagination with cursor-based keyset pagination

### DIFF
--- a/api/fires/repo.py
+++ b/api/fires/repo.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import base64
+import json as _json
 import logging
 import os
 import time
 from datetime import datetime, timezone
-from typing import Iterable, Literal, TYPE_CHECKING
+from typing import Callable, Iterable, Literal, TYPE_CHECKING
 
 from sqlalchemy import text, column as sa_column
 
@@ -64,6 +66,56 @@ def validate_bbox(bbox: BBox) -> None:
     if min_lat >= max_lat:
         raise ValueError(f"min_lat ({min_lat}) must be less than max_lat ({max_lat})")
 
+
+def _encode_cursor(**fields: object) -> str:
+    """Encode cursor fields as a URL-safe base64 JSON string."""
+    serialized: dict[str, object] = {}
+    for k, v in fields.items():
+        serialized[k] = v.isoformat() if isinstance(v, datetime) else v
+    return base64.urlsafe_b64encode(_json.dumps(serialized).encode()).decode()
+
+
+def _decode_cursor(cursor: str) -> dict:
+    """Decode a cursor string produced by _encode_cursor.
+
+    Returns a dict with field ``t`` parsed as a timezone-aware datetime (or
+    None) and all other fields left as-is.
+
+    Raises ValueError on malformed input.
+    """
+    try:
+        data = _json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+    except Exception as exc:
+        raise ValueError(f"Invalid cursor: {exc}") from exc
+    if data.get("t") is not None:
+        try:
+            t = datetime.fromisoformat(data["t"])
+            data["t"] = t if t.tzinfo else t.replace(tzinfo=timezone.utc)
+        except Exception as exc:
+            raise ValueError(f"Invalid cursor timestamp: {exc}") from exc
+    return data
+
+
+def _build_page(
+    rows: list,
+    limit: int,
+    cursor_fn: Callable[[dict], str],
+) -> dict:
+    """Trim rows to limit, detect has_more, encode next_cursor, return page dict."""
+    has_more = len(rows) > limit
+    if has_more:
+        rows = rows[:limit]
+    next_cursor: str | None = None
+    if has_more and rows:
+        next_cursor = cursor_fn(dict(rows[-1]))
+    return {
+        "data": [dict(r) for r in rows],
+        "next_cursor": next_cursor,
+        "has_more": has_more,
+        "limit": limit,
+    }
+
+
 # Keep this list tight to avoid SQL injection when constructing SELECT clauses.
 _ALLOWED_COLUMNS: dict[str, str] = {
     "id": "id",
@@ -108,7 +160,8 @@ def list_fire_detections_bbox_time(
     include_masked: bool = False,
     min_confidence: float | None = None,
     min_fire_likelihood: float | None = None,
-    cursor_after_id: int | None = None,
+    cursor: str | None = None,
+    offset: int | None = None,
 ) -> dict:
     """List fire detections in a lon/lat bbox and acquisition time window.
 
@@ -122,7 +175,7 @@ def list_fire_detections_bbox_time(
     - False-source masking: By default, filters out rows where `false_source_masked` is TRUE.
     - Filtering: min_confidence filters FIRMS confidence (0-100), min_fire_likelihood filters
       composite likelihood score (0-1). Both include NULL values (not yet scored).
-    - Pagination: Use cursor_after_id from previous response to fetch next page.
+    - Pagination: Pass next_cursor from a previous response as cursor to get the next page.
       Returns at most `limit` rows per request (default: 1000, max: 10000).
     """
 
@@ -131,6 +184,12 @@ def list_fire_detections_bbox_time(
     cols = list(columns)
     if not cols:
         raise ValueError("columns must be non-empty.")
+
+    # acq_time and id are required for keyset cursor construction; ensure they are
+    # always selected regardless of the caller-supplied column list.
+    for _required in ("id", "acq_time"):
+        if _required not in cols:
+            cols.append(_required)
 
     # Build SELECT clause using SQLAlchemy column objects for safety
     # This avoids SQL injection even if whitelist is bypassed in future
@@ -174,28 +233,45 @@ def list_fire_detections_bbox_time(
         limit = 1000
     if limit <= 0 or limit > 10000:
         raise ValueError("limit must be between 1 and 10000.")
-    
-    limit_sql = "\n        LIMIT :limit"
-    
-    # Cursor-based pagination: fetch rows after a specific ID
-    # This enables efficient pagination for large result sets
-    cursor_predicate = ""
-    if cursor_after_id is not None:
-        if cursor_after_id <= 0:
-            raise ValueError("cursor_after_id must be positive.")
-        cursor_predicate = "AND id > :cursor_after_id"
-    
+
     # Ensure datetimes are timezone-aware (UTC) for database queries
     if start_time.tzinfo is None:
         start_time = start_time.replace(tzinfo=timezone.utc)
     elif start_time.tzinfo != timezone.utc:
         start_time = start_time.astimezone(timezone.utc)
-    
+
     if end_time.tzinfo is None:
         end_time = end_time.replace(tzinfo=timezone.utc)
     elif end_time.tzinfo != timezone.utc:
         end_time = end_time.astimezone(timezone.utc)
-    
+
+    # Cursor-based pagination: keyset on (acq_time, id) for stable, index-friendly pagination.
+    # Cursor encodes {"t": acq_time_iso, "id": int_id}.
+    cursor_acq_time: datetime | None = None
+    cursor_id: int | None = None
+    cursor_predicate = ""
+    if cursor is not None:
+        parsed = _decode_cursor(cursor)
+        cursor_acq_time = parsed["t"]
+        cursor_id = int(parsed["id"])
+        if order == "asc":
+            cursor_predicate = (
+                "AND (acq_time > :cursor_acq_time "
+                "OR (acq_time = :cursor_acq_time AND id > :cursor_id))"
+            )
+        else:
+            cursor_predicate = (
+                "AND (acq_time < :cursor_acq_time "
+                "OR (acq_time = :cursor_acq_time AND id < :cursor_id))"
+            )
+
+    # Deprecated offset path: slow on large tables, kept for backward compatibility.
+    offset_sql = ""
+    if cursor is None and offset is not None:
+        if offset < 0:
+            raise ValueError("offset must be >= 0.")
+        offset_sql = "\n        OFFSET :offset"
+
     params: dict[str, object] = {
         "start_time": start_time,
         "end_time": end_time,
@@ -209,8 +285,11 @@ def list_fire_detections_bbox_time(
         params["min_confidence"] = float(min_confidence)
     if min_fire_likelihood is not None:
         params["min_fire_likelihood"] = float(min_fire_likelihood)
-    if cursor_after_id is not None:
-        params["cursor_after_id"] = int(cursor_after_id)
+    if cursor_acq_time is not None and cursor_id is not None:
+        params["cursor_acq_time"] = cursor_acq_time
+        params["cursor_id"] = cursor_id
+    if cursor is None and offset is not None:
+        params["offset"] = int(offset)
 
     stmt = text(
         f"""
@@ -226,32 +305,18 @@ def list_fire_detections_bbox_time(
           {likelihood_predicate}
           {cursor_predicate}
         ORDER BY acq_time {order}, id {order}
-        {limit_sql}
+        LIMIT :limit{offset_sql}
         """
     )
 
     with get_engine().begin() as conn:
         result = conn.execute(stmt, params)
         rows = result.mappings().all()
-    
-    # Determine if there's a next page and extract the cursor
-    has_more = len(rows) > limit
-    if has_more:
-        # Remove the extra row used for pagination detection
-        rows = rows[:limit]
-    
-    next_cursor = None
-    if has_more and rows:
-        # Use the last row's ID as the next cursor
-        last_row = dict(rows[-1])
-        next_cursor = last_row.get("id")
-    
-    return {
-        "data": [dict(r) for r in rows],
-        "next_cursor": next_cursor,
-        "has_more": has_more,
-        "limit": limit,
-    }
+
+    return _build_page(
+        rows, limit,
+        cursor_fn=lambda r: _encode_cursor(t=r["acq_time"], id=r["id"]),
+    )
 
 
 def update_false_source_masking(batch_id: int, conn: Connection | None = None) -> int:
@@ -726,8 +791,14 @@ def list_fire_events_bbox_time(
     min_event_score: float | None = None,
     include_review_required: bool = True,
     limit: int = 1000,
-) -> list[dict]:
-    """List denoiser events in a bbox/time window."""
+    cursor: str | None = None,
+    offset: int | None = None,
+) -> dict:
+    """List denoiser events in a bbox/time window.
+
+    Returns a dict with keys ``data``, ``next_cursor``, ``has_more``, and ``limit``.
+    Order is COALESCE(start_time, end_time) DESC, event_id DESC.
+    """
     min_lon, min_lat, max_lon, max_lat = bbox
 
     if limit <= 0 or limit > 10000:
@@ -746,6 +817,33 @@ def list_fire_events_bbox_time(
         review_predicate = "AND review_required IS NOT TRUE"
 
     score_predicate = ""
+    # Cursor keyset pagination on (COALESCE(start_time, end_time) DESC, event_id DESC).
+    # Cursor encodes {"t": iso_datetime_or_null, "id": event_id_string}.
+    cursor_predicate = ""
+    if cursor is not None:
+        parsed = _decode_cursor(cursor)
+        cursor_event_time: datetime | None = parsed.get("t")
+        cursor_event_id: str = str(parsed["id"])
+        if cursor_event_time is not None:
+            cursor_predicate = (
+                "AND (COALESCE(start_time, end_time) < :cursor_time "
+                "OR COALESCE(start_time, end_time) IS NULL "
+                "OR (COALESCE(start_time, end_time) = :cursor_time AND event_id < :cursor_id))"
+            )
+        else:
+            # Already in the NULL bucket; only advance by event_id.
+            cursor_predicate = (
+                "AND COALESCE(start_time, end_time) IS NULL "
+                "AND event_id < :cursor_id"
+            )
+
+    # Deprecated offset path.
+    offset_sql = ""
+    if cursor is None and offset is not None:
+        if offset < 0:
+            raise ValueError("offset must be >= 0.")
+        offset_sql = "\n            OFFSET :offset"
+
     params: dict[str, object] = {
         "start_time": start_time,
         "end_time": end_time,
@@ -753,11 +851,17 @@ def list_fire_events_bbox_time(
         "min_lat": float(min_lat),
         "max_lon": float(max_lon),
         "max_lat": float(max_lat),
-        "limit": int(limit),
+        "limit": int(limit) + 1,  # fetch one extra to detect has_more
     }
     if min_event_score is not None:
         score_predicate = "AND (event_score IS NULL OR event_score >= :min_event_score)"
         params["min_event_score"] = float(min_event_score)
+    if cursor is not None:
+        if cursor_event_time is not None:
+            params["cursor_time"] = cursor_event_time
+        params["cursor_id"] = cursor_event_id
+    if cursor is None and offset is not None:
+        params["offset"] = int(offset)
 
     stmt = text(
         f"""
@@ -786,8 +890,9 @@ def list_fire_events_bbox_time(
               AND ST_Intersects(geom, ST_MakeEnvelope(:min_lon, :min_lat, :max_lon, :max_lat, 4326))
               {review_predicate}
               {score_predicate}
+              {cursor_predicate}
             ORDER BY COALESCE(start_time, end_time) DESC, event_id DESC
-            LIMIT :limit
+            LIMIT :limit{offset_sql}
         )
         SELECT
             e.event_id,
@@ -840,7 +945,13 @@ def list_fire_events_bbox_time(
     with get_engine().begin() as conn:
         conn.execute(text("SET LOCAL statement_timeout = '5000ms'"))
         rows = conn.execute(stmt, params).mappings().all()
-    return [dict(r) for r in rows]
+
+    return _build_page(
+        rows, limit,
+        cursor_fn=lambda r: _encode_cursor(
+            t=r.get("start_time") or r.get("end_time"), id=r["event_id"]
+        ),
+    )
 
 
 def list_fire_fronts_bbox_time(
@@ -851,8 +962,14 @@ def list_fire_fronts_bbox_time(
     min_event_score: float | None = None,
     include_review_required: bool = True,
     limit: int = 2000,
-) -> list[dict]:
-    """List denoiser fire fronts in a bbox/time window."""
+    cursor: str | None = None,
+    offset: int | None = None,
+) -> dict:
+    """List denoiser fire fronts in a bbox/time window.
+
+    Returns a dict with keys ``data``, ``next_cursor``, ``has_more``, and ``limit``.
+    Order is COALESCE(overpass_end, overpass_start) DESC NULLS LAST, front_id DESC.
+    """
     min_lon, min_lat, max_lon, max_lat = bbox
 
     if limit <= 0 or limit > 10000:
@@ -872,6 +989,33 @@ def list_fire_fronts_bbox_time(
     if not include_review_required:
         review_predicate = "AND fe.review_required IS NOT TRUE"
 
+    # Cursor keyset pagination on (COALESCE(overpass_end, overpass_start) DESC NULLS LAST, front_id DESC).
+    # Cursor encodes {"t": iso_datetime_or_null, "id": front_id_string}.
+    cursor_predicate = ""
+    if cursor is not None:
+        parsed = _decode_cursor(cursor)
+        cursor_front_time: datetime | None = parsed.get("t")
+        cursor_front_id: str = str(parsed["id"])
+        if cursor_front_time is not None:
+            cursor_predicate = (
+                "AND (COALESCE(overpass_end, overpass_start) < :cursor_time "
+                "OR COALESCE(overpass_end, overpass_start) IS NULL "
+                "OR (COALESCE(overpass_end, overpass_start) = :cursor_time "
+                "AND front_id < :cursor_id))"
+            )
+        else:
+            cursor_predicate = (
+                "AND COALESCE(overpass_end, overpass_start) IS NULL "
+                "AND front_id < :cursor_id"
+            )
+
+    # Deprecated offset path.
+    offset_sql = ""
+    if cursor is None and offset is not None:
+        if offset < 0:
+            raise ValueError("offset must be >= 0.")
+        offset_sql = "\n            OFFSET :offset"
+
     score_predicate = ""
     params: dict[str, object] = {
         "start_time": start_time,
@@ -880,11 +1024,17 @@ def list_fire_fronts_bbox_time(
         "min_lat": float(min_lat),
         "max_lon": float(max_lon),
         "max_lat": float(max_lat),
-        "limit": effective_limit,
+        "limit": effective_limit + 1,  # fetch one extra to detect has_more
     }
     if min_event_score is not None:
         score_predicate = "AND (fe.event_score IS NULL OR fe.event_score >= :min_event_score)"
         params["min_event_score"] = float(min_event_score)
+    if cursor is not None:
+        if cursor_front_time is not None:
+            params["cursor_time"] = cursor_front_time
+        params["cursor_id"] = cursor_front_id
+    if cursor is None and offset is not None:
+        params["offset"] = int(offset)
 
     stmt = text(
         f"""
@@ -969,8 +1119,9 @@ def list_fire_fronts_bbox_time(
                 geom
             FROM ranked_fronts
             WHERE front_rank = 1
+              {cursor_predicate}
             ORDER BY COALESCE(overpass_end, overpass_start) DESC NULLS LAST, front_id DESC
-            LIMIT :limit
+            LIMIT :limit{offset_sql}
         )
         SELECT
             sf.front_id,
@@ -1002,7 +1153,13 @@ def list_fire_fronts_bbox_time(
         # Keep request latency bounded so map interactions do not starve API health checks.
         conn.execute(text("SET LOCAL statement_timeout = '5000ms'"))
         rows = conn.execute(stmt, params).mappings().all()
-    return [dict(r) for r in rows]
+
+    return _build_page(
+        rows, effective_limit,
+        cursor_fn=lambda r: _encode_cursor(
+            t=r.get("overpass_end") or r.get("overpass_start"), id=r["front_id"]
+        ),
+    )
 
 
 def get_fire_front_by_id(

--- a/api/migrations/versions/20260327_add_cursor_pagination_indexes.py
+++ b/api/migrations/versions/20260327_add_cursor_pagination_indexes.py
@@ -1,0 +1,94 @@
+"""Add compound indexes for cursor-based (keyset) pagination on fire endpoints.
+
+Cursor pagination on fire_detections uses ORDER BY acq_time, id.
+A compound index on (acq_time, id) lets PostgreSQL satisfy both the keyset
+predicate and the sort in a single index scan, eliminating sequential scans.
+
+Cursor pagination on fire_events uses ORDER BY COALESCE(start_time, end_time) DESC,
+event_id DESC.  A compound index on (start_time, event_id) supports the common case
+where start_time is non-NULL (covering both sort key and predicate).
+
+Cursor pagination on fire_fronts uses ORDER BY COALESCE(overpass_end, overpass_start)
+DESC NULLS LAST, front_id DESC.  A compound index on (overpass_end, front_id) supports
+the non-NULL case.
+
+EXPLAIN validation queries (run against a populated DB):
+
+  -- Detections forward page:
+  EXPLAIN SELECT id, acq_time FROM fire_detections
+    WHERE acq_time BETWEEN '2026-01-01' AND '2026-01-08'
+      AND (acq_time > '2026-01-03' OR (acq_time = '2026-01-03' AND id > 5000))
+    ORDER BY acq_time ASC, id ASC LIMIT 1001;
+  -- Expected: Index Scan using ix_fire_detections_acq_time_id
+
+  -- Events cursor page:
+  EXPLAIN SELECT event_id, start_time FROM fire_events
+    WHERE start_time <= '2026-01-08' AND end_time >= '2026-01-01'
+      AND (COALESCE(start_time, end_time) < '2026-01-05'
+           OR COALESCE(start_time, end_time) IS NULL
+           OR (COALESCE(start_time, end_time) = '2026-01-05' AND event_id < 'evt_abc'))
+    ORDER BY COALESCE(start_time, end_time) DESC, event_id DESC LIMIT 1001;
+  -- Expected: Index Scan using ix_fire_events_start_time_event_id
+
+  -- Fronts cursor page:
+  EXPLAIN SELECT front_id, overpass_end FROM fire_fronts
+    WHERE (COALESCE(overpass_end, overpass_start) < '2026-01-05'
+           OR COALESCE(overpass_end, overpass_start) IS NULL
+           OR (COALESCE(overpass_end, overpass_start) = '2026-01-05'
+               AND front_id < 'front_xyz'))
+    ORDER BY COALESCE(overpass_end, overpass_start) DESC NULLS LAST, front_id DESC LIMIT 801;
+  -- Expected: Index Scan using ix_fire_fronts_overpass_end_front_id
+
+Revision ID: 20260327_add_cursor_pagination_indexes
+Revises: 20260326_add_lulc_freshness_index
+Create Date: 2026-03-27 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260327_add_cursor_pagination_indexes"
+down_revision: Union[str, Sequence[str], None] = "20260326_add_lulc_freshness_index"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # fire_detections: compound index on (acq_time, id) for cursor keyset scan.
+    # ORDER BY acq_time ASC, id ASC / DESC — both directions covered by this B-tree.
+    op.create_index(
+        "ix_fire_detections_acq_time_id",
+        "fire_detections",
+        ["acq_time", "id"],
+    )
+
+    # fire_events: compound index on (start_time, event_id) to support the common
+    # (non-NULL start_time) cursor predicate and ORDER BY COALESCE(start_time, end_time).
+    op.create_index(
+        "ix_fire_events_start_time_event_id",
+        "fire_events",
+        ["start_time", "event_id"],
+        postgresql_ops={"start_time": "DESC", "event_id": "DESC"},
+    )
+
+    # fire_fronts: compound index on (overpass_end DESC NULLS LAST, front_id DESC) to support
+    # cursor predicate and ORDER BY COALESCE(overpass_end, overpass_start) DESC NULLS LAST.
+    # Raw SQL is used here because Alembic's create_index does not support NULLS LAST
+    # expressions in the columns list.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_fire_fronts_overpass_end_front_id "
+        "ON fire_fronts (overpass_end DESC NULLS LAST, front_id DESC)"
+    )
+
+    op.execute("ANALYZE fire_detections")
+    op.execute("ANALYZE fire_events")
+    op.execute("ANALYZE fire_fronts")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_fire_fronts_overpass_end_front_id")
+    op.drop_index("ix_fire_events_start_time_event_id", table_name="fire_events")
+    op.drop_index("ix_fire_detections_acq_time_id", table_name="fire_detections")

--- a/api/routes/fires.py
+++ b/api/routes/fires.py
@@ -60,6 +60,8 @@ def _list_detections(
     include_masked: bool,
     include_denoiser_fields: bool,
     limit: Optional[int],
+    cursor: Optional[str],
+    offset: Optional[int],
 ):
     # Validate bbox coordinates
     try:
@@ -71,20 +73,29 @@ def _list_detections(
     if include_denoiser_fields:
         columns.extend(FIRE_DETECTION_DENOISER_COLUMNS)
 
-    result = list_fire_detections_bbox_time(
-        bbox=(min_lon, min_lat, max_lon, max_lat),
-        start_time=start_time,
-        end_time=end_time,
-        columns=columns,
-        include_noise=include_noise,
-        include_masked=include_masked,
-        limit=limit,
-        min_confidence=min_confidence,
-        min_fire_likelihood=min_fire_likelihood,
-    )
-    detections = result["data"]
+    try:
+        result = list_fire_detections_bbox_time(
+            bbox=(min_lon, min_lat, max_lon, max_lat),
+            start_time=start_time,
+            end_time=end_time,
+            columns=columns,
+            include_noise=include_noise,
+            include_masked=include_masked,
+            limit=limit,
+            min_confidence=min_confidence,
+            min_fire_likelihood=min_fire_likelihood,
+            cursor=cursor,
+            offset=offset,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
-    return {"count": len(detections), "detections": detections}
+    return {
+        "count": len(result["data"]),
+        "detections": result["data"],
+        "next_cursor": result["next_cursor"],
+        "has_more": result["has_more"],
+    }
 
 
 @fires_router.get("", dependencies=[Depends(RateLimiter(times=30, seconds=60)), Depends(cache_60)])
@@ -103,6 +114,8 @@ async def get_fires(
         False, description="Include denoised_score and is_noise in response."
     ),
     limit: Optional[int] = Query(None, gt=0, le=10000),
+    cursor: Optional[str] = Query(None, description="Opaque pagination cursor from a previous response's next_cursor field."),
+    offset: Optional[int] = Query(None, ge=0, description="(Deprecated) Row offset for pagination. Use cursor instead."),
 ):
     """Alias for `/fires/detections` (kept for UI/backward compatibility)."""
     return _list_detections(
@@ -118,6 +131,8 @@ async def get_fires(
         limit=limit,
         min_confidence=min_confidence,
         min_fire_likelihood=min_fire_likelihood,
+        cursor=cursor,
+        offset=offset,
     )
 
 
@@ -137,10 +152,16 @@ async def get_detections(
         False, description="Include denoised_score and is_noise in response."
     ),
     limit: Optional[int] = Query(None, gt=0, le=10000),
+    cursor: Optional[str] = Query(None, description="Opaque pagination cursor from a previous response's next_cursor field."),
+    offset: Optional[int] = Query(None, ge=0, description="(Deprecated) Row offset for pagination. Use cursor instead."),
 ):
     """
     Get raw fire detections within a spatio-temporal window.
-    
+
+    Supports cursor-based pagination via the ``cursor`` param (pass the
+    ``next_cursor`` value from the previous response). The legacy ``offset``
+    param is still accepted but performs a sequential scan — prefer ``cursor``.
+
     By default, only non-noise detections (or those not yet scored) are returned.
     """
     return _list_detections(
@@ -156,6 +177,8 @@ async def get_detections(
         limit=limit,
         min_confidence=min_confidence,
         min_fire_likelihood=min_fire_likelihood,
+        cursor=cursor,
+        offset=offset,
     )
 
 
@@ -175,6 +198,8 @@ async def get_events(
         description="Include events currently marked as requiring review.",
     ),
     limit: Optional[int] = Query(1000, gt=0, le=10000),
+    cursor: Optional[str] = Query(None, description="Opaque pagination cursor from a previous response's next_cursor field."),
+    offset: Optional[int] = Query(None, ge=0, description="(Deprecated) Row offset for pagination. Use cursor instead."),
 ):
     """Get fire events within a spatio-temporal window."""
     try:
@@ -182,15 +207,26 @@ async def get_events(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    events = list_fire_events_bbox_time(
-        bbox=(min_lon, min_lat, max_lon, max_lat),
-        start_time=start_time,
-        end_time=end_time,
-        min_event_score=min_event_score,
-        include_review_required=include_review_required,
-        limit=int(limit or 1000),
-    )
-    return {"count": len(events), "events": events}
+    try:
+        result = list_fire_events_bbox_time(
+            bbox=(min_lon, min_lat, max_lon, max_lat),
+            start_time=start_time,
+            end_time=end_time,
+            min_event_score=min_event_score,
+            include_review_required=include_review_required,
+            limit=int(limit or 1000),
+            cursor=cursor,
+            offset=offset,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return {
+        "count": len(result["data"]),
+        "events": result["data"],
+        "next_cursor": result["next_cursor"],
+        "has_more": result["has_more"],
+    }
 
 
 @fires_router.get("/fronts", dependencies=[Depends(RateLimiter(times=30, seconds=60)), Depends(cache_60)])
@@ -209,6 +245,8 @@ async def get_fronts(
         description="Include fronts linked to events currently marked as requiring review.",
     ),
     limit: Optional[int] = Query(2000, gt=0, le=10000),
+    cursor: Optional[str] = Query(None, description="Opaque pagination cursor from a previous response's next_cursor field."),
+    offset: Optional[int] = Query(None, ge=0, description="(Deprecated) Row offset for pagination. Use cursor instead."),
 ):
     """Get fire fronts within a spatio-temporal window."""
     try:
@@ -216,15 +254,26 @@ async def get_fronts(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
-    fronts = list_fire_fronts_bbox_time(
-        bbox=(min_lon, min_lat, max_lon, max_lat),
-        start_time=start_time,
-        end_time=end_time,
-        min_event_score=min_event_score,
-        include_review_required=include_review_required,
-        limit=int(limit or 2000),
-    )
-    return {"count": len(fronts), "fronts": fronts}
+    try:
+        result = list_fire_fronts_bbox_time(
+            bbox=(min_lon, min_lat, max_lon, max_lat),
+            start_time=start_time,
+            end_time=end_time,
+            min_event_score=min_event_score,
+            include_review_required=include_review_required,
+            limit=int(limit or 2000),
+            cursor=cursor,
+            offset=offset,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return {
+        "count": len(result["data"]),
+        "fronts": result["data"],
+        "next_cursor": result["next_cursor"],
+        "has_more": result["has_more"],
+    }
 
 
 @fires_router.get("/reverse-geocode", dependencies=[Depends(RateLimiter(times=120, seconds=60))])

--- a/api/tests/test_fire_repo_denoiser_filter.py
+++ b/api/tests/test_fire_repo_denoiser_filter.py
@@ -122,7 +122,8 @@ def test_list_fire_fronts_bbox_time_uses_authoritative_event_links(monkeypatch):
     assert "ff.authoritative_perimeter_id" in sql
     assert executed_params is not None
     assert executed_params["min_event_score"] == 0.6
-    assert executed_params["limit"] == 400
+    # limit is sent as limit+1 to detect has_more; effective_limit caps fronts at 800
+    assert executed_params["limit"] == 401
 
 
 def test_list_fire_events_bbox_time_selects_geom_provenance_fields(monkeypatch):
@@ -171,4 +172,5 @@ def test_list_fire_events_bbox_time_selects_geom_provenance_fields(monkeypatch):
     assert "authoritative_perimeter_id" in sql
     assert executed_params is not None
     assert executed_params["min_event_score"] == 0.5
-    assert executed_params["limit"] == 250
+    # limit is sent as limit+1 to detect has_more
+    assert executed_params["limit"] == 251

--- a/api/tests/test_fires_endpoint.py
+++ b/api/tests/test_fires_endpoint.py
@@ -132,7 +132,7 @@ def test_get_detections_endpoint_with_include_noise(monkeypatch):
 
 def test_get_events_endpoint(monkeypatch):
     """Test that /fires/events delegates to list_fire_events_bbox_time."""
-    mock_events = MagicMock(return_value=[{"event_id": "evt_1", "event_score": 0.95}])
+    mock_events = MagicMock(return_value={"data": [{"event_id": "evt_1", "event_score": 0.95}], "next_cursor": None, "has_more": False, "limit": 1000})
     monkeypatch.setattr(fires, "list_fire_events_bbox_time", mock_events)
 
     response = client.get(
@@ -153,6 +153,8 @@ def test_get_events_endpoint(monkeypatch):
     payload = response.json()
     assert payload["count"] == 1
     assert payload["events"][0]["event_id"] == "evt_1"
+    assert payload["next_cursor"] is None
+    assert payload["has_more"] is False
 
     _, kwargs = mock_events.call_args
     assert kwargs["min_event_score"] == 0.5
@@ -162,13 +164,13 @@ def test_get_events_endpoint(monkeypatch):
 def test_get_events_endpoint_passthrough_geom_geojson(monkeypatch):
     """Test that /fires/events returns event geometry payload when provided by repo."""
     mock_events = MagicMock(
-        return_value=[
+        return_value={"data": [
             {
                 "event_id": "evt_geom_1",
                 "event_score": 0.93,
                 "geom_geojson": '{"type":"MultiPolygon","coordinates":[]}',
             }
-        ]
+        ], "next_cursor": None, "has_more": False, "limit": 1000}
     )
     monkeypatch.setattr(fires, "list_fire_events_bbox_time", mock_events)
 
@@ -194,7 +196,7 @@ def test_get_events_endpoint_passthrough_geom_geojson(monkeypatch):
 def test_get_events_endpoint_passthrough_geom_provenance(monkeypatch):
     """Test that /fires/events preserves geometry provenance fields from repo."""
     mock_events = MagicMock(
-        return_value=[
+        return_value={"data": [
             {
                 "event_id": "evt_geom_2",
                 "geom_source": "estimated",
@@ -203,7 +205,7 @@ def test_get_events_endpoint_passthrough_geom_provenance(monkeypatch):
                 "authority_profile": None,
                 "authoritative_perimeter_id": None,
             }
-        ]
+        ], "next_cursor": None, "has_more": False, "limit": 1000}
     )
     monkeypatch.setattr(fires, "list_fire_events_bbox_time", mock_events)
 
@@ -232,7 +234,7 @@ def test_get_events_endpoint_passthrough_geom_provenance(monkeypatch):
 
 def test_get_fronts_endpoint(monkeypatch):
     """Test that /fires/fronts delegates to list_fire_fronts_bbox_time."""
-    mock_fronts = MagicMock(return_value=[{"front_id": "front_1", "event_id": "evt_1"}])
+    mock_fronts = MagicMock(return_value={"data": [{"front_id": "front_1", "event_id": "evt_1"}], "next_cursor": None, "has_more": False, "limit": 800})
     monkeypatch.setattr(fires, "list_fire_fronts_bbox_time", mock_fronts)
 
     response = client.get(
@@ -253,6 +255,8 @@ def test_get_fronts_endpoint(monkeypatch):
     payload = response.json()
     assert payload["count"] == 1
     assert payload["fronts"][0]["front_id"] == "front_1"
+    assert payload["next_cursor"] is None
+    assert payload["has_more"] is False
 
     _, kwargs = mock_fronts.call_args
     assert kwargs["min_event_score"] == 0.5
@@ -262,7 +266,7 @@ def test_get_fronts_endpoint(monkeypatch):
 def test_get_fronts_endpoint_passthrough_geom_provenance(monkeypatch):
     """Test that /fires/fronts preserves geometry provenance fields from repo."""
     mock_fronts = MagicMock(
-        return_value=[
+        return_value={"data": [
             {
                 "front_id": "front_geom_1",
                 "event_id": "evt_geom_2",
@@ -272,7 +276,7 @@ def test_get_fronts_endpoint_passthrough_geom_provenance(monkeypatch):
                 "authority_profile": "wfigs_us",
                 "authoritative_perimeter_id": 12345,
             }
-        ]
+        ], "next_cursor": None, "has_more": False, "limit": 800}
     )
     monkeypatch.setattr(fires, "list_fire_fronts_bbox_time", mock_fronts)
 
@@ -374,3 +378,165 @@ def test_get_reverse_geocode_endpoint_bad_request(monkeypatch):
     )
 
     assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Cursor pagination tests
+# ---------------------------------------------------------------------------
+
+_BASE_PARAMS = {
+    "min_lon": 20.0,
+    "min_lat": 40.0,
+    "max_lon": 22.0,
+    "max_lat": 43.0,
+    "start_time": "2025-01-01T00:00:00Z",
+    "end_time": "2025-01-02T00:00:00Z",
+}
+
+
+def test_detections_response_includes_pagination_fields(monkeypatch):
+    """Response must include next_cursor and has_more even when empty."""
+    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
+    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+
+    response = client.get("/fires/detections", params=_BASE_PARAMS)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "next_cursor" in payload
+    assert "has_more" in payload
+    assert payload["next_cursor"] is None
+    assert payload["has_more"] is False
+
+
+def test_detections_cursor_param_forwarded_to_repo(monkeypatch):
+    """cursor query param must be forwarded to list_fire_detections_bbox_time."""
+    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
+    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+
+    client.get("/fires/detections", params={**_BASE_PARAMS, "cursor": "abc123"})
+
+    _, kwargs = mock_list.call_args
+    assert kwargs["cursor"] == "abc123"
+
+
+def test_detections_offset_param_forwarded_to_repo(monkeypatch):
+    """Deprecated offset query param must be forwarded to repo."""
+    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
+    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+
+    client.get("/fires/detections", params={**_BASE_PARAMS, "offset": 500})
+
+    _, kwargs = mock_list.call_args
+    assert kwargs["offset"] == 500
+
+
+def test_detections_response_has_more_true(monkeypatch):
+    """When repo signals has_more=True, next_cursor must be non-None in the response."""
+    mock_list = MagicMock(return_value={
+        "data": [{"id": 42, "lat": 41.0, "lon": 21.0}],
+        "next_cursor": "dGVzdGN1cnNvcg==",
+        "has_more": True,
+        "limit": 1000,
+    })
+    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+
+    response = client.get("/fires/detections", params=_BASE_PARAMS)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["has_more"] is True
+    assert payload["next_cursor"] == "dGVzdGN1cnNvcg=="
+
+
+def test_detections_invalid_cursor_returns_400(monkeypatch):
+    """A malformed cursor must produce HTTP 400."""
+    monkeypatch.setattr(
+        fires,
+        "list_fire_detections_bbox_time",
+        MagicMock(side_effect=ValueError("Invalid cursor: ...")),
+    )
+
+    response = client.get("/fires/detections", params={**_BASE_PARAMS, "cursor": "!!!notvalid!!!"})
+
+    assert response.status_code == 400
+
+
+def test_events_cursor_param_forwarded_to_repo(monkeypatch):
+    """cursor query param on /fires/events must be forwarded to repo."""
+    mock_events = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
+    monkeypatch.setattr(fires, "list_fire_events_bbox_time", mock_events)
+
+    client.get("/fires/events", params={**_BASE_PARAMS, "cursor": "evtcursor"})
+
+    _, kwargs = mock_events.call_args
+    assert kwargs["cursor"] == "evtcursor"
+
+
+def test_events_offset_param_forwarded_to_repo(monkeypatch):
+    """Deprecated offset query param on /fires/events must be forwarded to repo."""
+    mock_events = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
+    monkeypatch.setattr(fires, "list_fire_events_bbox_time", mock_events)
+
+    client.get("/fires/events", params={**_BASE_PARAMS, "offset": 200})
+
+    _, kwargs = mock_events.call_args
+    assert kwargs["offset"] == 200
+
+
+def test_events_response_has_more_true(monkeypatch):
+    """When repo signals has_more=True, next_cursor must appear in events response."""
+    mock_events = MagicMock(return_value={
+        "data": [{"event_id": "evt_x"}],
+        "next_cursor": "ZXZ0Y3Vyc29y",
+        "has_more": True,
+        "limit": 1000,
+    })
+    monkeypatch.setattr(fires, "list_fire_events_bbox_time", mock_events)
+
+    response = client.get("/fires/events", params=_BASE_PARAMS)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["has_more"] is True
+    assert payload["next_cursor"] == "ZXZ0Y3Vyc29y"
+
+
+def test_fronts_cursor_param_forwarded_to_repo(monkeypatch):
+    """cursor query param on /fires/fronts must be forwarded to repo."""
+    mock_fronts = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 800})
+    monkeypatch.setattr(fires, "list_fire_fronts_bbox_time", mock_fronts)
+
+    client.get("/fires/fronts", params={**_BASE_PARAMS, "cursor": "frontcursor"})
+
+    _, kwargs = mock_fronts.call_args
+    assert kwargs["cursor"] == "frontcursor"
+
+
+def test_fronts_offset_param_forwarded_to_repo(monkeypatch):
+    """Deprecated offset query param on /fires/fronts must be forwarded to repo."""
+    mock_fronts = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 800})
+    monkeypatch.setattr(fires, "list_fire_fronts_bbox_time", mock_fronts)
+
+    client.get("/fires/fronts", params={**_BASE_PARAMS, "offset": 100})
+
+    _, kwargs = mock_fronts.call_args
+    assert kwargs["offset"] == 100
+
+
+def test_fronts_response_has_more_true(monkeypatch):
+    """When repo signals has_more=True, next_cursor must appear in fronts response."""
+    mock_fronts = MagicMock(return_value={
+        "data": [{"front_id": "front_z"}],
+        "next_cursor": "ZnJvbnRjdXJzb3I=",
+        "has_more": True,
+        "limit": 800,
+    })
+    monkeypatch.setattr(fires, "list_fire_fronts_bbox_time", mock_fronts)
+
+    response = client.get("/fires/fronts", params=_BASE_PARAMS)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["has_more"] is True
+    assert payload["next_cursor"] == "ZnJvbnRjdXJzb3I="


### PR DESCRIPTION
## Summary
Replaces offset-based pagination with cursor-based keyset pagination on fire API endpoints (`/fires/detections`, `/fires/events`, `/fires/fronts`). Cursor pagination is more efficient for large result sets and provides stable iteration.

## Changes

### Core Pagination Logic (`api/fires/repo.py`)
- Added `_encode_cursor()` and `_decode_cursor()` utilities for base64-JSON cursor serialization
- Added `_build_page()` helper to trim results, detect `has_more`, and encode `next_cursor`
- Updated `list_fire_detections_bbox_time()` to use keyset pagination on `(acq_time, id)`
- Updated `list_fire_events_bbox_time()` to use keyset pagination on `(COALESCE(start_time, end_time), event_id)`
- Updated `list_fire_fronts_bbox_time()` to use keyset pagination on `(COALESCE(overpass_end, overpass_start), front_id)`
- All three functions now return a dict with `data`, `next_cursor`, `has_more`, and `limit` keys
- Legacy `offset` parameter kept for backward compatibility (triggers sequential scan)

### API Routes (`api/routes/fires.py`)
- Added `cursor` and `offset` query parameters to `/fires`, `/fires/detections`, `/fires/events`, `/fires/fronts`
- All endpoints now return `next_cursor` and `has_more` in response
- Added HTTPException handling for invalid cursor values (400 status)

### Database Indexes (`api/migrations/versions/20260327_add_cursor_pagination_indexes.py`)
- New compound indexes to support keyset predicate and sort order in single index scan:
  - `ix_fire_detections_acq_time_id` on `(acq_time, id)`
  - `ix_fire_events_start_time_event_id` on `(start_time DESC, event_id DESC)`
  - `ix_fire_fronts_overpass_end_front_id` on `(overpass_end DESC NULLS LAST, front_id DESC)`

### Tests (`api/tests/test_fires_endpoint.py`)
- Updated existing mocks to return new dict format with pagination fields
- Added comprehensive cursor pagination tests covering:
  - Pagination field presence in responses
  - Cursor parameter forwarding and handling
  - Invalid cursor error handling
  - `has_more=True` scenarios across all endpoints
- Updated denoiser filter tests to account for `limit+1` fetching strategy

## Migration Impact
The migration auto-analyzes tables after index creation. Existing `offset`-based queries continue to work but will not benefit from the new indexes.