### PR TITLE
fix: SQLite connection leaked in _write_gpkg when early execute calls fail (closes #219)

### DIFF
--- a/api/routes/exports.py
+++ b/api/routes/exports.py
@@ -92,34 +92,34 @@ def _write_gpkg(features: list[dict], layer_name: str, prop_names: list[str]) ->
     tmp.close()
     try:
         con = sqlite3.connect(tmp.name)
-        con.executescript(
-            "PRAGMA application_id = 1196444487;"  # 0x47504b47
-            "PRAGMA user_version = 10300;"          # GeoPackage 1.3
-            + _GPKG_SCHEMA_SQL
-        )
-        con.execute(
-            "INSERT INTO gpkg_spatial_ref_sys VALUES (?,?,?,?,?,?)",
-            ("WGS 84", _DEFAULT_SRID, "EPSG", _DEFAULT_SRID, _WGS84_WKT, "WGS 84 geographic 2D CRS"),
-        )
-        col_extra = (", " + ", ".join(f'"{p}" TEXT' for p in prop_names)) if prop_names else ""
-        con.execute(
-            f'CREATE TABLE "{layer_name}" (fid INTEGER PRIMARY KEY AUTOINCREMENT, geom BLOB{col_extra})'
-        )
-        con.execute(
-            "INSERT INTO gpkg_contents (table_name, data_type, identifier, srs_id) VALUES (?,?,?,?)",
-            (layer_name, "features", layer_name, _DEFAULT_SRID),
-        )
-        con.execute(
-            "INSERT INTO gpkg_geometry_columns VALUES (?,?,?,?,?,?)",
-            (layer_name, "geom", "GEOMETRY", _DEFAULT_SRID, 0, 0),
-        )
-        if prop_names:
-            col_list = ", ".join(f'"{p}"' for p in prop_names)
-            placeholders = ", ".join("?" * (1 + len(prop_names)))
-            insert_sql = f'INSERT INTO "{layer_name}" (geom, {col_list}) VALUES ({placeholders})'
-        else:
-            insert_sql = f'INSERT INTO "{layer_name}" (geom) VALUES (?)'
         try:
+            con.executescript(
+                "PRAGMA application_id = 1196444487;"  # 0x47504b47
+                "PRAGMA user_version = 10300;"          # GeoPackage 1.3
+                + _GPKG_SCHEMA_SQL
+            )
+            con.execute(
+                "INSERT INTO gpkg_spatial_ref_sys VALUES (?,?,?,?,?,?)",
+                ("WGS 84", _DEFAULT_SRID, "EPSG", _DEFAULT_SRID, _WGS84_WKT, "WGS 84 geographic 2D CRS"),
+            )
+            col_extra = (", " + ", ".join(f'"{p}" TEXT' for p in prop_names)) if prop_names else ""
+            con.execute(
+                f'CREATE TABLE "{layer_name}" (fid INTEGER PRIMARY KEY AUTOINCREMENT, geom BLOB{col_extra})'
+            )
+            con.execute(
+                "INSERT INTO gpkg_contents (table_name, data_type, identifier, srs_id) VALUES (?,?,?,?)",
+                (layer_name, "features", layer_name, _DEFAULT_SRID),
+            )
+            con.execute(
+                "INSERT INTO gpkg_geometry_columns VALUES (?,?,?,?,?,?)",
+                (layer_name, "geom", "GEOMETRY", _DEFAULT_SRID, 0, 0),
+            )
+            if prop_names:
+                col_list = ", ".join(f'"{p}"' for p in prop_names)
+                placeholders = ", ".join("?" * (1 + len(prop_names)))
+                insert_sql = f'INSERT INTO "{layer_name}" (geom, {col_list}) VALUES ({placeholders})'
+            else:
+                insert_sql = f'INSERT INTO "{layer_name}" (geom) VALUES (?)'
             rows = [
                 [_gpkg_geom_bytes(feat["geometry"]) if feat.get("geometry") else None]
                 + ["" if (v := (feat.get("properties") or {}).get(p)) is None else str(v) for p in prop_names]


### PR DESCRIPTION
## Summary
Fixes #219

The SQLite connection opened in `_write_gpkg` was not being closed if an exception occurred during schema setup (`executescript` or early `execute` calls). The connection is now properly wrapped in a try/finally block that ensures `con.close()` is always called, preventing file descriptor leaks.

## Changes
- Moved the inner `try/finally` block that closes the connection to wrap all database operations starting from `executescript`
- This ensures the connection is closed even if schema setup or early execute calls fail

## Test plan
- Existing tests continue to pass
- GeoPackage export functionality remains unchanged for successful cases
- Connection will now be properly cleaned up on schema setup failures