### PR TITLE
Add circuit breaker, configurable timeout, and degraded UI state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,9 @@ POSTGRES_DB=wildfire
 # GEMINI_API_KEY=your_gemini_api_key_here
 # GEMINI_MODEL=gemini-2.5-flash
 # GEMINI_API_BASE_URL=https://generativelanguage.googleapis.com/v1beta
+# GEMINI_TIMEOUT_SECONDS=60         # Max seconds to wait for a Gemini response (default 60)
+# GEMINI_CIRCUIT_BREAKER_THRESHOLD=5       # Consecutive failures before circuit opens (default 5)
+# GEMINI_CIRCUIT_BREAKER_COOLDOWN_SECONDS=60  # Seconds before a probe is allowed after opening (default 60)
 
 # =============================================================================
 # Iframe Embedding / Security Headers

--- a/api/config.py
+++ b/api/config.py
@@ -209,6 +209,17 @@ class AppSettings(BaseSettings):
         default="https://generativelanguage.googleapis.com/v1beta",
         validation_alias="GEMINI_API_BASE_URL",
     )
+    gemini_timeout_seconds: float = Field(
+        default=60.0, ge=1.0, le=300.0, validation_alias="GEMINI_TIMEOUT_SECONDS"
+    )
+    # Circuit breaker: open after this many consecutive failures
+    gemini_circuit_breaker_threshold: int = Field(
+        default=5, ge=1, validation_alias="GEMINI_CIRCUIT_BREAKER_THRESHOLD"
+    )
+    # Circuit breaker: seconds to wait before allowing a probe request
+    gemini_circuit_breaker_cooldown_seconds: float = Field(
+        default=60.0, ge=5.0, validation_alias="GEMINI_CIRCUIT_BREAKER_COOLDOWN_SECONDS"
+    )
 
     @property
     def data_status_critical_sources_set(self) -> set[str]:

--- a/api/routes/assistant.py
+++ b/api/routes/assistant.py
@@ -1,5 +1,10 @@
 """Assistant proxy router — forwards chat requests to Gemini server-side."""
 
+import logging
+import threading
+import time
+from enum import Enum
+
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 
@@ -8,12 +13,117 @@ from pydantic import BaseModel
 
 from api.config import settings
 
+LOGGER = logging.getLogger(__name__)
+
 assistant_router = APIRouter(prefix="/assistant", tags=["assistant"])
+
+
+class CircuitState(str, Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class _CircuitBreaker:
+    """Thread-safe circuit breaker for Gemini API calls.
+
+    States:
+      CLOSED   — normal operation; failures accumulate toward threshold.
+      OPEN     — short-circuit; requests fail immediately until cooldown expires.
+      HALF_OPEN — one probe request allowed; success closes, failure re-opens.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._failures = 0
+        self._opened_at: float | None = None
+
+    def _compute_state(self) -> CircuitState:
+        """Must be called with _lock held."""
+        if self._opened_at is None:
+            return CircuitState.CLOSED
+        elapsed = time.monotonic() - self._opened_at
+        if elapsed >= settings.gemini_circuit_breaker_cooldown_seconds:
+            return CircuitState.HALF_OPEN
+        return CircuitState.OPEN
+
+    @property
+    def state(self) -> CircuitState:
+        with self._lock:
+            return self._compute_state()
+
+    @property
+    def failure_count(self) -> int:
+        with self._lock:
+            return self._failures
+
+    @property
+    def cooldown_remaining_seconds(self) -> float | None:
+        with self._lock:
+            if self._opened_at is None:
+                return None
+            state = self._compute_state()
+            if state != CircuitState.OPEN:
+                return None
+            elapsed = time.monotonic() - self._opened_at
+            return max(0.0, settings.gemini_circuit_breaker_cooldown_seconds - elapsed)
+
+    def snapshot(self) -> tuple[CircuitState, int, float | None]:
+        """Return (state, failure_count, cooldown_remaining) under a single lock acquisition."""
+        with self._lock:
+            state = self._compute_state()
+            failures = self._failures
+            if self._opened_at is None or state != CircuitState.OPEN:
+                cooldown: float | None = None
+            else:
+                elapsed = time.monotonic() - self._opened_at
+                cooldown = max(0.0, settings.gemini_circuit_breaker_cooldown_seconds - elapsed)
+        return state, failures, cooldown
+
+    def allow_request(self) -> bool:
+        """Return True if a request should proceed (CLOSED or HALF_OPEN probe)."""
+        with self._lock:
+            return self._compute_state() != CircuitState.OPEN
+
+    def record_success(self) -> None:
+        with self._lock:
+            was_open = self._opened_at is not None
+            self._failures = 0
+            self._opened_at = None
+        if was_open:
+            LOGGER.info("gemini circuit breaker: closed after successful probe")
+
+    def record_failure(self) -> None:
+        with self._lock:
+            self._failures += 1
+            failures = self._failures
+            threshold = settings.gemini_circuit_breaker_threshold
+            if self._opened_at is not None:
+                # Already open/half-open — reset the cooldown timer on each failure.
+                self._opened_at = time.monotonic()
+                log_args: tuple = ("gemini circuit breaker: failure during open/half-open, cooldown reset",)
+            elif failures >= threshold:
+                self._opened_at = time.monotonic()
+                log_args = ("gemini circuit breaker opened after %d consecutive failures", failures)
+            else:
+                log_args = ("gemini circuit breaker: failure %d/%d", failures, threshold)
+        LOGGER.warning(*log_args)
+
+
+# Module-level singleton — shared across all requests within a worker process.
+_circuit = _CircuitBreaker()
 
 
 class AssistantConfigResponse(BaseModel):
     configured: bool
     model: str
+
+
+class AssistantHealthResponse(BaseModel):
+    configured: bool
+    circuit_state: CircuitState
+    failure_count: int
+    cooldown_remaining_seconds: float | None
 
 
 @assistant_router.get("/config", response_model=AssistantConfigResponse)
@@ -24,25 +134,53 @@ async def get_assistant_config() -> AssistantConfigResponse:
     )
 
 
+@assistant_router.get("/health", response_model=AssistantHealthResponse)
+async def get_assistant_health() -> AssistantHealthResponse:
+    state, failure_count, cooldown = _circuit.snapshot()
+    return AssistantHealthResponse(
+        configured=bool(settings.gemini_api_key),
+        circuit_state=state,
+        failure_count=failure_count,
+        cooldown_remaining_seconds=cooldown,
+    )
+
+
 @assistant_router.post("/chat", dependencies=[Depends(no_cache)])
 async def proxy_chat(body: dict) -> dict:
     """Proxy a Gemini generateContent request, injecting the server-side API key."""
     if not settings.gemini_api_key:
         raise HTTPException(status_code=503, detail="Assistant not configured")
 
+    if not _circuit.allow_request():
+        LOGGER.warning("gemini circuit breaker is open — short-circuiting request")
+        raise HTTPException(
+            status_code=503,
+            detail="Assistant temporarily unavailable (circuit open)",
+        )
+
     url = (
         f"{settings.gemini_api_base_url}/models/"
         f"{settings.gemini_model}:generateContent"
     )
 
-    async with httpx.AsyncClient(timeout=60.0) as client:
-        resp = await client.post(
-            url,
-            json=body,
-            headers={"x-goog-api-key": settings.gemini_api_key},
-        )
+    try:
+        async with httpx.AsyncClient(timeout=settings.gemini_timeout_seconds) as client:
+            resp = await client.post(
+                url,
+                json=body,
+                headers={"x-goog-api-key": settings.gemini_api_key},
+            )
+    except Exception as exc:
+        LOGGER.error("gemini request raised exception: %s", exc)
+        _circuit.record_failure()
+        raise HTTPException(status_code=503, detail="Assistant request failed") from exc
 
     if not resp.is_success:
+        LOGGER.error(
+            "gemini returned non-success status %d: %.200s", resp.status_code, resp.text
+        )
+        _circuit.record_failure()
         raise HTTPException(status_code=resp.status_code, detail=resp.text)
 
+    _circuit.record_success()
     return resp.json()

--- a/api/tests/test_assistant.py
+++ b/api/tests/test_assistant.py
@@ -1,0 +1,312 @@
+"""Tests for assistant proxy: circuit breaker open/close/timeout and health endpoint."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reset_circuit() -> None:
+    """Reset the module-level circuit breaker to CLOSED state."""
+    import api.routes.assistant as mod
+    cb = mod._circuit
+    with cb._lock:
+        cb._failures = 0
+        cb._opened_at = None
+
+
+# ---------------------------------------------------------------------------
+# /assistant/config
+# ---------------------------------------------------------------------------
+
+
+def test_config_returns_configured_false_when_no_key(monkeypatch) -> None:
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_api_key", "")
+    response = client.get("/assistant/config")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["configured"] is False
+    assert "model" in body
+
+
+def test_config_returns_configured_true_when_key_set(monkeypatch) -> None:
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_api_key", "fake-key")
+    response = client.get("/assistant/config")
+    assert response.status_code == 200
+    assert response.json()["configured"] is True
+
+
+# ---------------------------------------------------------------------------
+# /assistant/health — circuit breaker state reporting
+# ---------------------------------------------------------------------------
+
+
+def test_health_reports_closed_state(monkeypatch) -> None:
+    _reset_circuit()
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_api_key", "fake-key")
+    response = client.get("/assistant/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["circuit_state"] == "closed"
+    assert body["failure_count"] == 0
+    assert body["cooldown_remaining_seconds"] is None
+    assert body["configured"] is True
+
+
+def test_health_reports_open_state_after_failures(monkeypatch) -> None:
+    _reset_circuit()
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_api_key", "fake-key")
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_circuit_breaker_threshold", 3)
+    monkeypatch.setattr(
+        "api.routes.assistant.settings.gemini_circuit_breaker_cooldown_seconds", 120.0
+    )
+
+    import api.routes.assistant as mod
+    mod._circuit.record_failure()
+    mod._circuit.record_failure()
+    mod._circuit.record_failure()
+
+    response = client.get("/assistant/health")
+    body = response.json()
+    assert body["circuit_state"] == "open"
+    assert body["failure_count"] == 3
+    assert body["cooldown_remaining_seconds"] is not None
+    assert body["cooldown_remaining_seconds"] > 0
+
+
+def test_health_reports_half_open_after_cooldown(monkeypatch) -> None:
+    _reset_circuit()
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_api_key", "fake-key")
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_circuit_breaker_threshold", 1)
+    monkeypatch.setattr(
+        "api.routes.assistant.settings.gemini_circuit_breaker_cooldown_seconds", 0.01
+    )
+
+    import api.routes.assistant as mod
+    mod._circuit.record_failure()
+    time.sleep(0.05)  # allow cooldown to expire
+
+    response = client.get("/assistant/health")
+    body = response.json()
+    assert body["circuit_state"] == "half_open"
+    assert body["cooldown_remaining_seconds"] is None
+
+
+# ---------------------------------------------------------------------------
+# /assistant/chat — circuit breaker integration
+# ---------------------------------------------------------------------------
+
+
+def test_chat_returns_503_when_not_configured(monkeypatch) -> None:
+    _reset_circuit()
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_api_key", "")
+    response = client.post("/assistant/chat", json={"contents": []})
+    assert response.status_code == 503
+
+
+def test_chat_short_circuits_when_open(monkeypatch) -> None:
+    _reset_circuit()
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_api_key", "fake-key")
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_circuit_breaker_threshold", 1)
+    monkeypatch.setattr(
+        "api.routes.assistant.settings.gemini_circuit_breaker_cooldown_seconds", 120.0
+    )
+
+    import api.routes.assistant as mod
+    mod._circuit.record_failure()  # open the circuit
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        response = client.post("/assistant/chat", json={"contents": []})
+
+    # httpx should never have been called
+    mock_client_cls.assert_not_called()
+    assert response.status_code == 503
+    assert "circuit" in response.json()["message"].lower()
+
+
+def test_chat_records_failure_on_http_error(monkeypatch) -> None:
+    _reset_circuit()
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_api_key", "fake-key")
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_circuit_breaker_threshold", 10)
+
+    import api.routes.assistant as mod
+    failures_before = mod._circuit.failure_count
+
+    mock_resp = MagicMock()
+    mock_resp.is_success = False
+    mock_resp.status_code = 429
+    mock_resp.text = "rate limited"
+
+    async def _mock_post(*args, **kwargs):
+        return mock_resp
+
+    mock_async_client = AsyncMock()
+    mock_async_client.__aenter__ = AsyncMock(return_value=mock_async_client)
+    mock_async_client.__aexit__ = AsyncMock(return_value=False)
+    mock_async_client.post = _mock_post
+
+    with patch("api.routes.assistant.httpx.AsyncClient", return_value=mock_async_client):
+        response = client.post("/assistant/chat", json={"contents": []})
+
+    assert response.status_code == 429
+    assert mod._circuit.failure_count == failures_before + 1
+
+
+def test_chat_records_success_and_resets_failures(monkeypatch) -> None:
+    _reset_circuit()
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_api_key", "fake-key")
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_circuit_breaker_threshold", 10)
+
+    import api.routes.assistant as mod
+    # Pre-load some failures
+    mod._circuit._failures = 4
+
+    mock_resp = MagicMock()
+    mock_resp.is_success = True
+    mock_resp.json.return_value = {"candidates": [{"content": {"parts": [{"text": "ok"}]}}]}
+
+    async def _mock_post(*args, **kwargs):
+        return mock_resp
+
+    mock_async_client = AsyncMock()
+    mock_async_client.__aenter__ = AsyncMock(return_value=mock_async_client)
+    mock_async_client.__aexit__ = AsyncMock(return_value=False)
+    mock_async_client.post = _mock_post
+
+    with patch("api.routes.assistant.httpx.AsyncClient", return_value=mock_async_client):
+        response = client.post("/assistant/chat", json={"contents": []})
+
+    assert response.status_code == 200
+    assert mod._circuit.failure_count == 0
+    assert mod._circuit.state == "closed"
+
+
+def test_chat_records_failure_on_connection_error(monkeypatch) -> None:
+    _reset_circuit()
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_api_key", "fake-key")
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_circuit_breaker_threshold", 10)
+
+    import api.routes.assistant as mod
+    failures_before = mod._circuit.failure_count
+
+    async def _mock_post(*args, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    mock_async_client = AsyncMock()
+    mock_async_client.__aenter__ = AsyncMock(return_value=mock_async_client)
+    mock_async_client.__aexit__ = AsyncMock(return_value=False)
+    mock_async_client.post = _mock_post
+
+    with patch("api.routes.assistant.httpx.AsyncClient", return_value=mock_async_client):
+        response = client.post("/assistant/chat", json={"contents": []})
+
+    assert response.status_code == 503
+    assert mod._circuit.failure_count == failures_before + 1
+
+
+def test_circuit_opens_after_threshold_failures(monkeypatch) -> None:
+    _reset_circuit()
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_api_key", "fake-key")
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_circuit_breaker_threshold", 3)
+    monkeypatch.setattr(
+        "api.routes.assistant.settings.gemini_circuit_breaker_cooldown_seconds", 120.0
+    )
+
+    import api.routes.assistant as mod
+
+    mock_resp = MagicMock()
+    mock_resp.is_success = False
+    mock_resp.status_code = 500
+    mock_resp.text = "server error"
+
+    async def _mock_post(*args, **kwargs):
+        return mock_resp
+
+    mock_async_client = AsyncMock()
+    mock_async_client.__aenter__ = AsyncMock(return_value=mock_async_client)
+    mock_async_client.__aexit__ = AsyncMock(return_value=False)
+    mock_async_client.post = _mock_post
+
+    with patch("api.routes.assistant.httpx.AsyncClient", return_value=mock_async_client):
+        for _ in range(3):
+            client.post("/assistant/chat", json={"contents": []})
+
+    assert mod._circuit.state == "open"
+
+    # Next request must be short-circuited without hitting httpx
+    with patch("httpx.AsyncClient") as mock_cls:
+        response = client.post("/assistant/chat", json={"contents": []})
+    mock_cls.assert_not_called()
+    assert response.status_code == 503
+
+
+def test_circuit_closes_after_successful_probe(monkeypatch) -> None:
+    _reset_circuit()
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_api_key", "fake-key")
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_circuit_breaker_threshold", 1)
+    monkeypatch.setattr(
+        "api.routes.assistant.settings.gemini_circuit_breaker_cooldown_seconds", 0.01
+    )
+
+    import api.routes.assistant as mod
+    mod._circuit.record_failure()  # open the circuit
+    time.sleep(0.05)              # let cooldown expire → half_open
+
+    assert mod._circuit.state == "half_open"
+
+    mock_resp = MagicMock()
+    mock_resp.is_success = True
+    mock_resp.json.return_value = {"candidates": []}
+
+    async def _mock_post(*args, **kwargs):
+        return mock_resp
+
+    mock_async_client = AsyncMock()
+    mock_async_client.__aenter__ = AsyncMock(return_value=mock_async_client)
+    mock_async_client.__aexit__ = AsyncMock(return_value=False)
+    mock_async_client.post = _mock_post
+
+    with patch("api.routes.assistant.httpx.AsyncClient", return_value=mock_async_client):
+        response = client.post("/assistant/chat", json={"contents": []})
+
+    assert response.status_code == 200
+    assert mod._circuit.state == "closed"
+    assert mod._circuit.failure_count == 0
+
+
+def test_timeout_is_passed_to_httpx(monkeypatch) -> None:
+    _reset_circuit()
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_api_key", "fake-key")
+    monkeypatch.setattr("api.routes.assistant.settings.gemini_timeout_seconds", 42.0)
+
+    captured_timeout: list[float] = []
+
+    class _CapturingClient:
+        def __init__(self, timeout=None, **_kwargs):
+            captured_timeout.append(timeout)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return False
+
+        async def post(self, *args, **kwargs):
+            mock_resp = MagicMock()
+            mock_resp.is_success = True
+            mock_resp.json.return_value = {}
+            return mock_resp
+
+    with patch("api.routes.assistant.httpx.AsyncClient", _CapturingClient):
+        client.post("/assistant/chat", json={"contents": []})
+
+    assert captured_timeout == [42.0]

--- a/ui/src/components/AIChatAssistant.tsx
+++ b/ui/src/components/AIChatAssistant.tsx
@@ -4,10 +4,12 @@ import {
   CircularProgress,
   IconButton,
   TextField,
+  Tooltip,
   Typography
 } from "@mui/material";
 import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutline";
 import SendIcon from "@mui/icons-material/Send";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import ReactMarkdown from "react-markdown";
 
 import { EARTH_TOOLS_ASSISTANT_SYSTEM_PROMPT, SAFETY_ASSISTANT_SYSTEM_PROMPT } from "../config/assistant";
@@ -92,6 +94,7 @@ export default function AIChatAssistant(): JSX.Element {
   const [autoBriefing, setAutoBriefing] = useState<string | null>(null);
   const [isBriefing, setIsBriefing] = useState(false);
   const [assistantConfigured, setAssistantConfigured] = useState(false);
+  const [circuitDegraded, setCircuitDegraded] = useState(false);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const lastBriefedEventId = useRef<string | null>(null);
   const lastBriefedPrompt = useRef<string | null>(null);
@@ -107,12 +110,26 @@ export default function AIChatAssistant(): JSX.Element {
   const clearAssistantBriefingPrompt = useAppStore((s) => s.clearAssistantBriefingPrompt);
   const isSafetyMode = safety.enabled;
 
-  useEffect(() => {
-    fetch(`${apiBase}/assistant/config`)
+  const refreshHealth = useCallback(() => {
+    fetch(`${apiBase}/assistant/health`)
       .then((r) => r.json())
-      .then((data: { configured: boolean }) => setAssistantConfigured(data.configured))
-      .catch(() => setAssistantConfigured(false));
+      .then((data: { configured: boolean; circuit_state: string }) => {
+        setAssistantConfigured(data.configured);
+        setCircuitDegraded(data.circuit_state !== "closed");
+      })
+      .catch((err: unknown) => {
+        console.error("[AIChatAssistant] health check failed:", err);
+        setAssistantConfigured(false);
+      });
   }, []);
+
+  useEffect(() => {
+    refreshHealth();
+    // Poll more frequently when degraded, less when healthy.
+    const interval = setInterval(refreshHealth, circuitDegraded ? 15_000 : 60_000);
+    return () => clearInterval(interval);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [circuitDegraded]);
 
   const eventContext = useMemo(() => compactEventContext(selectedEvent), [selectedEvent]);
   const timeRange = useMemo(() => computeTimeRange(filters), [filters]);
@@ -192,8 +209,9 @@ export default function AIChatAssistant(): JSX.Element {
       const payload = (await response.json()) as unknown;
       const reply = extractReply(payload);
       if (reply) setAutoBriefing(reply);
-    } catch {
-      // Silently fail for auto-briefings — don't disrupt UX
+    } catch (err: unknown) {
+      console.error("[AIChatAssistant] auto-briefing failed:", err);
+      setCircuitDegraded(true);
     } finally {
       setIsBriefing(false);
     }
@@ -313,17 +331,22 @@ export default function AIChatAssistant(): JSX.Element {
         </Box>
 
         <Box sx={{ display: "flex", alignItems: "center", gap: 0.65 }}>
+          {assistantConfigured && circuitDegraded && (
+            <Tooltip title="Assistant degraded — circuit breaker open. Requests are being retried automatically." arrow>
+              <WarningAmberIcon sx={{ fontSize: 13, color: "#f59e0b" }} />
+            </Tooltip>
+          )}
           <Box
             sx={{
               width: 6,
               height: 6,
               borderRadius: "50%",
-              bgcolor: assistantConfigured ? "#22c55e" : "#f59e0b",
-              animation: assistantConfigured ? "pulse 1.4s ease-in-out infinite" : "none"
+              bgcolor: !assistantConfigured ? "#f59e0b" : circuitDegraded ? "#f59e0b" : "#22c55e",
+              animation: assistantConfigured && !circuitDegraded ? "pulse 1.4s ease-in-out infinite" : "none"
             }}
           />
           <Typography sx={{ fontSize: 10, color: "#6b7280", fontWeight: 700, letterSpacing: "0.1em", textTransform: "uppercase" }}>
-            {assistantConfigured ? "Live" : "Offline"}
+            {!assistantConfigured ? "Offline" : circuitDegraded ? "Degraded" : "Live"}
           </Typography>
         </Box>
       </Box>
@@ -332,6 +355,13 @@ export default function AIChatAssistant(): JSX.Element {
         <Box sx={{ px: 2, py: 1.1, borderBottom: "1px solid rgba(245,158,11,0.25)", bgcolor: "rgba(245,158,11,0.1)" }}>
           <Typography sx={{ fontSize: 11, color: "#fbbf24" }}>
             Assistant not configured. Set `GEMINI_API_KEY` on the API server.
+          </Typography>
+        </Box>
+      )}
+      {assistantConfigured && circuitDegraded && (
+        <Box sx={{ px: 2, py: 1.1, borderBottom: "1px solid rgba(245,158,11,0.25)", bgcolor: "rgba(245,158,11,0.06)" }}>
+          <Typography sx={{ fontSize: 11, color: "#fbbf24" }}>
+            Assistant degraded — responses may be slow or unavailable. Retrying automatically.
           </Typography>
         </Box>
       )}


### PR DESCRIPTION
## Changes

### Backend (`api/`)
- **Circuit Breaker Implementation**: Added thread-safe `_CircuitBreaker` class with three states (CLOSED, OPEN, HALF_OPEN) to detect and automatically short-circuit failing Gemini API requests
- **Configurable Settings**: Added three new environment variables:
  - `GEMINI_TIMEOUT_SECONDS` (default 60s, range 1-300s)
  - `GEMINI_CIRCUIT_BREAKER_THRESHOLD` (default 5 consecutive failures)
  - `GEMINI_CIRCUIT_BREAKER_COOLDOWN_SECONDS` (default 60s before probe allowed)
- **New Health Endpoint**: `/assistant/health` returns circuit state, failure count, and cooldown remaining time
- **Enhanced Error Handling**: Requests now fail fast when circuit is open; failures and exceptions are properly logged and recorded
- **Comprehensive Tests**: 312 lines of new tests covering circuit breaker state transitions, timeout configuration, failure tracking, and short-circuit behavior

### Frontend (`ui/src/components/AIChatAssistant.tsx`)
- **Health Polling**: Added periodic health checks to detect circuit degradation (15s interval when degraded, 60s when healthy)
- **Degraded UI State**: New `circuitDegraded` state reflected in:
  - Status indicator color changes to amber and stops pulsing
  - Status text changes from "Live" to "Degraded"
  - Warning icon with tooltip explaining the situation
  - Informational banner at top of chat
- **Graceful Auto-Briefing**: Catches circuit failures in auto-briefing flow

## Impact
- Improves API reliability by preventing cascading failures when Gemini is unavailable
- Provides visibility into assistant health through UI and health endpoint
- Allows operators to tune failure tolerance and recovery timing via environment variables