### PR TITLE
feat(archive): add multi-day historical replay mode

### DIFF
--- a/api/routes/archive.py
+++ b/api/routes/archive.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
-from datetime import date, datetime, timezone
+import time
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -33,6 +35,14 @@ TIMEFRAME_HOURS: dict[str, tuple[int, int]] = {
 }
 
 MAX_FIRMS_LOOKBACK_DAYS = 10
+MAX_ARCHIVE_RANGE_DAYS = int(os.getenv("MAX_ARCHIVE_RANGE_DAYS", "7"))
+INTER_DAY_DELAY_SECONDS = 2
+RANGE_REDIS_TTL_SECONDS = 7 * 86400  # 7 days
+
+
+def _redis_url() -> str:
+    """Return the Redis connection URL from environment variables."""
+    return f"redis://{os.getenv('REDIS_HOST', 'localhost')}:{os.getenv('REDIS_PORT', '6379')}"
 
 
 def _timeframe_window(date_str: str, timeframe: str) -> tuple[datetime, datetime]:
@@ -58,6 +68,91 @@ def _full_day_window(date_str: str) -> tuple[datetime, datetime]:
     start_dt = datetime(d.year, d.month, d.day, 0, 0, 0, tzinfo=timezone.utc)
     end_dt = datetime(d.year, d.month, d.day, 23, 59, 59, tzinfo=timezone.utc)
     return start_dt, end_dt
+
+
+class ArchiveRangeIngestRequest(BaseModel):
+    start_date: str  # 'YYYY-MM-DD'
+    end_date: str    # 'YYYY-MM-DD'
+
+
+class ArchiveRangeDayStatus(BaseModel):
+    date: str
+    status: str  # queued | started | finished | failed
+    error: str | None = None
+
+
+class ArchiveRangeIngestResponse(BaseModel):
+    range_job_id: str
+    dates: list[str]
+    estimated_minutes: int
+    warning: str | None = None
+
+
+class ArchiveRangeStatusResponse(BaseModel):
+    range_job_id: str
+    days: list[ArchiveRangeDayStatus]
+    overall_status: str  # queued | in_progress | completed | partial_failure | not_found
+    completed_count: int
+    total_count: int
+
+
+def _compute_range_overall_status(day_statuses: list[dict]) -> str:
+    """Derive an overall status string from the list of per-day status dicts."""
+    statuses = {d["status"] for d in day_statuses}
+    if not statuses or statuses <= {"queued"}:
+        return "queued"
+    if "started" in statuses or "queued" in statuses:
+        return "in_progress"
+    if statuses <= {"finished"}:
+        return "completed"
+    # Mix of finished + failed, no pending/started
+    return "partial_failure"
+
+
+def _run_archive_ingest_range(range_job_id: str, dates: list[str]) -> None:
+    """RQ worker task: ingest multiple archive dates sequentially.
+
+    Stores per-day status as a JSON blob in Redis under
+    ``archive_range:{range_job_id}`` so the status endpoint can report
+    fine-grained progress.  Processing continues even if individual days fail
+    so the caller can see which days succeeded.
+    """
+    import json as _json
+
+    from redis import Redis as _Redis
+
+    redis_conn = _Redis.from_url(_redis_url())
+    key = f"archive_range:{range_job_id}"
+
+    # Load the pre-initialised status map once; maintain it in memory for the
+    # rest of the loop to avoid a redundant Redis round-trip per day.
+    raw = redis_conn.get(key)
+    status_map: dict[str, dict] = (
+        _json.loads(raw)
+        if raw
+        else {d: {"status": "queued", "error": None} for d in dates}
+    )
+
+    for i, date_str in enumerate(dates):
+        status_map[date_str] = {"status": "started", "error": None}
+        redis_conn.setex(key, RANGE_REDIS_TTL_SECONDS, _json.dumps(status_map))
+
+        logger.info(
+            "Archive range ingest: day %d/%d: %s (range_job_id=%s)",
+            i + 1, len(dates), date_str, range_job_id,
+        )
+        try:
+            _run_archive_ingest(date_str, "full")
+            status_map[date_str] = {"status": "finished", "error": None}
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Archive range ingest failed for %s: %s", date_str, exc)
+            status_map[date_str] = {"status": "failed", "error": str(exc)}
+
+        redis_conn.setex(key, RANGE_REDIS_TTL_SECONDS, _json.dumps(status_map))
+
+        # Brief pause between days to stay within FIRMS rate limits
+        if i < len(dates) - 1:
+            time.sleep(INTER_DAY_DELAY_SECONDS)
 
 
 class ArchiveAvailabilityResponse(BaseModel):
@@ -186,10 +281,8 @@ async def trigger_archive_ingest(body: ArchiveIngestRequest) -> ArchiveIngestRes
     try:
         from redis import Redis
         from rq import Queue
-        import os
 
-        redis_url = f"redis://{os.getenv('REDIS_HOST', 'localhost')}:{os.getenv('REDIS_PORT', '6379')}"
-        redis_conn = Redis.from_url(redis_url)
+        redis_conn = Redis.from_url(_redis_url())
         q = Queue(connection=redis_conn, default_timeout=600)
         job = q.enqueue(_run_archive_ingest, body.date, body.timeframe)
         job_id = str(job.id)
@@ -213,10 +306,8 @@ async def get_archive_ingest_status(job_id: str) -> ArchiveIngestStatusResponse:
     try:
         from redis import Redis
         from rq.job import Job
-        import os
 
-        redis_url = f"redis://{os.getenv('REDIS_HOST', 'localhost')}:{os.getenv('REDIS_PORT', '6379')}"
-        redis_conn = Redis.from_url(redis_url)
+        redis_conn = Redis.from_url(_redis_url())
         job = Job.fetch(job_id, connection=redis_conn)
         job_status = job.get_status()
         error: str | None = None
@@ -228,3 +319,157 @@ async def get_archive_ingest_status(job_id: str) -> ArchiveIngestStatusResponse:
     except Exception as exc:
         logger.warning("Could not fetch job status for %s: %s", job_id, exc)
         return ArchiveIngestStatusResponse(status="unknown", error=None)
+
+
+@archive_router.post(
+    "/fires/archive/ingest-range",
+    response_model=ArchiveRangeIngestResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[Depends(no_cache)],
+)
+async def trigger_archive_ingest_range(body: ArchiveRangeIngestRequest) -> ArchiveRangeIngestResponse:
+    """Trigger background FIRMS re-ingest for a contiguous date range.
+
+    Each day is processed sequentially by a single RQ job.  Per-day progress
+    is tracked in Redis and available via ``GET /fires/archive/ingest-range/{range_job_id}/status``.
+    Ranges exceeding ``MAX_ARCHIVE_RANGE_DAYS`` (default 7, env-overridable) are rejected.
+    Ranges larger than 5 days include a warning about temporary DB size impact.
+    """
+    try:
+        start_d = date.fromisoformat(body.start_date)
+        end_d = date.fromisoformat(body.end_date)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid date format: {exc}. Expected YYYY-MM-DD.",
+        )
+
+    if end_d < start_d:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="end_date must be on or after start_date.",
+        )
+
+    today = date.today()
+    for d, label in [(start_d, "start_date"), (end_d, "end_date")]:
+        days_ago = (today - d).days
+        if days_ago < 0:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"{label} {d} is in the future. Cannot ingest future dates.",
+            )
+        if days_ago >= MAX_FIRMS_LOOKBACK_DAYS:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"{label} {d} is {days_ago} days ago. "
+                    f"FIRMS NRT API only supports up to {MAX_FIRMS_LOOKBACK_DAYS} days back."
+                ),
+            )
+
+    num_days = (end_d - start_d).days + 1
+    if num_days > MAX_ARCHIVE_RANGE_DAYS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Range of {num_days} days exceeds the maximum of {MAX_ARCHIVE_RANGE_DAYS}. "
+                "Reduce the date range or increase MAX_ARCHIVE_RANGE_DAYS."
+            ),
+        )
+
+    dates = [(start_d + timedelta(days=i)).isoformat() for i in range(num_days)]
+
+    warning: str | None = None
+    if num_days > 5:
+        warning = (
+            f"Ingesting {num_days} days will write a significant volume of archive data. "
+            "Archive rows carry a 3-day TTL and are cleaned up automatically, "
+            "but large ranges may temporarily increase DB size."
+        )
+
+    try:
+        import json as _json
+        import uuid as _uuid
+
+        from redis import Redis
+        from rq import Queue
+
+        redis_conn = Redis.from_url(_redis_url())
+
+        # Pre-generate the range_job_id so we can initialise Redis state before the
+        # worker starts (the status endpoint needs to see "queued" immediately).
+        range_job_id = str(_uuid.uuid4())
+        status_map = {d: {"status": "queued", "error": None} for d in dates}
+        redis_conn.setex(
+            f"archive_range:{range_job_id}",
+            RANGE_REDIS_TTL_SECONDS,
+            _json.dumps(status_map),
+        )
+
+        q = Queue(connection=redis_conn, default_timeout=num_days * 600)  # 10 min per day
+        q.enqueue(_run_archive_ingest_range, range_job_id, dates)
+
+    except Exception as exc:
+        logger.error("Failed to enqueue archive range ingest: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Worker queue unavailable. Please try again later.",
+        )
+
+    estimated_minutes = num_days * 5  # ~5 min per day (FIRMS fetch + eventize)
+
+    return ArchiveRangeIngestResponse(
+        range_job_id=range_job_id,
+        dates=dates,
+        estimated_minutes=estimated_minutes,
+        warning=warning,
+    )
+
+
+@archive_router.get(
+    "/fires/archive/ingest-range/{range_job_id}/status",
+    response_model=ArchiveRangeStatusResponse,
+)
+async def get_archive_range_status(range_job_id: str) -> ArchiveRangeStatusResponse:
+    """Return per-day completion status for a range ingest job."""
+    try:
+        import json as _json
+
+        from redis import Redis
+
+        redis_conn = Redis.from_url(_redis_url())
+        raw = redis_conn.get(f"archive_range:{range_job_id}")
+
+        if raw is None:
+            return ArchiveRangeStatusResponse(
+                range_job_id=range_job_id,
+                days=[],
+                overall_status="not_found",
+                completed_count=0,
+                total_count=0,
+            )
+
+        status_map: dict[str, dict] = _json.loads(raw)
+        days = [
+            ArchiveRangeDayStatus(date=d, status=v["status"], error=v.get("error"))
+            for d, v in sorted(status_map.items())
+        ]
+        overall = _compute_range_overall_status([{"status": v["status"]} for v in status_map.values()])
+        completed = sum(1 for v in status_map.values() if v["status"] == "finished")
+
+        return ArchiveRangeStatusResponse(
+            range_job_id=range_job_id,
+            days=days,
+            overall_status=overall,
+            completed_count=completed,
+            total_count=len(days),
+        )
+    except Exception as exc:
+        logger.warning("Could not fetch range status for %s: %s", range_job_id, exc)
+        return ArchiveRangeStatusResponse(
+            range_job_id=range_job_id,
+            days=[],
+            overall_status="not_found",
+            completed_count=0,
+            total_count=0,
+        )

--- a/api/tests/test_archive_range.py
+++ b/api/tests/test_archive_range.py
@@ -1,0 +1,283 @@
+"""Tests for multi-day archive range ingest routes and helpers."""
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.routes.archive import (
+    MAX_ARCHIVE_RANGE_DAYS,
+    MAX_FIRMS_LOOKBACK_DAYS,
+    _compute_range_overall_status,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client():
+    from api.main import app
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _error_text(resp) -> str:
+    body = resp.json()
+    return str(body.get("message") or body.get("detail") or body).lower()
+
+
+def _recent_date(days_ago: int = 1) -> str:
+    return (date.today() - timedelta(days=days_ago)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# _compute_range_overall_status
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRangeOverallStatus:
+    def test_all_queued(self):
+        assert _compute_range_overall_status([{"status": "queued"}, {"status": "queued"}]) == "queued"
+
+    def test_empty(self):
+        assert _compute_range_overall_status([]) == "queued"
+
+    def test_one_started(self):
+        result = _compute_range_overall_status([{"status": "started"}, {"status": "queued"}])
+        assert result == "in_progress"
+
+    def test_mix_queued_finished(self):
+        result = _compute_range_overall_status([{"status": "finished"}, {"status": "queued"}])
+        assert result == "in_progress"
+
+    def test_all_finished(self):
+        result = _compute_range_overall_status([{"status": "finished"}, {"status": "finished"}])
+        assert result == "completed"
+
+    def test_partial_failure(self):
+        result = _compute_range_overall_status([{"status": "finished"}, {"status": "failed"}])
+        assert result == "partial_failure"
+
+    def test_all_failed(self):
+        result = _compute_range_overall_status([{"status": "failed"}, {"status": "failed"}])
+        assert result == "partial_failure"
+
+
+# ---------------------------------------------------------------------------
+# POST /fires/archive/ingest-range — validation
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerArchiveIngestRange:
+    def test_rejects_end_before_start(self, client):
+        resp = client.post(
+            "/fires/archive/ingest-range",
+            json={"start_date": _recent_date(2), "end_date": _recent_date(3)},
+        )
+        assert resp.status_code == 422
+        assert "end_date" in _error_text(resp)
+
+    def test_rejects_future_start(self, client):
+        future = (date.today() + timedelta(days=1)).isoformat()
+        resp = client.post(
+            "/fires/archive/ingest-range",
+            json={"start_date": future, "end_date": future},
+        )
+        assert resp.status_code == 422
+        assert "future" in _error_text(resp)
+
+    def test_rejects_start_beyond_lookback(self, client):
+        too_old = (date.today() - timedelta(days=MAX_FIRMS_LOOKBACK_DAYS)).isoformat()
+        yesterday = _recent_date(1)
+        resp = client.post(
+            "/fires/archive/ingest-range",
+            json={"start_date": too_old, "end_date": yesterday},
+        )
+        assert resp.status_code == 422
+        assert str(MAX_FIRMS_LOOKBACK_DAYS) in _error_text(resp)
+
+    def test_rejects_end_beyond_lookback(self, client):
+        # end_date is within lookback but start is even older — still rejected by end check
+        # Actually both are validated. Use a case where start is valid but end is too old.
+        # With MAX_FIRMS_LOOKBACK_DAYS=10: start=9 days ago (ok), end=10 days ago < start → rejected first.
+        # Let's test: start=10 days ago directly.
+        too_old = (date.today() - timedelta(days=MAX_FIRMS_LOOKBACK_DAYS)).isoformat()
+        resp = client.post(
+            "/fires/archive/ingest-range",
+            json={"start_date": too_old, "end_date": too_old},
+        )
+        assert resp.status_code == 422
+
+    def test_rejects_range_too_large(self, client):
+        # MAX_ARCHIVE_RANGE_DAYS+1 days — but must stay within FIRMS lookback.
+        # Only possible if MAX_ARCHIVE_RANGE_DAYS < MAX_FIRMS_LOOKBACK_DAYS - 1 (default: 7 < 9)
+        if MAX_ARCHIVE_RANGE_DAYS >= MAX_FIRMS_LOOKBACK_DAYS - 1:
+            pytest.skip("Cannot construct oversized range within FIRMS lookback window")
+        end_days_ago = 1
+        start_days_ago = end_days_ago + MAX_ARCHIVE_RANGE_DAYS  # one day more than max
+        resp = client.post(
+            "/fires/archive/ingest-range",
+            json={"start_date": _recent_date(start_days_ago), "end_date": _recent_date(end_days_ago)},
+        )
+        assert resp.status_code == 422
+        assert str(MAX_ARCHIVE_RANGE_DAYS) in _error_text(resp)
+
+    def test_rejects_invalid_date_format(self, client):
+        resp = client.post(
+            "/fires/archive/ingest-range",
+            json={"start_date": "not-a-date", "end_date": _recent_date(1)},
+        )
+        assert resp.status_code == 422
+
+    @patch("rq.Queue")
+    @patch("redis.Redis")
+    def test_accepts_single_day_range(self, mock_redis_cls, mock_queue_cls, client):
+        mock_redis_cls.from_url.return_value = MagicMock()
+        mock_queue_cls.return_value.enqueue.return_value = MagicMock()
+
+        yesterday = _recent_date(1)
+        resp = client.post(
+            "/fires/archive/ingest-range",
+            json={"start_date": yesterday, "end_date": yesterday},
+        )
+        assert resp.status_code == 202
+        body = resp.json()
+        assert "range_job_id" in body
+        assert body["dates"] == [yesterday]
+        assert body["estimated_minutes"] == 5
+        assert body["warning"] is None
+
+    @patch("rq.Queue")
+    @patch("redis.Redis")
+    def test_returns_warning_for_large_range(self, mock_redis_cls, mock_queue_cls, client):
+        if MAX_ARCHIVE_RANGE_DAYS < 6:
+            pytest.skip("MAX_ARCHIVE_RANGE_DAYS too small to test warning threshold")
+        mock_redis_cls.from_url.return_value = MagicMock()
+        mock_queue_cls.return_value.enqueue.return_value = MagicMock()
+
+        end_days_ago = 1
+        start_days_ago = 6  # 6-day range → triggers warning
+        if start_days_ago > MAX_ARCHIVE_RANGE_DAYS:
+            pytest.skip("Cannot construct 6-day range within limits")
+        resp = client.post(
+            "/fires/archive/ingest-range",
+            json={"start_date": _recent_date(start_days_ago), "end_date": _recent_date(end_days_ago)},
+        )
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["warning"] is not None
+        assert "db" in body["warning"].lower() or "archive" in body["warning"].lower()
+
+    @patch("rq.Queue")
+    @patch("redis.Redis")
+    def test_dates_list_covers_full_range(self, mock_redis_cls, mock_queue_cls, client):
+        mock_redis_cls.from_url.return_value = MagicMock()
+        mock_queue_cls.return_value.enqueue.return_value = MagicMock()
+
+        start = _recent_date(3)
+        end = _recent_date(1)
+        resp = client.post(
+            "/fires/archive/ingest-range",
+            json={"start_date": start, "end_date": end},
+        )
+        assert resp.status_code == 202
+        body = resp.json()
+        assert len(body["dates"]) == 3
+        assert body["dates"][0] == start
+        assert body["dates"][-1] == end
+
+
+# ---------------------------------------------------------------------------
+# GET /fires/archive/ingest-range/{range_job_id}/status
+# ---------------------------------------------------------------------------
+
+
+class TestGetArchiveRangeStatus:
+    def test_returns_not_found_when_redis_empty(self, client):
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        with patch("redis.Redis") as mock_cls:
+            mock_cls.from_url.return_value = mock_redis
+            resp = client.get("/fires/archive/ingest-range/nonexistent-uuid/status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["overall_status"] == "not_found"
+        assert body["days"] == []
+
+    def test_returns_queued_status(self, client):
+        status_map = {
+            "2026-03-20": {"status": "queued", "error": None},
+            "2026-03-21": {"status": "queued", "error": None},
+        }
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = json.dumps(status_map).encode()
+        with patch("redis.Redis") as mock_cls:
+            mock_cls.from_url.return_value = mock_redis
+            resp = client.get("/fires/archive/ingest-range/some-range-id/status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["overall_status"] == "queued"
+        assert body["total_count"] == 2
+        assert body["completed_count"] == 0
+
+    def test_returns_completed_status(self, client):
+        status_map = {
+            "2026-03-20": {"status": "finished", "error": None},
+            "2026-03-21": {"status": "finished", "error": None},
+        }
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = json.dumps(status_map).encode()
+        with patch("redis.Redis") as mock_cls:
+            mock_cls.from_url.return_value = mock_redis
+            resp = client.get("/fires/archive/ingest-range/some-range-id/status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["overall_status"] == "completed"
+        assert body["completed_count"] == 2
+        assert body["total_count"] == 2
+
+    def test_returns_partial_failure_status(self, client):
+        status_map = {
+            "2026-03-20": {"status": "finished", "error": None},
+            "2026-03-21": {"status": "failed", "error": "FIRMS ingest failed"},
+        }
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = json.dumps(status_map).encode()
+        with patch("redis.Redis") as mock_cls:
+            mock_cls.from_url.return_value = mock_redis
+            resp = client.get("/fires/archive/ingest-range/some-range-id/status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["overall_status"] == "partial_failure"
+        assert body["completed_count"] == 1
+        # Failed day error is surfaced in the days list
+        failed = next(d for d in body["days"] if d["date"] == "2026-03-21")
+        assert failed["error"] == "FIRMS ingest failed"
+
+    def test_days_sorted_by_date(self, client):
+        status_map = {
+            "2026-03-22": {"status": "finished", "error": None},
+            "2026-03-20": {"status": "finished", "error": None},
+            "2026-03-21": {"status": "queued", "error": None},
+        }
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = json.dumps(status_map).encode()
+        with patch("redis.Redis") as mock_cls:
+            mock_cls.from_url.return_value = mock_redis
+            resp = client.get("/fires/archive/ingest-range/some-range-id/status")
+        assert resp.status_code == 200
+        body = resp.json()
+        dates = [d["date"] for d in body["days"]]
+        assert dates == sorted(dates)
+
+    def test_returns_not_found_on_redis_error(self, client):
+        with patch("redis.Redis") as mock_cls:
+            mock_cls.from_url.side_effect = ConnectionError("Redis down")
+            resp = client.get("/fires/archive/ingest-range/any-id/status")
+        assert resp.status_code == 200
+        assert resp.json()["overall_status"] == "not_found"

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Box,
   Button,
   CircularProgress,
+  LinearProgress,
   Paper,
   TextField,
   Tooltip,
@@ -27,7 +28,9 @@ import ForecastNotification from "./components/ForecastNotification";
 import RegionFilter from "./components/RegionFilter";
 import ReviewQueuePanel from "./components/ReviewQueuePanel";
 import SafetyStatusBar from "./components/SafetyStatusBar";
+import ArchiveRangeScrubber from "./components/ArchiveRangeScrubber";
 import { useArchiveData } from "./hooks/useArchiveData";
+import { useArchiveRangeData } from "./hooks/useArchiveRangeData";
 import { useEmbedMode } from "./hooks/useEmbedMode";
 import { useForecastPolling } from "./hooks/useForecastPolling";
 import { useGeolocation } from "./hooks/useGeolocation";
@@ -139,6 +142,9 @@ export default function App(): JSX.Element {
   const exitToLiveMode = useAppStore((s) => s.exitToLiveMode);
   const setArchiveDate = useAppStore((s) => s.setArchiveDate);
   const setArchiveTimeframe = useAppStore((s) => s.setArchiveTimeframe);
+  const setArchiveSubMode = useAppStore((s) => s.setArchiveSubMode);
+  const setArchiveRange = useAppStore((s) => s.setArchiveRange);
+  const setScrubDate = useAppStore((s) => s.setScrubDate);
   const safety = useAppStore((s) => s.safety);
   const enableSafetyMode = useAppStore((s) => s.enableSafetyMode);
   const disableSafetyMode = useAppStore((s) => s.disableSafetyMode);
@@ -150,9 +156,21 @@ export default function App(): JSX.Element {
   useParentFrame(isEmbedded);
 
   const isArchiveMode = archive.viewMode === "archive";
+  const isRangeMode = isArchiveMode && archive.archiveSubMode === "range";
   const isSafetyMode = safety.enabled;
   const archiveData = useArchiveData();
+  const archiveRangeData = useArchiveRangeData();
   const { requestLocation } = useGeolocation();
+
+  // Local inputs for range date pickers (not committed until "Load Range" is clicked)
+  const today = new Date().toISOString().slice(0, 10);
+  const [rangeInputStart, setRangeInputStart] = useState<string>("");
+  const [rangeInputEnd, setRangeInputEnd] = useState<string>("");
+
+  const handleLoadRange = useCallback(() => {
+    if (!rangeInputStart || !rangeInputEnd) return;
+    setArchiveRange(rangeInputStart, rangeInputEnd);
+  }, [rangeInputStart, rangeInputEnd, setArchiveRange]);
 
   useForecastPolling();
   const safetyEvents = useMemo(
@@ -291,12 +309,19 @@ export default function App(): JSX.Element {
     { label: "High Confidence", value: confidencePercent === null ? "n/a" : formatStatValue(confidencePercent, 1), unit: "%", icon: VerifiedIcon, color: "#4ade80" }
   ];
 
-  const archiveStats: StatCard[] = [
-    { label: "Time Filter", value: activeTimeframeDef?.label ?? "—", unit: "", icon: activeTimeframeDef ? TIMEFRAME_ICONS[activeTimeframeDef.id] : AccessTimeIcon, color: "#60a5fa" },
-    { label: "Active Events", value: formatStatValue(filteredEvents.length), unit: "", icon: ShowChartIcon, color: "#f97316" },
-    { label: "Max Intensity", value: maxIntensityFrp === null ? "n/a" : formatStatValue(maxIntensityFrp), unit: "MW", icon: LocalFireDepartmentIcon, color: "#ef4444" },
-    { label: "Context", value: "ARCHIVE", unit: "", icon: PublicIcon, color: "#4ade80" }
-  ];
+  const archiveStats: StatCard[] = isRangeMode
+    ? [
+      { label: "Viewing Date", value: archive.scrubDate ?? "—", unit: "", icon: AccessTimeIcon, color: "#60a5fa" },
+      { label: "Active Events", value: formatStatValue(filteredEvents.length), unit: "", icon: ShowChartIcon, color: "#f97316" },
+      { label: "Max Intensity", value: maxIntensityFrp === null ? "n/a" : formatStatValue(maxIntensityFrp), unit: "MW", icon: LocalFireDepartmentIcon, color: "#ef4444" },
+      { label: "Context", value: "REPLAY", unit: "", icon: PublicIcon, color: "#4ade80" }
+    ]
+    : [
+      { label: "Time Filter", value: activeTimeframeDef?.label ?? "—", unit: "", icon: activeTimeframeDef ? TIMEFRAME_ICONS[activeTimeframeDef.id] : AccessTimeIcon, color: "#60a5fa" },
+      { label: "Active Events", value: formatStatValue(filteredEvents.length), unit: "", icon: ShowChartIcon, color: "#f97316" },
+      { label: "Max Intensity", value: maxIntensityFrp === null ? "n/a" : formatStatValue(maxIntensityFrp), unit: "MW", icon: LocalFireDepartmentIcon, color: "#ef4444" },
+      { label: "Context", value: "ARCHIVE", unit: "", icon: PublicIcon, color: "#4ade80" }
+    ];
 
   const SAFETY_TIER_COLORS: Record<string, string> = {
     SAFE: "#22c55e", WATCH: "#eab308", WARNING: "#f97316", DANGER: "#ef4444"
@@ -467,12 +492,17 @@ export default function App(): JSX.Element {
             <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.8 }}>
               {isArchiveMode && <AccessTimeIcon sx={{ color: "#60a5fa", fontSize: 28 }} />}
               <Typography variant="h3" sx={{ color: "#fff", fontWeight: 800, lineHeight: 1.05, letterSpacing: "-0.02em" }}>
-                {isArchiveMode ? "Wildfire Snapshot" : "Wildfire Nowcast"}
+                {isRangeMode ? "Wildfire Replay" : isArchiveMode ? "Wildfire Snapshot" : "Wildfire Nowcast"}
               </Typography>
             </Box>
 
             {/* Subtitle */}
-            {isArchiveMode ? (
+            {isRangeMode ? (
+              <Typography sx={{ color: "#6b7280", maxWidth: 650, fontSize: 14, lineHeight: 1.65 }}>
+                Replaying {archive.rangeStart ?? "—"} → {archive.rangeEnd ?? "—"}.
+                {archive.scrubDate ? ` Viewing ${archive.scrubDate}.` : " Select a day on the scrubber below."}
+              </Typography>
+            ) : isArchiveMode ? (
               <Typography sx={{ color: "#6b7280", maxWidth: 650, fontSize: 14, lineHeight: 1.65 }}>
                 Viewing Archive for {archive.archiveDate ?? "—"}. Quadrant:{" "}
                 {activeTimeframeDef?.label ?? "—"}.
@@ -483,72 +513,195 @@ export default function App(): JSX.Element {
               </Typography>
             )}
 
-            {/* Archive date + timeframe controls */}
+            {/* Archive controls */}
             {isArchiveMode && (
-              <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mt: 1.5, flexWrap: "wrap" }}>
-                <TextField
-                  type="date"
-                  size="small"
-                  value={archive.archiveDate ?? ""}
-                  onChange={(e) => setArchiveDate(e.target.value)}
-                  inputProps={{ max: new Date().toISOString().slice(0, 10) }}
-                  sx={{
-                    "& .MuiOutlinedInput-root": {
-                      bgcolor: "#0d1117",
-                      borderRadius: 2,
-                      fontSize: 12,
-                      color: "#e5e7eb"
-                    },
-                    "& input": { colorScheme: "light" }
-                  }}
-                />
-                <Box sx={{ display: "flex", gap: 0.5 }}>
-                  {TIMEFRAME_DEFS.map((def) => {
-                    const Icon = TIMEFRAME_ICONS[def.id];
-                    const isSelected = archive.archiveTimeframe === def.id;
+              <Box sx={{ mt: 1.5 }}>
+                {/* Sub-mode selector: Single Day | Range */}
+                <Box sx={{ display: "flex", gap: 0, mb: 1.5, p: 0.4, bgcolor: "#0d1117", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 1.5, width: "fit-content" }}>
+                  {(["single", "range"] as const).map((mode) => {
+                    const active = archive.archiveSubMode === mode;
                     return (
-                      <Tooltip key={def.id} title={def.label}>
-                        <Box
-                          component="button"
-                          onClick={() => setArchiveTimeframe(def.id)}
-                          sx={{
-                            p: 0.8,
-                            borderRadius: 1.5,
-                            border: isSelected ? "1px solid rgba(59,130,246,0.6)" : "1px solid rgba(255,255,255,0.1)",
-                            bgcolor: isSelected ? "rgba(59,130,246,0.15)" : "#0d1117",
-                            color: isSelected ? "#60a5fa" : "#6b7280",
-                            cursor: "pointer",
-                            display: "flex",
-                            alignItems: "center",
-                            transition: "all 0.15s",
-                            "&:hover": { borderColor: "rgba(59,130,246,0.4)", color: "#93c5fd" }
-                          }}
-                        >
-                          <Icon sx={{ fontSize: 16 }} />
-                        </Box>
-                      </Tooltip>
+                      <Box
+                        key={mode}
+                        component="button"
+                        onClick={() => setArchiveSubMode(mode)}
+                        sx={{
+                          px: 1.5,
+                          py: 0.5,
+                          borderRadius: 1,
+                          fontSize: 10,
+                          fontWeight: 800,
+                          letterSpacing: "0.1em",
+                          textTransform: "uppercase",
+                          cursor: "pointer",
+                          border: "none",
+                          bgcolor: active ? (mode === "range" ? "rgba(96,165,250,0.15)" : "rgba(249,115,22,0.12)") : "transparent",
+                          color: active ? (mode === "range" ? "#60a5fa" : "#f97316") : "#6b7280",
+                          transition: "all 0.15s",
+                          "&:hover": { color: mode === "range" ? "#93c5fd" : "#fb923c" }
+                        }}
+                      >
+                        {mode === "single" ? "Single Day" : "Date Range"}
+                      </Box>
                     );
                   })}
                 </Box>
-                {/* Ingestion status indicator */}
-                {archiveData.status === "checking" && (
-                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
-                    <CircularProgress size={14} sx={{ color: "#60a5fa" }} />
-                    <Typography sx={{ fontSize: 11, color: "#6b7280" }}>Checking data…</Typography>
+
+                {/* Single-day controls */}
+                {archive.archiveSubMode === "single" && (
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+                    <TextField
+                      type="date"
+                      size="small"
+                      value={archive.archiveDate ?? ""}
+                      onChange={(e) => setArchiveDate(e.target.value)}
+                      inputProps={{ max: today }}
+                      sx={{
+                        "& .MuiOutlinedInput-root": { bgcolor: "#0d1117", borderRadius: 2, fontSize: 12, color: "#e5e7eb" },
+                        "& input": { colorScheme: "light" }
+                      }}
+                    />
+                    <Box sx={{ display: "flex", gap: 0.5 }}>
+                      {TIMEFRAME_DEFS.map((def) => {
+                        const Icon = TIMEFRAME_ICONS[def.id];
+                        const isSelected = archive.archiveTimeframe === def.id;
+                        return (
+                          <Tooltip key={def.id} title={def.label}>
+                            <Box
+                              component="button"
+                              onClick={() => setArchiveTimeframe(def.id)}
+                              sx={{
+                                p: 0.8,
+                                borderRadius: 1.5,
+                                border: isSelected ? "1px solid rgba(59,130,246,0.6)" : "1px solid rgba(255,255,255,0.1)",
+                                bgcolor: isSelected ? "rgba(59,130,246,0.15)" : "#0d1117",
+                                color: isSelected ? "#60a5fa" : "#6b7280",
+                                cursor: "pointer",
+                                display: "flex",
+                                alignItems: "center",
+                                transition: "all 0.15s",
+                                "&:hover": { borderColor: "rgba(59,130,246,0.4)", color: "#93c5fd" }
+                              }}
+                            >
+                              <Icon sx={{ fontSize: 16 }} />
+                            </Box>
+                          </Tooltip>
+                        );
+                      })}
+                    </Box>
+                    {archiveData.status === "checking" && (
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+                        <CircularProgress size={14} sx={{ color: "#60a5fa" }} />
+                        <Typography sx={{ fontSize: 11, color: "#6b7280" }}>Checking data…</Typography>
+                      </Box>
+                    )}
+                    {archiveData.status === "ingesting" && (
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+                        <CircularProgress size={14} sx={{ color: "#f97316" }} />
+                        <Typography sx={{ fontSize: 11, color: "#f97316" }}>
+                          {archiveData.message ?? "Ingesting data…"}
+                        </Typography>
+                      </Box>
+                    )}
+                    {archiveData.status === "unavailable" && (
+                      <Typography sx={{ fontSize: 11, color: "#ef4444" }}>
+                        {archiveData.message ?? "Data unavailable for this date."}
+                      </Typography>
+                    )}
                   </Box>
                 )}
-                {archiveData.status === "ingesting" && (
-                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
-                    <CircularProgress size={14} sx={{ color: "#f97316" }} />
-                    <Typography sx={{ fontSize: 11, color: "#f97316" }}>
-                      {archiveData.message ?? "Ingesting data…"}
-                    </Typography>
+
+                {/* Range controls */}
+                {archive.archiveSubMode === "range" && (
+                  <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+                      <TextField
+                        type="date"
+                        size="small"
+                        label="Start"
+                        value={rangeInputStart}
+                        onChange={(e) => setRangeInputStart(e.target.value)}
+                        inputProps={{ max: today }}
+                        InputLabelProps={{ shrink: true, sx: { fontSize: 11, color: "#6b7280" } }}
+                        sx={{
+                          "& .MuiOutlinedInput-root": { bgcolor: "#0d1117", borderRadius: 2, fontSize: 12, color: "#e5e7eb" },
+                          "& input": { colorScheme: "light" }
+                        }}
+                      />
+                      <Typography sx={{ fontSize: 10, color: "#374151" }}>→</Typography>
+                      <TextField
+                        type="date"
+                        size="small"
+                        label="End"
+                        value={rangeInputEnd}
+                        onChange={(e) => setRangeInputEnd(e.target.value)}
+                        inputProps={{ max: today, min: rangeInputStart || undefined }}
+                        InputLabelProps={{ shrink: true, sx: { fontSize: 11, color: "#6b7280" } }}
+                        sx={{
+                          "& .MuiOutlinedInput-root": { bgcolor: "#0d1117", borderRadius: 2, fontSize: 12, color: "#e5e7eb" },
+                          "& input": { colorScheme: "light" }
+                        }}
+                      />
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={handleLoadRange}
+                        disabled={!rangeInputStart || !rangeInputEnd || archiveRangeData.status === "loading"}
+                        sx={{
+                          fontSize: 10,
+                          fontWeight: 800,
+                          letterSpacing: "0.1em",
+                          borderColor: "rgba(96,165,250,0.4)",
+                          color: "#60a5fa",
+                          "&:hover": { borderColor: "rgba(96,165,250,0.7)", bgcolor: "rgba(96,165,250,0.07)" },
+                          "&.Mui-disabled": { borderColor: "rgba(255,255,255,0.08)", color: "#374151" }
+                        }}
+                      >
+                        Load Range
+                      </Button>
+                    </Box>
+
+                    {/* Range ingest progress */}
+                    {archiveRangeData.status === "loading" && archiveRangeData.totalCount > 0 && (
+                      <Box sx={{ maxWidth: 420 }}>
+                        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 0.5 }}>
+                          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+                            <CircularProgress size={12} sx={{ color: "#60a5fa" }} />
+                            <Typography sx={{ fontSize: 11, color: "#6b7280" }}>
+                              {archiveRangeData.message ?? "Loading range…"}
+                            </Typography>
+                          </Box>
+                          <Typography sx={{ fontSize: 10, color: "#374151", fontVariantNumeric: "tabular-nums" }}>
+                            {archiveRangeData.completedCount}/{archiveRangeData.totalCount}
+                          </Typography>
+                        </Box>
+                        <LinearProgress
+                          variant="determinate"
+                          value={archiveRangeData.totalCount > 0 ? (archiveRangeData.completedCount / archiveRangeData.totalCount) * 100 : 0}
+                          sx={{
+                            height: 3,
+                            borderRadius: 2,
+                            bgcolor: "rgba(255,255,255,0.06)",
+                            "& .MuiLinearProgress-bar": { bgcolor: "#60a5fa", borderRadius: 2 }
+                          }}
+                        />
+                      </Box>
+                    )}
+
+                    {/* Warning for large ranges */}
+                    {archiveRangeData.warning && (
+                      <Typography sx={{ fontSize: 11, color: "#eab308", maxWidth: 500 }}>
+                        ⚠ {archiveRangeData.warning}
+                      </Typography>
+                    )}
+
+                    {/* Error */}
+                    {archiveRangeData.status === "unavailable" && (
+                      <Typography sx={{ fontSize: 11, color: "#ef4444" }}>
+                        {archiveRangeData.message ?? "Range ingest unavailable."}
+                      </Typography>
+                    )}
                   </Box>
-                )}
-                {archiveData.status === "unavailable" && (
-                  <Typography sx={{ fontSize: 11, color: "#ef4444" }}>
-                    {archiveData.message ?? "Data unavailable for this date."}
-                  </Typography>
                 )}
               </Box>
             )}
@@ -634,6 +787,17 @@ export default function App(): JSX.Element {
                 confidenceFilter={confidenceFilter}
               />
             </Box>
+
+            {/* Timeline scrubber — visible only in range mode once at least one day status exists */}
+            {isRangeMode && archive.rangeStart && archive.rangeEnd && archiveRangeData.dayStatuses.length > 0 && (
+              <ArchiveRangeScrubber
+                startDate={archive.rangeStart}
+                endDate={archive.rangeEnd}
+                scrubDate={archive.scrubDate}
+                dayStatuses={archiveRangeData.dayStatuses}
+                onScrub={setScrubDate}
+              />
+            )}
 
             <Box
               sx={{

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -395,6 +395,45 @@ export async function triggerArchiveIngest(
   return postJson<ArchiveIngestResponse>("/fires/archive/ingest", { date, timeframe }, 202);
 }
 
+export type ArchiveDayIngestStatus = 'queued' | 'started' | 'finished' | 'failed';
+export type ArchiveRangeOverallStatus = 'queued' | 'in_progress' | 'completed' | 'partial_failure' | 'not_found';
+
+export interface ArchiveRangeDayStatus {
+  date: string;
+  status: ArchiveDayIngestStatus;
+  error: string | null;
+}
+
+export interface ArchiveRangeIngestResponse {
+  range_job_id: string;
+  dates: string[];
+  estimated_minutes: number;
+  warning: string | null;
+}
+
+export interface ArchiveRangeStatusResponse {
+  range_job_id: string;
+  days: ArchiveRangeDayStatus[];
+  overall_status: ArchiveRangeOverallStatus;
+  completed_count: number;
+  total_count: number;
+}
+
+export async function triggerArchiveRangeIngest(
+  startDate: string,
+  endDate: string
+): Promise<ArchiveRangeIngestResponse> {
+  return postJson<ArchiveRangeIngestResponse>(
+    "/fires/archive/ingest-range",
+    { start_date: startDate, end_date: endDate },
+    202
+  );
+}
+
+export async function getArchiveRangeStatus(rangeJobId: string): Promise<ArchiveRangeStatusResponse> {
+  return getJson<ArchiveRangeStatusResponse>(`/fires/archive/ingest-range/${rangeJobId}/status`, {});
+}
+
 export async function getDenoiserReviewQueue(): Promise<ReviewQueueResponse> {
   return getJson<ReviewQueueResponse>("/internal/denoiser/review-queue", { limit: 200, status: "open" });
 }

--- a/ui/src/components/ArchiveRangeScrubber.tsx
+++ b/ui/src/components/ArchiveRangeScrubber.tsx
@@ -1,0 +1,258 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Box,
+  IconButton,
+  Slider,
+  Tooltip,
+  Typography
+} from "@mui/material";
+import PauseIcon from "@mui/icons-material/Pause";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import SkipNextIcon from "@mui/icons-material/SkipNext";
+import SkipPreviousIcon from "@mui/icons-material/SkipPrevious";
+
+import type { ArchiveDayIngestStatus, ArchiveRangeDayStatus } from "../api/client";
+import { datesInRange } from "../utils/time";
+
+interface ArchiveRangeScrubberProps {
+  startDate: string;             // 'YYYY-MM-DD'
+  endDate: string;               // 'YYYY-MM-DD'
+  scrubDate: string | null;
+  dayStatuses: ArchiveRangeDayStatus[];
+  onScrub: (date: string) => void;
+}
+
+// Speed label → milliseconds per day step
+const PLAY_SPEEDS_MS: Record<string, number> = {
+  "0.5×": 2000,
+  "1×": 1000,
+  "2×": 500,
+};
+
+function statusColor(status: ArchiveDayIngestStatus | undefined): string {
+  switch (status) {
+    case "finished": return "#4ade80";
+    case "started":  return "#f97316";
+    case "failed":   return "#ef4444";
+    default:         return "#374151"; // queued / unknown
+  }
+}
+
+export default function ArchiveRangeScrubber({
+  startDate,
+  endDate,
+  scrubDate,
+  dayStatuses,
+  onScrub,
+}: ArchiveRangeScrubberProps) {
+  // Memoize derived values so they don't recompute on every render
+  const dates = useMemo(() => datesInRange(startDate, endDate), [startDate, endDate]);
+  const statusByDate = useMemo(
+    () => Object.fromEntries(dayStatuses.map((d) => [d.date, d.status])) as Record<string, ArchiveDayIngestStatus>,
+    [dayStatuses]
+  );
+
+  const currentIndex = scrubDate ? Math.max(0, dates.indexOf(scrubDate)) : 0;
+
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [speedLabel, setSpeedLabel] = useState<string>("1×");
+  const playRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Refs for mutable playback state — lets advanceToNext stay stable across renders
+  // so the playback interval is not unnecessarily restarted on each scrub step.
+  const datesRef = useRef(dates);
+  datesRef.current = dates;
+  const statusByDateRef = useRef(statusByDate);
+  statusByDateRef.current = statusByDate;
+  const scrubDateRef = useRef(scrubDate);
+  scrubDateRef.current = scrubDate;
+  const onScrubRef = useRef(onScrub);
+  onScrubRef.current = onScrub;
+
+  const stopPlay = useCallback(() => {
+    if (playRef.current !== null) {
+      clearInterval(playRef.current);
+      playRef.current = null;
+    }
+    setIsPlaying(false);
+  }, []);
+
+  const stopPlayRef = useRef(stopPlay);
+  stopPlayRef.current = stopPlay;
+
+  // Stable callback — reads current values from refs, so the playback interval
+  // doesn't need to restart every time scrubDate changes.
+  const advanceToNext = useCallback(() => {
+    const currentDates = datesRef.current;
+    const currentScrubDate = scrubDateRef.current;
+    const currentStatusByDate = statusByDateRef.current;
+
+    if (!currentScrubDate) {
+      onScrubRef.current(currentDates[0]);
+      return;
+    }
+    const idx = currentDates.indexOf(currentScrubDate);
+    if (idx < 0 || idx >= currentDates.length - 1) {
+      stopPlayRef.current();
+      return;
+    }
+    const nextDate = currentDates[idx + 1];
+    // Only advance to dates that have finished ingesting
+    if (currentStatusByDate[nextDate] === "finished") {
+      onScrubRef.current(nextDate);
+    }
+  }, []); // stable — intentionally no deps; reads from refs above
+
+  // Restart interval only when play state or speed changes (not on every scrub step)
+  useEffect(() => {
+    if (!isPlaying) return;
+    const intervalMs = PLAY_SPEEDS_MS[speedLabel] ?? 1000;
+    playRef.current = setInterval(advanceToNext, intervalMs);
+    return () => {
+      if (playRef.current !== null) clearInterval(playRef.current);
+    };
+  }, [isPlaying, speedLabel, advanceToNext]);
+
+  // Stop playback when component unmounts
+  useEffect(() => () => stopPlay(), [stopPlay]);
+
+  const handlePlayPause = () => {
+    if (isPlaying) {
+      stopPlay();
+    } else {
+      setIsPlaying(true);
+    }
+  };
+
+  const handleSliderChange = (_: Event, value: number | number[]) => {
+    if (Array.isArray(value)) return;
+    const date = dates[value];
+    if (date) onScrub(date);
+    stopPlay();
+  };
+
+  const handlePrev = () => {
+    stopPlay();
+    const idx = scrubDate ? dates.indexOf(scrubDate) : 0;
+    if (idx > 0) onScrub(dates[idx - 1]);
+  };
+
+  const handleNext = () => {
+    stopPlay();
+    const idx = scrubDate ? dates.indexOf(scrubDate) : -1;
+    if (idx < dates.length - 1) onScrub(dates[idx + 1]);
+  };
+
+  return (
+    <Box sx={{ bgcolor: "#0d1117", border: "1px solid rgba(255,255,255,0.08)", borderRadius: 2, p: 2 }}>
+      {/* Header */}
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1 }}>
+        <Typography sx={{ fontSize: 10, fontWeight: 800, letterSpacing: "0.14em", textTransform: "uppercase", color: "#6b7280" }}>
+          Timeline Scrubber
+        </Typography>
+        <Typography sx={{ fontSize: 11, color: "#60a5fa", fontWeight: 700 }}>
+          {scrubDate ?? startDate}
+        </Typography>
+      </Box>
+
+      {/* Day status track */}
+      <Box sx={{ display: "flex", gap: "2px", mb: 1.5, alignItems: "center" }}>
+        {dates.map((d) => {
+          const s = statusByDate[d];
+          const isCurrent = d === scrubDate;
+          return (
+            <Tooltip key={d} title={`${d} · ${s ?? "queued"}`}>
+              <Box
+                component="button"
+                onClick={() => { onScrub(d); stopPlay(); }}
+                sx={{
+                  flex: 1,
+                  height: 10,
+                  borderRadius: "2px",
+                  cursor: "pointer",
+                  border: isCurrent ? "1px solid #60a5fa" : "1px solid transparent",
+                  bgcolor: statusColor(s),
+                  transition: "all 0.1s",
+                  "&:hover": { opacity: 0.8 }
+                }}
+              />
+            </Tooltip>
+          );
+        })}
+      </Box>
+
+      {/* Slider */}
+      <Slider
+        value={currentIndex}
+        min={0}
+        max={Math.max(0, dates.length - 1)}
+        step={1}
+        onChange={handleSliderChange}
+        size="small"
+        sx={{
+          color: "#60a5fa",
+          "& .MuiSlider-thumb": { width: 12, height: 12 },
+          "& .MuiSlider-track": { height: 3 },
+          "& .MuiSlider-rail": { height: 3, bgcolor: "#374151" },
+          mb: 0.5
+        }}
+      />
+
+      {/* Controls */}
+      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 0.5 }}>
+        <IconButton size="small" onClick={handlePrev} disabled={currentIndex === 0} sx={{ color: "#9ca3af" }}>
+          <SkipPreviousIcon fontSize="small" />
+        </IconButton>
+        <IconButton size="small" onClick={handlePlayPause} sx={{ color: isPlaying ? "#f97316" : "#60a5fa" }}>
+          {isPlaying ? <PauseIcon fontSize="small" /> : <PlayArrowIcon fontSize="small" />}
+        </IconButton>
+        <IconButton size="small" onClick={handleNext} disabled={currentIndex >= dates.length - 1} sx={{ color: "#9ca3af" }}>
+          <SkipNextIcon fontSize="small" />
+        </IconButton>
+
+        {/* Speed selector */}
+        <Box sx={{ ml: "auto", display: "flex", gap: 0.5 }}>
+          {Object.keys(PLAY_SPEEDS_MS).map((label) => (
+            <Box
+              key={label}
+              component="button"
+              onClick={() => setSpeedLabel(label)}
+              sx={{
+                px: 1,
+                py: 0.3,
+                borderRadius: 1,
+                fontSize: 10,
+                fontWeight: 700,
+                cursor: "pointer",
+                border: speedLabel === label ? "1px solid rgba(96,165,250,0.5)" : "1px solid rgba(255,255,255,0.1)",
+                bgcolor: speedLabel === label ? "rgba(96,165,250,0.1)" : "transparent",
+                color: speedLabel === label ? "#60a5fa" : "#6b7280",
+              }}
+            >
+              {label}
+            </Box>
+          ))}
+        </Box>
+
+        <Typography sx={{ fontSize: 10, color: "#4b5563", ml: 1 }}>
+          {dates.indexOf(scrubDate ?? "") + 1}/{dates.length}
+        </Typography>
+      </Box>
+
+      {/* Legend */}
+      <Box sx={{ display: "flex", gap: 2, mt: 1 }}>
+        {[
+          { color: "#4ade80", label: "Ready" },
+          { color: "#f97316", label: "Loading" },
+          { color: "#ef4444", label: "Failed" },
+          { color: "#374151", label: "Queued" },
+        ].map(({ color, label }) => (
+          <Box key={label} sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <Box sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: color }} />
+            <Typography sx={{ fontSize: 9, color: "#6b7280" }}>{label}</Typography>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/ui/src/components/FireMap.tsx
+++ b/ui/src/components/FireMap.tsx
@@ -47,7 +47,7 @@ import {
   isForecastContourVisible,
   toRenderEvent
 } from "../map/layerUtils";
-import { computeArchiveTimeRange, computeTimeRange } from "../utils/time";
+import { computeArchiveTimeRange, computeFullDayTimeRange, computeTimeRange } from "../utils/time";
 import { eventLimitForZoom, frontLimitForZoom, shouldLoadFronts, shouldRenderCentroids, viewportBbox } from "../utils/mapMath";
 import { useDebounce } from "../hooks/useDebounce";
 import { selectionViewFromBounds } from "../utils/mapSelection";
@@ -145,11 +145,16 @@ export default function FireMap({
   const debouncedMapView = useDebounce(mapView, 400);
   const bbox = useMemo(() => viewportBbox(debouncedMapView), [debouncedMapView]);
   const timeRange = useMemo(() => {
-    if (isArchiveMode && archive.archiveDate && archive.archiveTimeframe) {
-      return computeArchiveTimeRange(archive.archiveDate, archive.archiveTimeframe);
+    if (isArchiveMode) {
+      if (archive.archiveSubMode === "range" && archive.scrubDate) {
+        return computeFullDayTimeRange(archive.scrubDate);
+      }
+      if (archive.archiveDate && archive.archiveTimeframe) {
+        return computeArchiveTimeRange(archive.archiveDate, archive.archiveTimeframe);
+      }
     }
     return computeTimeRange(filters);
-  }, [isArchiveMode, archive.archiveDate, archive.archiveTimeframe, filters]);
+  }, [isArchiveMode, archive.archiveSubMode, archive.scrubDate, archive.archiveDate, archive.archiveTimeframe, filters]);
   const normalizedSearch = searchQuery.trim().toLowerCase();
 
   const eventsQuery = useQuery({

--- a/ui/src/hooks/useArchiveData.ts
+++ b/ui/src/hooks/useArchiveData.ts
@@ -15,7 +15,7 @@ const POLL_INTERVAL_MS = 5_000;
 
 export function useArchiveData(): ArchiveDataState {
   const archive = useAppStore((s) => s.archive);
-  const { viewMode, archiveDate, archiveTimeframe } = archive;
+  const { viewMode, archiveDate, archiveTimeframe, archiveSubMode } = archive;
 
   const [state, setState] = useState<ArchiveDataState>({ status: "idle", message: null, estimatedMinutes: null });
 
@@ -39,7 +39,7 @@ export function useArchiveData(): ArchiveDataState {
   useEffect(() => {
     stopPolling();
 
-    if (viewMode !== "archive" || !archiveDate || !archiveTimeframe) {
+    if (viewMode !== "archive" || !archiveDate || !archiveTimeframe || archiveSubMode === "range") {
       setState({ status: "idle", message: null, estimatedMinutes: null });
       return;
     }
@@ -140,7 +140,7 @@ export function useArchiveData(): ArchiveDataState {
       cancelled = true;
       stopPolling();
     };
-  }, [viewMode, archiveDate, archiveTimeframe, stopPolling]);
+  }, [viewMode, archiveDate, archiveTimeframe, archiveSubMode, stopPolling]);
 
   return state;
 }

--- a/ui/src/hooks/useArchiveRangeData.ts
+++ b/ui/src/hooks/useArchiveRangeData.ts
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { getArchiveRangeStatus, triggerArchiveRangeIngest } from "../api/client";
+import type { ArchiveRangeDayStatus } from "../api/client";
+import { useAppStore } from "../state/store";
+
+export type ArchiveRangeStatus =
+  | "idle"
+  | "loading"       // ingest job enqueued, days being processed
+  | "ready"          // all (or some) days finished
+  | "error"
+  | "unavailable";
+
+export interface ArchiveRangeDataState {
+  status: ArchiveRangeStatus;
+  dayStatuses: ArchiveRangeDayStatus[];
+  completedCount: number;
+  totalCount: number;
+  message: string | null;
+  warning: string | null;
+}
+
+const POLL_INTERVAL_MS = 5_000;
+
+export function useArchiveRangeData(): ArchiveRangeDataState {
+  const archive = useAppStore((s) => s.archive);
+  const setRangeJobId = useAppStore((s) => s.setRangeJobId);
+  const { viewMode, archiveSubMode, rangeStart, rangeEnd, rangeJobId } = archive;
+
+  const [state, setState] = useState<ArchiveRangeDataState>({
+    status: "idle",
+    dayStatuses: [],
+    completedCount: 0,
+    totalCount: 0,
+    message: null,
+    warning: null,
+  });
+
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const mountedRef = useRef(true);
+  // Track last seen poll result to avoid no-op setState calls every 5 s
+  const lastPollKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    stopPolling();
+
+    if (viewMode !== "archive" || archiveSubMode !== "range" || !rangeStart || !rangeEnd) {
+      setState({ status: "idle", dayStatuses: [], completedCount: 0, totalCount: 0, message: null, warning: null });
+      return;
+    }
+
+    const start = rangeStart;
+    const end = rangeEnd;
+    let cancelled = false;
+    let activeJobId = rangeJobId;
+
+    async function pollStatus(jobId: string) {
+      if (cancelled) return;
+
+      pollRef.current = setInterval(async () => {
+        if (cancelled) {
+          stopPolling();
+          return;
+        }
+        try {
+          const result = await getArchiveRangeStatus(jobId);
+          if (cancelled) return;
+
+          const isDone =
+            result.overall_status === "completed" ||
+            result.overall_status === "partial_failure" ||
+            result.overall_status === "not_found";
+
+          // Skip setState when nothing has changed to avoid spurious re-renders
+          const pollKey = `${result.overall_status}:${result.completed_count}`;
+          if (pollKey !== lastPollKeyRef.current) {
+            lastPollKeyRef.current = pollKey;
+            setState((prev) => ({
+              ...prev,
+              status: isDone ? "ready" : "loading",
+              dayStatuses: result.days,
+              completedCount: result.completed_count,
+              totalCount: result.total_count,
+              message: isDone
+                ? null
+                : `Loading range: ${result.completed_count}/${result.total_count} days ready…`,
+            }));
+          }
+
+          if (isDone) {
+            stopPolling();
+          }
+        } catch {
+          // Keep polling on transient errors
+        }
+      }, POLL_INTERVAL_MS);
+    }
+
+    async function run() {
+      if (cancelled) return;
+
+      // If we already have a job ID (e.g., store was preserved across re-render), go straight to polling
+      if (activeJobId) {
+        setState((prev) => ({
+          ...prev,
+          status: "loading",
+          message: `Resuming range ingest…`,
+        }));
+        await pollStatus(activeJobId);
+        return;
+      }
+
+      setState({ status: "loading", dayStatuses: [], completedCount: 0, totalCount: 0, message: "Enqueueing range ingest…", warning: null });
+
+      try {
+        const result = await triggerArchiveRangeIngest(start, end);
+        if (cancelled) return;
+
+        activeJobId = result.range_job_id;
+        setRangeJobId(result.range_job_id);
+
+        setState((prev) => ({
+          ...prev,
+          status: "loading",
+          totalCount: result.dates.length,
+          message: `Loading range: 0/${result.dates.length} days ready… (~${result.estimated_minutes} min total)`,
+          warning: result.warning,
+        }));
+
+        await pollStatus(result.range_job_id);
+      } catch (err: unknown) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : "Failed to start range ingest.";
+        setState({ status: "unavailable", dayStatuses: [], completedCount: 0, totalCount: 0, message, warning: null });
+      }
+    }
+
+    run();
+
+    return () => {
+      cancelled = true;
+      stopPolling();
+    };
+  // rangeJobId is intentionally excluded: the hook itself writes it via setRangeJobId, so
+  // including it would cause a self-triggered re-run loop every time the job is enqueued.
+  // activeJobId (local var) already handles the "resume existing job" path on mount.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewMode, archiveSubMode, rangeStart, rangeEnd, setRangeJobId, stopPolling]);
+
+  return state;
+}

--- a/ui/src/state/store.ts
+++ b/ui/src/state/store.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import type { FireEvent } from "../types/api";
 import type {
   ArchiveModeState,
+  ArchiveSubMode,
   ArchiveTimeframe,
   AssistantViewContext,
   FiltersState,
@@ -56,6 +57,11 @@ const DEFAULT_ARCHIVE_STATE: ArchiveModeState = {
   viewMode: 'live',
   archiveDate: null,
   archiveTimeframe: null,
+  archiveSubMode: 'single',
+  rangeStart: null,
+  rangeEnd: null,
+  rangeJobId: null,
+  scrubDate: null,
 };
 
 function computeSafetyTier(nearestKm: number | null): SafetyTier {
@@ -118,6 +124,10 @@ interface AppStoreState {
   setArchiveDate: (date: string) => void;
   setArchiveTimeframe: (tf: ArchiveTimeframe) => void;
   setViewMode: (mode: ViewMode) => void;
+  setArchiveSubMode: (subMode: ArchiveSubMode) => void;
+  setArchiveRange: (startDate: string, endDate: string) => void;
+  setRangeJobId: (jobId: string | null) => void;
+  setScrubDate: (date: string | null) => void;
   enableSafetyMode: () => void;
   disableSafetyMode: () => void;
   setSafetyLocation: (location: UserLocationState | null) => void;
@@ -267,7 +277,7 @@ export const useAppStore = create<AppStoreState>((set) => ({
     const today = new Date();
     const date = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
     set((state) => ({
-      archive: { viewMode: 'archive', archiveDate: date, archiveTimeframe: currentTimeframe() },
+      archive: { ...state.archive, viewMode: 'archive', archiveDate: date, archiveTimeframe: currentTimeframe(), archiveSubMode: 'single' as const },
       selectedEvent: null,
       lastClick: null,
       forecast: { ...state.forecast, jobId: null, pollCount: 0, activeRequest: null, notification: null },
@@ -294,6 +304,34 @@ export const useAppStore = create<AppStoreState>((set) => ({
 
   setViewMode: (mode) => {
     set((state) => ({ archive: { ...state.archive, viewMode: mode } }));
+  },
+
+  setArchiveSubMode: (subMode) => {
+    set((state) => ({ archive: { ...state.archive, archiveSubMode: subMode } }));
+  },
+
+  setArchiveRange: (startDate, endDate) => {
+    set((state) => ({
+      archive: {
+        ...state.archive,
+        viewMode: 'archive',
+        archiveSubMode: 'range',
+        rangeStart: startDate,
+        rangeEnd: endDate,
+        rangeJobId: null,
+        scrubDate: startDate,
+      },
+      selectedEvent: null,
+      lastClick: null,
+    }));
+  },
+
+  setRangeJobId: (jobId) => {
+    set((state) => ({ archive: { ...state.archive, rangeJobId: jobId } }));
+  },
+
+  setScrubDate: (date) => {
+    set((state) => ({ archive: { ...state.archive, scrubDate: date }, selectedEvent: null, lastClick: null }));
   },
 
   focusMapOnPoint: (lat, lon, minZoom) => {

--- a/ui/src/tests/archive-range.test.ts
+++ b/ui/src/tests/archive-range.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useAppStore } from "../state/store";
+import { computeFullDayTimeRange } from "../utils/time";
+
+// ---------------------------------------------------------------------------
+// computeFullDayTimeRange
+// ---------------------------------------------------------------------------
+
+describe("computeFullDayTimeRange", () => {
+  it("returns UTC midnight to 23:59:59 for a given date", () => {
+    const { startTime, endTime } = computeFullDayTimeRange("2026-03-20");
+    expect(startTime.toISOString()).toBe("2026-03-20T00:00:00.000Z");
+    expect(endTime.toISOString()).toBe("2026-03-20T23:59:59.000Z");
+  });
+
+  it("handles month and year boundaries correctly", () => {
+    const { startTime, endTime } = computeFullDayTimeRange("2025-12-31");
+    expect(startTime.toISOString()).toBe("2025-12-31T00:00:00.000Z");
+    expect(endTime.toISOString()).toBe("2025-12-31T23:59:59.000Z");
+  });
+
+  it("startTime is strictly before endTime", () => {
+    const { startTime, endTime } = computeFullDayTimeRange("2026-01-15");
+    expect(startTime.getTime()).toBeLessThan(endTime.getTime());
+  });
+
+  it("start and end are on the same calendar date", () => {
+    const { startTime, endTime } = computeFullDayTimeRange("2026-06-01");
+    expect(startTime.toISOString().slice(0, 10)).toBe("2026-06-01");
+    expect(endTime.toISOString().slice(0, 10)).toBe("2026-06-01");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Archive range store actions
+// ---------------------------------------------------------------------------
+
+describe("archive range store", () => {
+  const baseState = useAppStore.getState();
+
+  beforeEach(() => {
+    useAppStore.setState({
+      ...baseState,
+      archive: {
+        viewMode: "live",
+        archiveDate: null,
+        archiveTimeframe: null,
+        archiveSubMode: "single",
+        rangeStart: null,
+        rangeEnd: null,
+        rangeJobId: null,
+        scrubDate: null,
+      },
+    });
+  });
+
+  it("setArchiveSubMode switches between single and range", () => {
+    useAppStore.getState().setArchiveSubMode("range");
+    expect(useAppStore.getState().archive.archiveSubMode).toBe("range");
+
+    useAppStore.getState().setArchiveSubMode("single");
+    expect(useAppStore.getState().archive.archiveSubMode).toBe("single");
+  });
+
+  it("setArchiveRange enters archive/range mode with correct dates", () => {
+    useAppStore.getState().setArchiveRange("2026-03-18", "2026-03-20");
+    const { archive } = useAppStore.getState();
+
+    expect(archive.viewMode).toBe("archive");
+    expect(archive.archiveSubMode).toBe("range");
+    expect(archive.rangeStart).toBe("2026-03-18");
+    expect(archive.rangeEnd).toBe("2026-03-20");
+    expect(archive.scrubDate).toBe("2026-03-18");  // initialised to start
+    expect(archive.rangeJobId).toBeNull();          // job not yet assigned
+  });
+
+  it("setArchiveRange clears selection", () => {
+    useAppStore.setState({ ...useAppStore.getState(), selectedEvent: {} as never, lastClick: {} as never });
+    useAppStore.getState().setArchiveRange("2026-03-18", "2026-03-20");
+    expect(useAppStore.getState().selectedEvent).toBeNull();
+    expect(useAppStore.getState().lastClick).toBeNull();
+  });
+
+  it("setRangeJobId stores the job id", () => {
+    const id = "test-range-job-uuid";
+    useAppStore.getState().setRangeJobId(id);
+    expect(useAppStore.getState().archive.rangeJobId).toBe(id);
+  });
+
+  it("setRangeJobId accepts null to clear", () => {
+    useAppStore.getState().setRangeJobId("something");
+    useAppStore.getState().setRangeJobId(null);
+    expect(useAppStore.getState().archive.rangeJobId).toBeNull();
+  });
+
+  it("setScrubDate advances the current viewing date", () => {
+    useAppStore.getState().setArchiveRange("2026-03-18", "2026-03-20");
+    useAppStore.getState().setScrubDate("2026-03-19");
+    expect(useAppStore.getState().archive.scrubDate).toBe("2026-03-19");
+  });
+
+  it("setScrubDate clears selection and lastClick", () => {
+    useAppStore.setState({ ...useAppStore.getState(), selectedEvent: {} as never, lastClick: {} as never });
+    useAppStore.getState().setScrubDate("2026-03-19");
+    expect(useAppStore.getState().selectedEvent).toBeNull();
+    expect(useAppStore.getState().lastClick).toBeNull();
+  });
+
+  it("exitToLiveMode resets all range fields", () => {
+    useAppStore.getState().setArchiveRange("2026-03-18", "2026-03-20");
+    useAppStore.getState().setRangeJobId("some-job");
+    useAppStore.getState().setScrubDate("2026-03-19");
+    useAppStore.getState().exitToLiveMode();
+
+    const { archive } = useAppStore.getState();
+    expect(archive.viewMode).toBe("live");
+    expect(archive.archiveSubMode).toBe("single");
+    expect(archive.rangeStart).toBeNull();
+    expect(archive.rangeEnd).toBeNull();
+    expect(archive.rangeJobId).toBeNull();
+    expect(archive.scrubDate).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Date range enumeration (mirrors the backend's date list logic)
+// ---------------------------------------------------------------------------
+
+describe("range date enumeration", () => {
+  function datesInRange(start: string, end: string): string[] {
+    const dates: string[] = [];
+    const startMs = Date.parse(start);
+    const endMs = Date.parse(end);
+    for (let ms = startMs; ms <= endMs; ms += 86_400_000) {
+      dates.push(new Date(ms).toISOString().slice(0, 10));
+    }
+    return dates;
+  }
+
+  it("generates a single date for same start and end", () => {
+    expect(datesInRange("2026-03-20", "2026-03-20")).toEqual(["2026-03-20"]);
+  });
+
+  it("generates all dates inclusive", () => {
+    const dates = datesInRange("2026-03-18", "2026-03-20");
+    expect(dates).toEqual(["2026-03-18", "2026-03-19", "2026-03-20"]);
+  });
+
+  it("handles month crossings", () => {
+    const dates = datesInRange("2026-01-30", "2026-02-02");
+    expect(dates).toEqual(["2026-01-30", "2026-01-31", "2026-02-01", "2026-02-02"]);
+  });
+
+  it("length matches (end - start) + 1 days", () => {
+    const dates = datesInRange("2026-03-15", "2026-03-21");
+    expect(dates).toHaveLength(7);
+  });
+});

--- a/ui/src/types/state.ts
+++ b/ui/src/types/state.ts
@@ -2,11 +2,18 @@ import type { FireEvent } from "./api";
 
 export type ViewMode = 'live' | 'archive';
 export type ArchiveTimeframe = 'morning' | 'afternoon' | 'evening' | 'night';
+export type ArchiveSubMode = 'single' | 'range';
 
 export interface ArchiveModeState {
   viewMode: ViewMode;
-  archiveDate: string | null;  // 'YYYY-MM-DD'
+  archiveDate: string | null;       // 'YYYY-MM-DD' — used in single-day mode
   archiveTimeframe: ArchiveTimeframe | null;
+  // Range-mode fields (active when archiveSubMode === 'range')
+  archiveSubMode: ArchiveSubMode;
+  rangeStart: string | null;        // 'YYYY-MM-DD'
+  rangeEnd: string | null;          // 'YYYY-MM-DD'
+  rangeJobId: string | null;
+  scrubDate: string | null;         // current day displayed in range playback
 }
 
 export interface FiltersState {

--- a/ui/src/utils/time.ts
+++ b/ui/src/utils/time.ts
@@ -54,6 +54,24 @@ export function currentTimeframe(): ArchiveTimeframe {
   return 'afternoon';
 }
 
+/** Return every calendar date (YYYY-MM-DD) from start to end, inclusive. */
+export function datesInRange(start: string, end: string): string[] {
+  const dates: string[] = [];
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  for (let ms = startMs; ms <= endMs; ms += 86_400_000) {
+    dates.push(new Date(ms).toISOString().slice(0, 10));
+  }
+  return dates;
+}
+
+export function computeFullDayTimeRange(date: string): { startTime: Date; endTime: Date } {
+  const [year, month, day] = date.split('-').map(Number);
+  const startTime = new Date(Date.UTC(year, month - 1, day, 0, 0, 0, 0));
+  const endTime = new Date(Date.UTC(year, month - 1, day, 23, 59, 59, 0));
+  return { startTime, endTime };
+}
+
 export function formatTimeWindow(filters: FiltersState): string {
   const hours = filters.hoursStart - filters.hoursEnd;
   if (filters.hoursEnd === 0) {


### PR DESCRIPTION
## Overview
Adds support for ingesting and replaying multiple consecutive days of historical fire data. Users can now select a date range, trigger background ingestion of FIRMS data for all days in the range, and scrub through the loaded days with a timeline player.

## Backend Changes
- **New endpoints**:
  - `POST /fires/archive/ingest-range`: Trigger multi-day range ingest with validation
  - `GET /fires/archive/ingest-range/{range_job_id}/status`: Poll per-day progress
- **Worker task**: `_run_archive_ingest_range()` processes days sequentially with per-day status tracking in Redis
- **Validation**: Enforces max range size (7 days by default, env-configurable), FIRMS lookback limits (10 days), and future date checks
- **Warnings**: Large ranges (>5 days) surface a warning about temporary DB size impact
- **Tests**: Comprehensive test suite in `test_archive_range.py` covering validation, status transitions, and error handling

## Frontend Changes
- **Archive sub-modes**: Switch between "Single Day" and "Date Range" archive views
- **New components**:
  - `ArchiveRangeScrubber`: Timeline scrubber with play/pause controls, speed adjustment, and per-day status visualization
  - Range date pickers with "Load Range" button
  - Progress bar showing ingest completion
- **State management**: New store fields for `archiveSubMode`, `rangeStart`, `rangeEnd`, `scrubDate`
- **Hook**: `useArchiveRangeData()` polls ingest progress and surfaces day statuses
- **UI updates**: Conditional stats card and subtitle text based on replay mode

## New Utilities
- `datesInRange()`: Generate list of ISO date strings between two dates
- API client methods: `triggerArchiveRangeIngest()`, `getArchiveRangeStatus()`