### PR TITLE
fix: replace get_event_loop() with get_running_loop() in async SSE generator (closes #217)

### DIFF
--- a/api/routes/forecast.py
+++ b/api/routes/forecast.py
@@ -498,7 +498,7 @@ async def _job_status_event_stream(
     Yields:
         SSE formatted event strings with job status updates
     """
-    start_time = asyncio.get_event_loop().time()
+    start_time = asyncio.get_running_loop().time()
     last_status = None
     
     status_messages = {
@@ -513,7 +513,7 @@ async def _job_status_event_stream(
     try:
         while True:
             # Check for timeout
-            elapsed = asyncio.get_event_loop().time() - start_time
+            elapsed = asyncio.get_running_loop().time() - start_time
             if elapsed > max_duration:
                 yield f"event: timeout\ndata: {json.dumps({'message': 'Stream timeout - check status endpoint'})}\n\n"
                 break


### PR DESCRIPTION
## Summary
Fixes #217

`asyncio.get_event_loop()` was called inside an async generator (`_job_status_event_stream`) in `api/routes/forecast.py`. In Python 3.10+, calling `get_event_loop()` from within a running coroutine emits a DeprecationWarning and can return an incorrect event loop in some execution contexts. The fix replaces both occurrences with `asyncio.get_running_loop()`, which is the correct API when called from inside an async context.

## Test plan
- [ ] Existing tests pass (`uv run pytest -m "not integration"`)
- [ ] No DeprecationWarning emitted during SSE stream heartbeat/timeout logic
- [ ] SSE job-status stream behaves identically at runtime