### PR TITLE
fix(ops): fix rate-limit false-positive on fresh systems

### DIFF
--- a/api/notifications.py
+++ b/api/notifications.py
@@ -43,7 +43,7 @@ def _is_rate_limited(event_type: str) -> bool:
     now = time.monotonic()
     window = _rate_limit_seconds()
     with _rate_limit_lock:
-        last = _last_sent.get(event_type, 0.0)
+        last = _last_sent.get(event_type, float("-inf"))
         if now - last < window:
             return True
         _last_sent[event_type] = now


### PR DESCRIPTION
## Summary

- `_last_sent.get(event_type, 0.0)` used epoch `0.0` as the "never seen" sentinel for rate limiting
- On a freshly booted CI runner where `time.monotonic() < 900 s`, every first-time event appeared rate-limited (`now - 0.0 < 900` → True)
- Fixes 4 failing tests from #212 (`test_first_call_allowed`, `test_different_events_independent`, `test_rate_limited_event_skips_webhook`, `test_webhook_called_in_async_context`)

**Fix:** change sentinel to `float("-inf")` so `now - (-inf) = inf`, which is never within any rate-limit window.

## Test plan

- [ ] `lint-and-test (api)` passes
- [ ] All 20 notification tests pass including the 4 that failed in CI

Fixes broken CI from #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)