### PR TITLE
feat(ops): add async webhook + email notification system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -180,3 +180,20 @@ DENOISER_MODEL_RUN_DIR=             # e.g. /app/models/denoiser/run_001
 # Cleanup / retention
 # RETENTION_DAYS=14                  # NRT fire_detections retention (default: 14)
 # ARCHIVE_RETENTION_DAYS=3           # Archive-ingested fire_detections retention (default: 3)
+
+# =============================================================================
+# Optional: Operational Notifications (webhook + email)
+# =============================================================================
+# Webhook (Slack / Discord incoming webhook — leave unset to disable):
+# NOTIFICATION_WEBHOOK_URL=https://hooks.slack.com/services/...
+#
+# Email (all three vars required to enable email alerts):
+# NOTIFICATION_EMAIL_TO=ops@example.com
+# NOTIFICATION_SMTP_HOST=smtp.example.com
+# NOTIFICATION_SMTP_PORT=587
+# NOTIFICATION_SMTP_USER=alerts@example.com
+# NOTIFICATION_SMTP_PASSWORD=secret
+# NOTIFICATION_EMAIL_FROM=wildfire-nowcast@example.com
+#
+# Rate limiting (default: 900 s = 15 min per event type):
+# NOTIFICATION_RATE_LIMIT_SECONDS=900

--- a/api/model_registry.py
+++ b/api/model_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from datetime import datetime, timezone
 from typing import Any
@@ -15,6 +16,36 @@ from sqlalchemy.exc import SQLAlchemyError
 from api.db import get_engine
 
 MODEL_FAMILIES = {"denoiser", "spread"}
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _notify_model_event(
+    action: str,
+    family: str,
+    model_id: str,
+    promoted_by: str | None,
+    notes: str | None,
+) -> None:
+    try:
+        from api.notifications import notify  # noqa: PLC0415
+
+        severity = "warning" if action == "rollback" else "info"
+        body_parts = [f"model_id={model_id}", f"by={promoted_by or 'unknown'}"]
+        if notes:
+            body_parts.append(notes.rstrip("."))
+        notify(
+            f"model_{action}:{family}",
+            title=f"Model {action}: {family}",
+            body=". ".join(body_parts) + ".",
+            severity=severity,
+            family=family,
+            model_id=model_id,
+            action=action,
+            promoted_by=promoted_by or "unknown",
+        )
+    except Exception:
+        LOGGER.debug("Failed to send model-%s notification for family=%s", action, family)
 
 
 def _utc_now() -> datetime:
@@ -193,6 +224,7 @@ def promote_model(
     promoted_by: str | None = None,
     notes: str | None = None,
     engine: Engine | None = None,
+    _notify: bool = True,
 ) -> dict[str, Any]:
     """Promote a registered model to active champion for its family."""
     family_norm = _normalize_family(family)
@@ -292,6 +324,8 @@ def promote_model(
     active = resolve_active_model(family_norm, engine=db)
     if active is None:
         raise RuntimeError(f"Promotion failed to resolve active model for family={family_norm}")
+    if _notify:
+        _notify_model_event("promoted", family_norm, model_id, promoted_by, notes)
     return active
 
 
@@ -327,12 +361,14 @@ def rollback_model(
     if not merged_notes:
         merged_notes = "rollback"
 
+    _notify_model_event("rollback", family_norm, str(rollback_model_id), promoted_by, merged_notes)
     return promote_model(
         family=family_norm,
         model_id=str(rollback_model_id),
         promoted_by=promoted_by,
         notes=merged_notes,
         engine=db,
+        _notify=False,
     )
 
 

--- a/api/notifications.py
+++ b/api/notifications.py
@@ -1,0 +1,193 @@
+"""Lightweight operational notification client.
+
+Delivers alerts via webhook (Slack/Discord-compatible) and optional SMTP email.
+All sends are fire-and-forget — never blocks the caller.
+Rate-limited to at most one notification per event_type per window (default 900 s / 15 min).
+Silently no-ops when no channel is configured.
+
+Environment variables:
+    NOTIFICATION_WEBHOOK_URL          Slack/Discord-compatible incoming webhook URL.
+    NOTIFICATION_EMAIL_TO             Recipient address for email alerts.
+    NOTIFICATION_SMTP_HOST            SMTP server hostname (required for email).
+    NOTIFICATION_SMTP_PORT            SMTP port (default: 587).
+    NOTIFICATION_SMTP_USER            SMTP username (optional).
+    NOTIFICATION_SMTP_PASSWORD        SMTP password (optional).
+    NOTIFICATION_EMAIL_FROM           Sender address (default: wildfire-nowcast@localhost).
+    NOTIFICATION_RATE_LIMIT_SECONDS   Per-event rate-limit window in seconds (default: 900).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import smtplib
+import threading
+import time
+from email.message import EmailMessage
+from typing import Any, Literal
+
+import httpx
+
+LOGGER = logging.getLogger(__name__)
+
+_rate_limit_lock = threading.Lock()
+_last_sent: dict[str, float] = {}
+
+
+def _rate_limit_seconds() -> int:
+    return int(os.getenv("NOTIFICATION_RATE_LIMIT_SECONDS", "900"))
+
+
+def _is_rate_limited(event_type: str) -> bool:
+    """Return True if event_type was sent within the rate-limit window. Thread-safe."""
+    now = time.monotonic()
+    window = _rate_limit_seconds()
+    with _rate_limit_lock:
+        last = _last_sent.get(event_type, 0.0)
+        if now - last < window:
+            return True
+        _last_sent[event_type] = now
+        return False
+
+
+def _build_webhook_payload(
+    event_type: str,
+    title: str,
+    body: str,
+    severity: Literal["info", "warning", "critical"],
+    context: dict[str, Any],
+) -> dict[str, Any]:
+    color = {"info": "#36a64f", "warning": "#ff9800", "critical": "#e53935"}.get(severity, "#888888")
+    fields = [{"title": k, "value": str(v), "short": True} for k, v in context.items()]
+    return {
+        "attachments": [
+            {
+                "color": color,
+                "title": f"[{severity.upper()}] {title}",
+                "text": body,
+                "fields": fields,
+                "footer": "wildfire-nowcast",
+                "ts": int(time.time()),
+            }
+        ]
+    }
+
+
+async def _post_webhook(url: str, payload: dict[str, Any]) -> None:
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(url, json=payload)
+        resp.raise_for_status()
+
+
+def _send_email_blocking(
+    smtp_host: str,
+    smtp_port: int,
+    smtp_user: str | None,
+    smtp_password: str | None,
+    from_addr: str,
+    to_addr: str,
+    subject: str,
+    body: str,
+) -> None:
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = from_addr
+    msg["To"] = to_addr
+    msg.set_content(body)
+    with smtplib.SMTP(smtp_host, smtp_port, timeout=15) as smtp:
+        smtp.ehlo()
+        if smtp.has_extn("STARTTLS"):
+            smtp.starttls()
+            smtp.ehlo()
+        if smtp_user and smtp_password:
+            smtp.login(smtp_user, smtp_password)
+        smtp.send_message(msg)
+
+
+async def _dispatch(
+    event_type: str,
+    title: str,
+    body: str,
+    severity: Literal["info", "warning", "critical"],
+    context: dict[str, Any],
+    webhook_url: str,
+    email_to: str,
+    smtp_host: str,
+) -> None:
+    if webhook_url:
+        try:
+            payload = _build_webhook_payload(event_type, title, body, severity, context)
+            await _post_webhook(webhook_url, payload)
+        except Exception:
+            LOGGER.exception("Webhook notification failed (non-fatal): event_type=%s", event_type)
+
+    if email_to and smtp_host:
+        try:
+            smtp_port = int(os.getenv("NOTIFICATION_SMTP_PORT", "587"))
+            smtp_user = os.getenv("NOTIFICATION_SMTP_USER") or None
+            smtp_password = os.getenv("NOTIFICATION_SMTP_PASSWORD") or None
+            from_addr = os.getenv("NOTIFICATION_EMAIL_FROM", "wildfire-nowcast@localhost").strip()
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(
+                None,
+                lambda: _send_email_blocking(
+                    smtp_host=smtp_host,
+                    smtp_port=smtp_port,
+                    smtp_user=smtp_user,
+                    smtp_password=smtp_password,
+                    from_addr=from_addr,
+                    to_addr=email_to,
+                    subject=f"[{severity.upper()}] {title}",
+                    body=body,
+                ),
+            )
+        except Exception:
+            LOGGER.exception("Email notification failed (non-fatal): event_type=%s", event_type)
+
+
+def notify(
+    event_type: str,
+    title: str,
+    body: str,
+    severity: Literal["info", "warning", "critical"] = "info",
+    **context: Any,
+) -> None:
+    """Fire-and-forget operational notification. Never blocks the caller.
+
+    Args:
+        event_type: Stable identifier used for rate limiting, e.g. ``"ingest_job_failed:firms"``.
+        title:      Short human-readable summary (shown as attachment title).
+        body:       Longer description (shown as attachment text).
+        severity:   ``"info"`` | ``"warning"`` | ``"critical"`` — controls colour coding.
+        **context:  Arbitrary key=value pairs rendered as fields in the notification.
+
+    Silently no-ops when ``NOTIFICATION_WEBHOOK_URL`` is unset and no email is configured.
+    Rate-limited: at most one notification per *event_type* per ``NOTIFICATION_RATE_LIMIT_SECONDS``
+    (default 900 s / 15 min).
+    """
+    webhook_url = os.getenv("NOTIFICATION_WEBHOOK_URL", "").strip()
+    email_to = os.getenv("NOTIFICATION_EMAIL_TO", "").strip()
+    smtp_host = os.getenv("NOTIFICATION_SMTP_HOST", "").strip()
+
+    if not webhook_url and not (email_to and smtp_host):
+        return  # No channel configured — silent no-op
+
+    if _is_rate_limited(event_type):
+        LOGGER.debug("Notification suppressed by rate limit: %s", event_type)
+        return
+
+    async def _run() -> None:
+        await _dispatch(
+            event_type, title, body, severity, dict(context),
+            webhook_url=webhook_url, email_to=email_to, smtp_host=smtp_host,
+        )
+
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(_run())
+    except RuntimeError:
+        # No running event loop (sync caller) — dispatch in a daemon thread.
+        def _thread() -> None:
+            asyncio.run(_run())
+
+        threading.Thread(target=_thread, daemon=True).start()

--- a/api/tests/test_notifications.py
+++ b/api/tests/test_notifications.py
@@ -1,0 +1,191 @@
+"""Tests for api/notifications.py — webhook format, rate limiting, graceful degradation."""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import unittest
+from unittest.mock import AsyncMock, patch
+
+import api.notifications as notif
+from api.notifications import (
+    _build_webhook_payload,
+    _dispatch,
+    _is_rate_limited,
+    _last_sent,
+    notify,
+)
+
+
+class TestWebhookPayload(unittest.TestCase):
+    """_build_webhook_payload produces a Slack-compatible attachment payload."""
+
+    def test_critical_color_and_title(self):
+        payload = _build_webhook_payload("ev", "My Title", "My body", "critical", {})
+        att = payload["attachments"][0]
+        self.assertEqual(att["color"], "#e53935")
+        self.assertIn("[CRITICAL]", att["title"])
+        self.assertIn("My Title", att["title"])
+
+    def test_warning_color(self):
+        att = _build_webhook_payload("ev", "t", "b", "warning", {})["attachments"][0]
+        self.assertEqual(att["color"], "#ff9800")
+
+    def test_info_color(self):
+        att = _build_webhook_payload("ev", "t", "b", "info", {})["attachments"][0]
+        self.assertEqual(att["color"], "#36a64f")
+
+    def test_unknown_severity_fallback_color(self):
+        att = _build_webhook_payload("ev", "t", "b", "debug", {})["attachments"][0]
+        self.assertEqual(att["color"], "#888888")
+
+    def test_body_in_text_field(self):
+        att = _build_webhook_payload("ev", "t", "my body text", "info", {})["attachments"][0]
+        self.assertEqual(att["text"], "my body text")
+
+    def test_footer(self):
+        att = _build_webhook_payload("ev", "t", "b", "info", {})["attachments"][0]
+        self.assertEqual(att["footer"], "wildfire-nowcast")
+
+    def test_context_becomes_fields(self):
+        payload = _build_webhook_payload("ev", "t", "b", "critical", {"job": "firms", "code": 1})
+        fields = {f["title"]: f["value"] for f in payload["attachments"][0]["fields"]}
+        self.assertEqual(fields["job"], "firms")
+        self.assertEqual(fields["code"], "1")  # values are str-coerced
+
+    def test_empty_context_no_fields(self):
+        att = _build_webhook_payload("ev", "t", "b", "info", {})["attachments"][0]
+        self.assertEqual(att["fields"], [])
+
+    def test_ts_is_integer(self):
+        att = _build_webhook_payload("ev", "t", "b", "info", {})["attachments"][0]
+        self.assertIsInstance(att["ts"], int)
+
+
+class TestRateLimiting(unittest.TestCase):
+    def setUp(self):
+        _last_sent.clear()
+
+    def test_first_call_allowed(self):
+        self.assertFalse(_is_rate_limited("event_first"))
+
+    def test_second_call_within_window_blocked(self):
+        _is_rate_limited("event_double")
+        self.assertTrue(_is_rate_limited("event_double"))
+
+    def test_different_events_independent(self):
+        _is_rate_limited("event_x")
+        self.assertFalse(_is_rate_limited("event_y"))
+
+    def test_rate_limit_respects_env_window(self):
+        """With a 0-second window every call is allowed."""
+        _last_sent.clear()
+        with patch.dict(os.environ, {"NOTIFICATION_RATE_LIMIT_SECONDS": "0"}):
+            _is_rate_limited("ev_zero")
+            # Should NOT be rate-limited because window=0
+            self.assertFalse(_is_rate_limited("ev_zero"))
+
+    def test_expired_window_allows_resend(self):
+        event = "event_expired"
+        _is_rate_limited(event)  # mark as sent
+        # Manually backdate well past any window
+        notif._last_sent[event] = time.monotonic() - 99999
+        self.assertFalse(_is_rate_limited(event))
+
+
+class TestGracefulDegradation(unittest.TestCase):
+    """notify() must never raise and must no-op when no channel is configured."""
+
+    def setUp(self):
+        _last_sent.clear()
+
+    def _clear_notification_env(self):
+        for key in ("NOTIFICATION_WEBHOOK_URL", "NOTIFICATION_EMAIL_TO", "NOTIFICATION_SMTP_HOST"):
+            os.environ.pop(key, None)
+
+    def test_no_config_is_silent(self):
+        self._clear_notification_env()
+        # Should not raise under any circumstances
+        notify("ev_no_config", "Title", "Body", severity="critical", job="firms")
+
+    def test_webhook_http_error_is_swallowed(self):
+        """A failed POST must be caught and logged, not re-raised."""
+        _last_sent.clear()
+        with patch("api.notifications._post_webhook", new_callable=AsyncMock) as mock_post:
+            mock_post.side_effect = Exception("connection refused")
+            # _dispatch should not raise even when _post_webhook fails
+            asyncio.run(
+                _dispatch(
+                    "ev_err", "Title", "Body", "critical", {},
+                    webhook_url="http://localhost:9/hook",
+                    email_to="",
+                    smtp_host="",
+                )
+            )
+
+    def test_notify_does_not_raise_when_webhook_configured_and_fails(self):
+        _last_sent.clear()
+        with patch.dict(os.environ, {"NOTIFICATION_WEBHOOK_URL": "http://localhost:9/hook"}):
+            with patch("api.notifications._post_webhook", new_callable=AsyncMock) as mock_post:
+                mock_post.side_effect = Exception("network error")
+                # notify() itself must not raise in sync context
+                notify("ev_safe", "Title", "Body", severity="warning")
+                # Give daemon thread time to finish
+                time.sleep(0.05)
+
+
+class TestNotifyDispatch(unittest.TestCase):
+    """notify() actually calls _post_webhook when a webhook URL is set."""
+
+    def setUp(self):
+        _last_sent.clear()
+
+    def test_webhook_called_in_async_context(self):
+        captured: list[tuple] = []
+
+        async def run():
+            _last_sent.clear()
+            with patch.dict(os.environ, {"NOTIFICATION_WEBHOOK_URL": "http://fake/hook"}):
+                with patch("api.notifications._post_webhook", new_callable=AsyncMock) as mock_post:
+                    mock_post.side_effect = lambda url, payload: captured.append((url, payload))
+                    notify("ev_async", "Title", "Body", severity="critical", job="firms")
+                    # Yield control so the scheduled task can run
+                    await asyncio.sleep(0.05)
+
+            self.assertEqual(len(captured), 1)
+            url, payload = captured[0]
+            self.assertEqual(url, "http://fake/hook")
+            self.assertIn("attachments", payload)
+            fields = {f["title"]: f["value"] for f in payload["attachments"][0]["fields"]}
+            self.assertEqual(fields["job"], "firms")
+
+        asyncio.run(run())
+
+    def test_rate_limited_event_skips_webhook(self):
+        _last_sent.clear()
+        call_count = 0
+
+        async def run():
+            nonlocal call_count
+            _last_sent.clear()
+            with patch.dict(os.environ, {"NOTIFICATION_WEBHOOK_URL": "http://fake/hook"}):
+                with patch("api.notifications._post_webhook", new_callable=AsyncMock) as mock_post:
+                    mock_post.side_effect = lambda url, payload: None
+
+                    notify("ev_rl_test", "Title", "Body")
+                    await asyncio.sleep(0.05)
+                    notify("ev_rl_test", "Title", "Body")  # should be rate-limited
+                    await asyncio.sleep(0.05)
+
+                    call_count = mock_post.call_count
+
+        asyncio.run(run())
+        self.assertEqual(call_count, 1)
+
+    def test_notify_sync_context_spawns_thread(self):
+        """In a sync context (no event loop), notify() must not raise."""
+        _last_sent.clear()
+        with patch.dict(os.environ, {"NOTIFICATION_WEBHOOK_URL": "http://fake/hook"}):
+            with patch("api.notifications._post_webhook", new_callable=AsyncMock):
+                notify("ev_sync", "Title", "Body")
+                time.sleep(0.05)  # give the daemon thread time to finish

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -653,6 +653,20 @@ def _run_denoiser_drift(args: argparse.Namespace) -> int:
             mean_val,
             mean_delta_hard,
         )
+        _safe_notify(
+            "denoiser_drift_hard",
+            title="Denoiser drift hard violation — manual review required",
+            body=(
+                f"PSI={psi_val:.4f} (hard threshold={psi_hard:.2f}), "
+                f"score_mean_delta={mean_val:.4f} (hard threshold={mean_delta_hard:.2f}). "
+                "Run: make model-rollback FAMILY=denoiser"
+            ),
+            severity="critical",
+            psi=f"{psi_val:.4f}",
+            psi_hard_threshold=f"{psi_hard:.2f}",
+            mean_delta=f"{mean_val:.4f}",
+            mean_delta_hard_threshold=f"{mean_delta_hard:.2f}",
+        )
         return 1  # surfaces as job failure in dashboard; no rollback triggered
     if warn_violation:
         LOGGER.warning(
@@ -684,6 +698,16 @@ def _run_cleanup(args: argparse.Namespace) -> int:
     return 0
 
 
+def _safe_notify(event_type: str, title: str, body: str, severity: str = "info", **context: Any) -> None:
+    """Dispatch a notification without blocking or raising. Lazy-imports to avoid startup cost."""
+    try:
+        from api.notifications import notify  # noqa: PLC0415
+
+        notify(event_type, title, body, severity, **context)
+    except Exception:
+        LOGGER.debug("Notification skipped: %s", event_type)
+
+
 def _run_with_logging(name: str, runner: Callable[[], int]) -> int:
     started = time.monotonic()
     LOGGER.info("Job started: %s", name)
@@ -691,6 +715,14 @@ def _run_with_logging(name: str, runner: Callable[[], int]) -> int:
         code = int(runner())
     except Exception:  # pragma: no cover - defensive wrapper
         LOGGER.exception("Job failed with unhandled exception: %s", name)
+        _safe_notify(
+            f"ingest_job_failed:{name}",
+            title=f"Ingest job failed: {name}",
+            body=f"Job '{name}' raised an unhandled exception. Check logs for details.",
+            severity="critical",
+            job=name,
+            exit_code="1",
+        )
         return 1
 
     elapsed = time.monotonic() - started
@@ -698,6 +730,14 @@ def _run_with_logging(name: str, runner: Callable[[], int]) -> int:
         LOGGER.info("Job succeeded: %s (%.2fs)", name, elapsed)
     else:
         LOGGER.error("Job failed: %s exit_code=%s (%.2fs)", name, code, elapsed)
+        _safe_notify(
+            f"ingest_job_failed:{name}",
+            title=f"Ingest job failed: {name}",
+            body=f"Job '{name}' exited with code {code}. Check logs for details.",
+            severity="critical",
+            job=name,
+            exit_code=str(code),
+        )
     return code
 
 
@@ -963,6 +1003,20 @@ def _execute_job(
 
     fresh_snapshot = status_snapshot_fn() if should_capture_snapshot else None
     _write_dashboard(dashboard_path=dashboard_path, metrics=metrics, snapshot=fresh_snapshot)
+    if fresh_snapshot and str(fresh_snapshot.get("overall_state", "")) == "critical":
+        critical_sources = fresh_snapshot.get("critical_stale_sources", [])
+        _safe_notify(
+            "data_stale_critical",
+            title="Critical data sources are stale",
+            body=(
+                f"Data freshness state is CRITICAL. "
+                f"Stale critical sources: {', '.join(critical_sources) or 'none detected'}. "
+                "Run: make ingest-orchestrator"
+            ),
+            severity="critical",
+            overall_state="critical",
+            stale_sources=", ".join(critical_sources),
+        )
     return code
 
 


### PR DESCRIPTION
## Changes

Adds a lightweight, fire-and-forget operational notification system for critical events:

### New Files
- **`api/notifications.py`**: Core notification client supporting:
  - Async webhook delivery (Slack/Discord-compatible)
  - Optional SMTP email alerts
  - Per-event-type rate limiting (configurable, default 15 min)
  - Thread-safe operation in both sync and async contexts
  - Graceful degradation when channels not configured

- **`api/tests/test_notifications.py`**: Comprehensive test suite covering:
  - Slack attachment payload format validation
  - Rate limiting behavior
  - Graceful error handling
  - Async/sync context dispatch

### Modified Files
- **`.env.example`**: Added optional notification configuration variables for webhook URL, SMTP settings, and rate limits

- **`api/model_registry.py`**: Integrated notifications on model promotion/rollback events via new `_notify_model_event()` helper

- **`ingest/orchestrator.py`**: Added notifications for:
  - Denoiser drift hard violations (critical)
  - Ingest job failures (critical)
  - Critical data source staleness (critical)
  - Uses new `_safe_notify()` helper to prevent blocking

### Design Highlights
- **Non-blocking**: All sends are async, delegated to daemon threads or event loop tasks
- **Rate-limited**: Prevents notification spam with configurable per-event windows
- **Fail-safe**: Exceptions in notification code never propagate to callers
- **Zero-overhead**: Silent no-op when no channels configured; lazy imports avoid startup cost