### PR TITLE
fix: asyncio.CancelledError swallowed in SSE stream — cancellation never propagates (closes #218)

### DIFF
--- a/api/routes/forecast.py
+++ b/api/routes/forecast.py
@@ -556,6 +556,7 @@ async def _job_status_event_stream(
     except asyncio.CancelledError:
         # Client disconnected
         yield f"event: close\ndata: {json.dumps({'message': 'Client disconnected'})}\n\n"
+        raise
     except Exception as e:
         yield f"event: error\ndata: {json.dumps({'message': str(e)})}\n\n"
 


### PR DESCRIPTION
## Summary
Fixes #218

When a client disconnects from the SSE stream in `_job_status_event_stream`, the `asyncio.CancelledError` was caught and a close event was yielded, but the exception was never re-raised. This prevented FastAPI/Starlette from properly tearing down the streaming task, leaving background polling loops running indefinitely and leaking resources on every client disconnect.

This fix adds `raise` after the yield statement to ensure the cancellation properly propagates.

## Test plan
- [x] Python syntax validation
- [ ] Existing tests pass (CI will verify)
- [ ] Manual verification: background polling loops are properly cleaned up on client disconnect