### PR TITLE
fix: compare fallback GFS age against wall-clock time (closes #220)

### DIFF
--- a/ingest/weather_ingest.py
+++ b/ingest/weather_ingest.py
@@ -1122,10 +1122,10 @@ def ingest_weather_for_bbox(
     except httpx.HTTPStatusError as exc:
         error_ctx = _extract_error_context(exc)
         prev_run_time = forecast_time - timedelta(hours=6)
-        
+
         # Check if fallback would exceed max age
         if max_fallback_age_hours > 0:
-            fallback_age_hours = (forecast_time - prev_run_time).total_seconds() / 3600
+            fallback_age_hours = (datetime.now(timezone.utc) - prev_run_time).total_seconds() / 3600
             if fallback_age_hours > max_fallback_age_hours:
                 LOGGER.error(
                     "Fallback cycle %s would be %.1f hours old, exceeding max age of %d hours. "


### PR DESCRIPTION
## Summary
Fixes #220

The fallback age guard in GFS weather ingestion was permanently dead code. Since `prev_run_time` is defined as `forecast_time - timedelta(hours=6)`, the condition `(forecast_time - prev_run_time) > max_fallback_age_hours` always evaluated to `6h > 12h` (always False).

This fix changes the age calculation to use `datetime.now(timezone.utc)` instead of `forecast_time`, so the guard properly rejects stale fallback GFS cycles that exceed the configured maximum age.

## Test plan
- [x] Syntax check passes (Python 3.11)
- [x] Ruff linter passes
- [x] Minimal fix targeting only the root cause