### PR TITLE
feat(api): add industrial coverage endpoint and spread service warnings

### DIFF
--- a/api/industrial_coverage.py
+++ b/api/industrial_coverage.py
@@ -1,0 +1,101 @@
+"""Industrial source coverage queries for health monitoring and decision support.
+
+Used by the internal health endpoint and spread service to detect forecast
+regions with no industrial noise-filter coverage (blind spots).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import text
+
+from api.db import get_engine
+
+LOGGER = logging.getLogger(__name__)
+
+# Fallback buffer (metres) when no active masking policy is found.
+DEFAULT_BUFFER_M = 1000.0
+
+
+def query_industrial_coverage(
+    bbox: tuple[float, float, float, float],
+    engine=None,
+) -> dict:
+    """Return industrial source coverage report for the given bounding box.
+
+    Queries active industrial sources that intersect the bbox, then computes
+    the fraction of bbox area covered by buffered source zones using the
+    active masking policy's gold_buffer_m (or DEFAULT_BUFFER_M if no policy).
+
+    Parameters
+    ----------
+    bbox : tuple[float, float, float, float]
+        (min_lon, min_lat, max_lon, max_lat) in EPSG:4326.
+    engine : optional
+        SQLAlchemy engine. Defaults to ``api.db.get_engine()``.
+
+    Returns
+    -------
+    dict
+        source_count : int
+        types : list[str]  — distinct source type values present in bbox
+        coverage_fraction : float  — 0.0–1.0, area fraction covered by buffers
+        buffer_m : float  — buffer radius used for the computation
+    """
+    min_lon, min_lat, max_lon, max_lat = bbox
+    db_engine = engine or get_engine()
+
+    with db_engine.begin() as conn:
+        # Single CTE: resolve active policy buffer and compute coverage in one round-trip.
+        row = conn.execute(
+            text("""
+                WITH active_policy AS (
+                    SELECT COALESCE(gold_buffer_m, :default_buffer) AS buffer_m
+                    FROM industrial_mask_policies
+                    WHERE (active_to IS NULL OR active_to > NOW())
+                    ORDER BY active_from DESC
+                    LIMIT 1
+                ),
+                effective_policy AS (
+                    SELECT COALESCE((SELECT buffer_m FROM active_policy), :default_buffer) AS buffer_m
+                ),
+                bbox AS (
+                    SELECT ST_MakeEnvelope(:min_lon, :min_lat, :max_lon, :max_lat, 4326) AS geom
+                ),
+                srcs AS (
+                    SELECT geom, type
+                    FROM industrial_sources
+                    WHERE is_active = true
+                      AND ST_Intersects(geom, (SELECT geom FROM bbox))
+                )
+                SELECT
+                    COUNT(*)::int AS source_count,
+                    array_agg(DISTINCT type ORDER BY type)
+                        FILTER (WHERE type IS NOT NULL) AS types,
+                    CASE WHEN COUNT(*) > 0 THEN
+                        ST_Area(
+                            ST_Intersection(
+                                ST_Union(ST_Buffer(geom::geography, (SELECT buffer_m FROM effective_policy))::geometry),
+                                (SELECT geom FROM bbox)
+                            )::geography
+                        ) / NULLIF(ST_Area((SELECT geom FROM bbox)::geography), 0)
+                    ELSE 0.0 END AS coverage_fraction,
+                    (SELECT buffer_m FROM effective_policy) AS buffer_m
+                FROM srcs
+            """),
+            {
+                "min_lon": min_lon,
+                "min_lat": min_lat,
+                "max_lon": max_lon,
+                "max_lat": max_lat,
+                "default_buffer": DEFAULT_BUFFER_M,
+            },
+        ).fetchone()
+
+    return {
+        "source_count": int(row["source_count"]),
+        "types": sorted(row["types"] or []),
+        "coverage_fraction": float(row["coverage_fraction"] or 0.0),
+        "buffer_m": float(row["buffer_m"]),
+    }

--- a/api/routes/internal.py
+++ b/api/routes/internal.py
@@ -13,6 +13,7 @@ from api.model_registry import (
     rollback_model,
     validate_model_gate,
 )
+from api.industrial_coverage import query_industrial_coverage
 from api.terrain.features_repo import list_terrain_coverage_inventory
 from api.fires.repo import (
     get_latest_denoiser_gate_report,
@@ -173,6 +174,54 @@ async def terrain_coverage_inventory() -> dict:
         "stale_threshold_minutes": settings.data_stale_terrain_minutes,
         "region_count": len(regions),
         "regions": regions,
+    }
+
+
+@internal_router.get("/internal/health/industrial-coverage")
+async def industrial_coverage_health(bbox: str) -> dict:
+    """Return industrial source coverage report for a given bounding box.
+
+    ``bbox`` is a comma-separated string ``min_lon,min_lat,max_lon,max_lat``
+    in EPSG:4326.  Coverage fraction is the fraction of bbox area covered by
+    buffered industrial source zones, computed using the active masking policy
+    gold_buffer_m (or 1 km fallback).
+
+    Operators use this to detect forecast regions that lack industrial noise
+    filtering (blind spots where false-alarm detections may not be suppressed).
+    """
+    as_of = datetime.now(timezone.utc).isoformat()
+    try:
+        parts = [float(x.strip()) for x in bbox.split(",")]
+        if len(parts) != 4:
+            raise ValueError("Expected 4 comma-separated values")
+        bbox_tuple: tuple[float, float, float, float] = (parts[0], parts[1], parts[2], parts[3])
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=f"Invalid bbox: {exc}")
+
+    bbox_dict = {"min_lon": bbox_tuple[0], "min_lat": bbox_tuple[1], "max_lon": bbox_tuple[2], "max_lat": bbox_tuple[3]}
+
+    try:
+        coverage = query_industrial_coverage(bbox_tuple)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        return {
+            "as_of": as_of,
+            "bbox": bbox_dict,
+            "source_count": None,
+            "types": [],
+            "coverage_fraction": None,
+            "has_coverage": None,
+            "buffer_m": None,
+            "error": str(exc),
+        }
+
+    return {
+        "as_of": as_of,
+        "bbox": bbox_dict,
+        "source_count": coverage["source_count"],
+        "types": coverage["types"],
+        "coverage_fraction": coverage["coverage_fraction"],
+        "has_coverage": coverage["source_count"] > 0,
+        "buffer_m": coverage["buffer_m"],
     }
 
 

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi.testclient import TestClient
 
 from api.main import app
@@ -457,6 +458,61 @@ def test_consolidated_dashboard_cleanup_section(monkeypatch) -> None:
     assert cleanup["last_outcome"] == "success"
     assert cleanup["next_run_at"] == "2026-03-26T06:00:00+00:00"
     assert cleanup["source"] == "orchestrator_dashboard"
+
+
+# ---------------------------------------------------------------------------
+# /internal/health/industrial-coverage
+# ---------------------------------------------------------------------------
+
+
+def _mock_industrial_coverage(source_count: int, types: list, coverage_fraction: float, buffer_m: float = 1000.0):
+    return {
+        "source_count": source_count,
+        "types": types,
+        "coverage_fraction": coverage_fraction,
+        "buffer_m": buffer_m,
+    }
+
+
+def test_industrial_coverage_with_sources(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "api.routes.internal.query_industrial_coverage",
+        lambda bbox: _mock_industrial_coverage(12, ["gas_facility", "oil_refinery"], 0.34),
+    )
+    response = client.get("/internal/health/industrial-coverage?bbox=-120.5,37.0,-119.5,38.0")
+    assert response.status_code == 200
+    body = response.json()
+    assert "as_of" in body
+    assert body["source_count"] == 12
+    assert body["types"] == ["gas_facility", "oil_refinery"]
+    assert body["coverage_fraction"] == pytest.approx(0.34)
+    assert body["has_coverage"] is True
+    assert body["buffer_m"] == 1000.0
+    assert body["bbox"] == {"min_lon": -120.5, "min_lat": 37.0, "max_lon": -119.5, "max_lat": 38.0}
+
+
+def test_industrial_coverage_zero_sources(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "api.routes.internal.query_industrial_coverage",
+        lambda bbox: _mock_industrial_coverage(0, [], 0.0),
+    )
+    response = client.get("/internal/health/industrial-coverage?bbox=-110.0,40.0,-109.0,41.0")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["source_count"] == 0
+    assert body["types"] == []
+    assert body["coverage_fraction"] == 0.0
+    assert body["has_coverage"] is False
+
+
+def test_industrial_coverage_invalid_bbox() -> None:
+    response = client.get("/internal/health/industrial-coverage?bbox=bad,values")
+    assert response.status_code == 422
+
+
+def test_industrial_coverage_bbox_wrong_part_count() -> None:
+    response = client.get("/internal/health/industrial-coverage?bbox=-120.0,37.0,-119.0")
+    assert response.status_code == 422
 
 
 def test_consolidated_dashboard_no_dashboard_file(monkeypatch) -> None:

--- a/ml/spread/service.py
+++ b/ml/spread/service.py
@@ -243,6 +243,35 @@ def run_spread_forecast(
             f"Window: {inputs_package.window.lat.size}x{inputs_package.window.lon.size}"
         )
 
+    # Check industrial source coverage — warn if forecasting in a blind spot.
+    # Lazy import mirrors the pattern used for build_spread_inputs.
+    try:
+        from api.industrial_coverage import query_industrial_coverage as _query_industrial_coverage
+
+        _ind_cov = _query_industrial_coverage(request.bbox)
+        if _ind_cov["source_count"] == 0:
+            LOGGER.warning(
+                "No industrial sources in forecast bbox — industrial noise filtering blind spot; "
+                "fire detections in this region are not masked against false industrial alarms. "
+                "Mitigation: ingest industrial sources for this region (science_grade target).",
+                extra={"bbox": request.bbox, "region": request.region_name},
+            )
+        else:
+            LOGGER.info(
+                "Industrial source coverage ok",
+                extra={
+                    "bbox": request.bbox,
+                    "source_count": _ind_cov["source_count"],
+                    "coverage_fraction": _ind_cov["coverage_fraction"],
+                },
+            )
+    except Exception as _exc:
+        LOGGER.warning(
+            "Could not check industrial source coverage: %s",
+            _exc,
+            extra={"bbox": request.bbox},
+        )
+
     # 2. Select and run model
     if model is None:
         # Default to baseline heuristic unless request includes explicit selection.

--- a/ml/tests/test_spread_service.py
+++ b/ml/tests/test_spread_service.py
@@ -777,3 +777,87 @@ class TestResolveClusterToBbox:
         cell_deg = max(0.08, 8.0 / 16)  # z=4 → cellDeg=0.5
         assert abs(min_lat - (-5 * cell_deg)) < 1e-9
         assert abs(min_lon - (-3 * cell_deg)) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Industrial coverage WARNING in run_spread_forecast
+# ---------------------------------------------------------------------------
+
+
+def _make_spread_request(bbox=(20.0, 40.0, 20.2, 40.2)):
+    return SpreadForecastRequest(
+        region_name="test_region",
+        bbox=bbox,
+        forecast_reference_time=datetime(2026, 3, 27, 12, 0, tzinfo=timezone.utc),
+    )
+
+
+def _make_mock_forecast():
+    mock_forecast = MagicMock(spec=SpreadForecast)
+    mock_forecast.probabilities = MagicMock()
+    mock_forecast.probabilities.min.return_value = 0.0
+    mock_forecast.probabilities.max.return_value = 0.0
+    return mock_forecast
+
+
+def test_spread_forecast_warns_when_no_industrial_coverage(mock_spread_inputs, caplog):
+    """run_spread_forecast must log a WARNING when industrial source count is 0."""
+    import logging
+
+    mock_model = MagicMock()
+    mock_model.predict.return_value = _make_mock_forecast()
+
+    with patch("ml.spread.service.build_spread_inputs", return_value=mock_spread_inputs):
+        with patch(
+            "api.industrial_coverage.query_industrial_coverage",
+            return_value={"source_count": 0, "types": [], "coverage_fraction": 0.0, "buffer_m": 1000.0},
+        ):
+            with caplog.at_level(logging.WARNING, logger="ml.spread.service"):
+                run_spread_forecast(_make_spread_request(), model=mock_model)
+
+    warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("industrial" in m.lower() and "blind spot" in m.lower() for m in warning_msgs), (
+        f"Expected industrial blind-spot WARNING, got: {warning_msgs}"
+    )
+
+
+def test_spread_forecast_no_warning_when_industrial_coverage_present(mock_spread_inputs, caplog):
+    """run_spread_forecast must not log industrial-coverage WARNING when sources exist."""
+    import logging
+
+    mock_model = MagicMock()
+    mock_model.predict.return_value = _make_mock_forecast()
+
+    with patch("ml.spread.service.build_spread_inputs", return_value=mock_spread_inputs):
+        with patch(
+            "api.industrial_coverage.query_industrial_coverage",
+            return_value={"source_count": 5, "types": ["gas_facility"], "coverage_fraction": 0.21, "buffer_m": 1000.0},
+        ):
+            with caplog.at_level(logging.WARNING, logger="ml.spread.service"):
+                run_spread_forecast(_make_spread_request(), model=mock_model)
+
+    warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert not any("blind spot" in m.lower() for m in warning_msgs), (
+        f"Unexpected industrial blind-spot WARNING: {warning_msgs}"
+    )
+
+
+def test_spread_forecast_continues_when_industrial_coverage_check_fails(mock_spread_inputs, caplog):
+    """Coverage check failure must not abort the forecast — only log a warning."""
+    import logging
+
+    mock_model = MagicMock()
+    mock_model.predict.return_value = _make_mock_forecast()
+
+    def _raise(bbox):
+        raise RuntimeError("DB is down")
+
+    with patch("ml.spread.service.build_spread_inputs", return_value=mock_spread_inputs):
+        with patch("api.industrial_coverage.query_industrial_coverage", side_effect=_raise):
+            with caplog.at_level(logging.WARNING, logger="ml.spread.service"):
+                result = run_spread_forecast(_make_spread_request(), model=mock_model)
+
+    # Forecast must still succeed
+    assert result is not None
+    warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("industrial source coverage" in m.lower() for m in warning_msgs)


### PR DESCRIPTION
## Changes

### New Industrial Coverage Module
- Added `api/industrial_coverage.py` with `query_industrial_coverage()` function
- Queries active industrial sources within a bounding box
- Computes coverage fraction using active masking policy buffer (1 km fallback)
- Returns source count, types, coverage fraction, and buffer radius

### Health Endpoint
- Added `/internal/health/industrial-coverage` endpoint in `api/routes/internal.py`
- Accepts bbox as comma-separated string (min_lon, min_lat, max_lon, max_lat)
- Returns coverage report with has_coverage boolean flag
- Helps operators detect forecast regions lacking industrial noise filtering

### Spread Service Enhancement
- Integrated industrial coverage check into `ml/spread/service.py`
- **Logs WARNING** when forecasting in a blind spot (no industrial sources)
- **Logs INFO** when coverage is present with source count and fraction
- Gracefully handles check failures without aborting forecast

### Test Coverage
- Added comprehensive tests in `api/tests/test_health.py` for endpoint
- Added tests in `ml/tests/test_spread_service.py` for coverage warnings
- Covers success cases, zero sources, invalid input, and error handling