### PR TITLE
refactor(fires): introduce FireRepository class for dependency injection

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -2,7 +2,11 @@
 
 from typing import Callable, Optional
 
-from fastapi import Response
+from fastapi import Depends, Response
+from sqlalchemy.engine import Engine
+
+from api.db import get_engine
+from api.fires.repository import FireRepository
 
 
 def cache_control(max_age: Optional[int] = None) -> Callable[[Response], None]:
@@ -22,3 +26,8 @@ def cache_control(max_age: Optional[int] = None) -> Callable[[Response], None]:
 cache_60 = cache_control(60)
 cache_300 = cache_control(300)
 no_cache = cache_control()
+
+
+def get_fire_repo(engine: Engine = Depends(get_engine)) -> FireRepository:
+    """FastAPI dependency that provides a FireRepository bound to the current engine."""
+    return FireRepository(engine)

--- a/api/fires/repository.py
+++ b/api/fires/repository.py
@@ -1,0 +1,166 @@
+"""Class-based repository for fire detection queries."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Iterable, Literal
+
+from sqlalchemy.engine import Engine
+
+import api.fires.repo as _repo
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection
+
+
+class FireRepository:
+    """Thin class wrapper around the fire detection query module."""
+
+    def __init__(self, engine: Engine) -> None:
+        self._engine = engine
+
+    def validate_bbox(self, bbox: _repo.BBox) -> None:
+        _repo.validate_bbox(bbox)
+
+    def list_fire_detections_bbox_time(
+        self,
+        bbox: _repo.BBox,
+        start_time: datetime,
+        end_time: datetime,
+        *,
+        columns: Iterable[str] = ("lat", "lon", "acq_time"),
+        limit: int | None = None,
+        order: Literal["asc", "desc"] = "asc",
+        include_noise: bool = False,
+        include_masked: bool = False,
+        min_confidence: float | None = None,
+        min_fire_likelihood: float | None = None,
+        cursor: str | None = None,
+        offset: int | None = None,
+    ) -> dict:
+        return _repo.list_fire_detections_bbox_time(
+            bbox,
+            start_time,
+            end_time,
+            columns=columns,
+            limit=limit,
+            order=order,
+            include_noise=include_noise,
+            include_masked=include_masked,
+            min_confidence=min_confidence,
+            min_fire_likelihood=min_fire_likelihood,
+            cursor=cursor,
+            offset=offset,
+        )
+
+    def list_fire_events_bbox_time(
+        self,
+        bbox: _repo.BBox,
+        start_time: datetime,
+        end_time: datetime,
+        *,
+        min_event_score: float | None = None,
+        include_review_required: bool = True,
+        limit: int = 1000,
+        cursor: str | None = None,
+        offset: int | None = None,
+    ) -> dict:
+        return _repo.list_fire_events_bbox_time(
+            bbox,
+            start_time,
+            end_time,
+            min_event_score=min_event_score,
+            include_review_required=include_review_required,
+            limit=limit,
+            cursor=cursor,
+            offset=offset,
+        )
+
+    def list_fire_fronts_bbox_time(
+        self,
+        bbox: _repo.BBox,
+        start_time: datetime,
+        end_time: datetime,
+        *,
+        min_event_score: float | None = None,
+        include_review_required: bool = True,
+        limit: int = 2000,
+        cursor: str | None = None,
+        offset: int | None = None,
+    ) -> dict:
+        return _repo.list_fire_fronts_bbox_time(
+            bbox,
+            start_time,
+            end_time,
+            min_event_score=min_event_score,
+            include_review_required=include_review_required,
+            limit=limit,
+            cursor=cursor,
+            offset=offset,
+        )
+
+    def get_fire_front_by_id(
+        self,
+        front_id: str,
+        *,
+        buffer_km: float = 0.0,
+    ) -> dict | None:
+        return _repo.get_fire_front_by_id(front_id, buffer_km=buffer_km)
+
+    def update_false_source_masking(self, batch_id: int, conn: Connection | None = None) -> int:
+        return _repo.update_false_source_masking(batch_id, conn)
+
+    def update_persistence_scores(self, batch_id: int, conn: Connection | None = None) -> int:
+        return _repo.update_persistence_scores(batch_id, conn)
+
+    def update_landcover_scores(self, batch_id: int, conn: Connection | None = None) -> int:
+        return _repo.update_landcover_scores(batch_id, conn)
+
+    def update_weather_scores(self, batch_id: int, conn: Connection | None = None) -> int:
+        return _repo.update_weather_scores(batch_id, conn)
+
+    def update_fire_likelihood(self, batch_id: int, conn: Connection | None = None) -> int:
+        return _repo.update_fire_likelihood(batch_id, conn)
+
+    def update_all_scoring_for_batch(
+        self,
+        batch_id: int,
+        conn: Connection | None = None,
+    ) -> dict[str, int]:
+        return _repo.update_all_scoring_for_batch(batch_id, conn)
+
+    def get_latest_denoiser_gate_report(self) -> dict | None:
+        return _repo.get_latest_denoiser_gate_report()
+
+    def get_latest_denoiser_coverage_status(
+        self, authority_profile: str = "wfigs_us"
+    ) -> dict | None:
+        return _repo.get_latest_denoiser_coverage_status(authority_profile)
+
+    def get_latest_denoiser_industrial_coverage_status(
+        self,
+        source_profile: str | None = None,
+        policy_version: str | None = None,
+    ) -> dict | None:
+        return _repo.get_latest_denoiser_industrial_coverage_status(
+            source_profile, policy_version
+        )
+
+    def list_recent_denoiser_drift(self, limit: int = 50) -> list[dict]:
+        return _repo.list_recent_denoiser_drift(limit)
+
+    def list_denoiser_review_queue(self, limit: int = 200, status: str = "open") -> list[dict]:
+        return _repo.list_denoiser_review_queue(limit, status)
+
+    def resolve_denoiser_review_event(
+        self,
+        event_id: str,
+        *,
+        resolved_by: str,
+        resolved_notes: str | None = None,
+    ) -> int:
+        return _repo.resolve_denoiser_review_event(
+            event_id,
+            resolved_by=resolved_by,
+            resolved_notes=resolved_notes,
+        )

--- a/api/routes/fires.py
+++ b/api/routes/fires.py
@@ -4,13 +4,8 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi_limiter.depends import RateLimiter
 
-from api.deps import cache_60
-from api.fires.repo import (
-    validate_bbox,
-    list_fire_detections_bbox_time,
-    list_fire_events_bbox_time,
-    list_fire_fronts_bbox_time,
-)
+from api.deps import cache_60, get_fire_repo
+from api.fires.repository import FireRepository
 from api.fires.geocoding import reverse_geocode_point
 
 
@@ -47,6 +42,7 @@ fires_router = APIRouter(prefix="/fires", tags=["fires"])
 
 
 def _list_detections(
+    repo: FireRepository,
     *,
     min_lon: float,
     min_lat: float,
@@ -65,7 +61,7 @@ def _list_detections(
 ):
     # Validate bbox coordinates
     try:
-        validate_bbox((min_lon, min_lat, max_lon, max_lat))
+        repo.validate_bbox((min_lon, min_lat, max_lon, max_lat))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -74,7 +70,7 @@ def _list_detections(
         columns.extend(FIRE_DETECTION_DENOISER_COLUMNS)
 
     try:
-        result = list_fire_detections_bbox_time(
+        result = repo.list_fire_detections_bbox_time(
             bbox=(min_lon, min_lat, max_lon, max_lat),
             start_time=start_time,
             end_time=end_time,
@@ -116,9 +112,11 @@ async def get_fires(
     limit: Optional[int] = Query(None, gt=0, le=10000),
     cursor: Optional[str] = Query(None, description="Opaque pagination cursor from a previous response's next_cursor field."),
     offset: Optional[int] = Query(None, ge=0, description="(Deprecated) Row offset for pagination. Use cursor instead."),
+    repo: FireRepository = Depends(get_fire_repo),
 ):
     """Alias for `/fires/detections` (kept for UI/backward compatibility)."""
     return _list_detections(
+        repo,
         min_lon=min_lon,
         min_lat=min_lat,
         max_lon=max_lon,
@@ -154,6 +152,7 @@ async def get_detections(
     limit: Optional[int] = Query(None, gt=0, le=10000),
     cursor: Optional[str] = Query(None, description="Opaque pagination cursor from a previous response's next_cursor field."),
     offset: Optional[int] = Query(None, ge=0, description="(Deprecated) Row offset for pagination. Use cursor instead."),
+    repo: FireRepository = Depends(get_fire_repo),
 ):
     """
     Get raw fire detections within a spatio-temporal window.
@@ -165,6 +164,7 @@ async def get_detections(
     By default, only non-noise detections (or those not yet scored) are returned.
     """
     return _list_detections(
+        repo,
         min_lon=min_lon,
         min_lat=min_lat,
         max_lon=max_lon,
@@ -200,15 +200,16 @@ async def get_events(
     limit: Optional[int] = Query(1000, gt=0, le=10000),
     cursor: Optional[str] = Query(None, description="Opaque pagination cursor from a previous response's next_cursor field."),
     offset: Optional[int] = Query(None, ge=0, description="(Deprecated) Row offset for pagination. Use cursor instead."),
+    repo: FireRepository = Depends(get_fire_repo),
 ):
     """Get fire events within a spatio-temporal window."""
     try:
-        validate_bbox((min_lon, min_lat, max_lon, max_lat))
+        repo.validate_bbox((min_lon, min_lat, max_lon, max_lat))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
     try:
-        result = list_fire_events_bbox_time(
+        result = repo.list_fire_events_bbox_time(
             bbox=(min_lon, min_lat, max_lon, max_lat),
             start_time=start_time,
             end_time=end_time,
@@ -247,15 +248,16 @@ async def get_fronts(
     limit: Optional[int] = Query(2000, gt=0, le=10000),
     cursor: Optional[str] = Query(None, description="Opaque pagination cursor from a previous response's next_cursor field."),
     offset: Optional[int] = Query(None, ge=0, description="(Deprecated) Row offset for pagination. Use cursor instead."),
+    repo: FireRepository = Depends(get_fire_repo),
 ):
     """Get fire fronts within a spatio-temporal window."""
     try:
-        validate_bbox((min_lon, min_lat, max_lon, max_lat))
+        repo.validate_bbox((min_lon, min_lat, max_lon, max_lat))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
     try:
-        result = list_fire_fronts_bbox_time(
+        result = repo.list_fire_fronts_bbox_time(
             bbox=(min_lon, min_lat, max_lon, max_lat),
             start_time=start_time,
             end_time=end_time,

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -21,10 +21,19 @@ if str(workspace_root) not in sys.path:
 
 @pytest.fixture(autouse=True)
 def disable_rate_limiter(monkeypatch):
-    """Bypass FastAPI rate limiting in tests to avoid Redis dependency."""
-    from fastapi_limiter.depends import RateLimiter
+    """Bypass FastAPI rate limiting in tests to avoid Redis dependency.
 
-    async def _allow(*args, **kwargs):
+    The replacement must mirror the original ``RateLimiter.__call__`` signature
+    (``request``, ``response``) so that FastAPI's dependency inspector does not
+    treat the parameters as required query-string fields.  Using ``*args`` /
+    ``**kwargs`` breaks when ``app.dependency_overrides`` is non-empty because
+    FastAPI re-inspects all dependency signatures in that code path.
+    """
+    from fastapi_limiter.depends import RateLimiter
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+    async def _allow(self, request: Request, response: Response) -> None:
         return None
 
     monkeypatch.setattr(RateLimiter, "__call__", _allow)

--- a/api/tests/test_fires_endpoint.py
+++ b/api/tests/test_fires_endpoint.py
@@ -3,20 +3,44 @@ from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
 
-import api.routes.fires as fires
+from api.deps import get_fire_repo
+from api.fires.repository import FireRepository
 from api.main import app
 
 client = TestClient(app)
 
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_repo(**method_overrides) -> FireRepository:
+    """Return a MagicMock FireRepository with validate_bbox silenced by default."""
+    repo = MagicMock(spec=FireRepository)
+    repo.validate_bbox.return_value = None
+    for name, value in method_overrides.items():
+        getattr(repo, name).return_value = value
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Tests — detections
+# ---------------------------------------------------------------------------
 
 def test_get_detections_endpoint_basic(monkeypatch):
     """Test that the /fires/detections endpoint works and calls the repo helper."""
     mock_detections = [
         {"id": 1, "lat": 42.0, "lon": 21.0, "acq_time": datetime(2025, 1, 1, tzinfo=timezone.utc)}
     ]
-    mock_list = MagicMock(return_value={"data": mock_detections, "next_cursor": None, "has_more": False, "limit": 1000})
-    # Monkeypatch where it's used
-    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+    fake_repo = _make_repo(
+        list_fire_detections_bbox_time={
+            "data": mock_detections,
+            "next_cursor": None,
+            "has_more": False,
+            "limit": 1000,
+        }
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get(
         "/fires/detections",
@@ -34,9 +58,8 @@ def test_get_detections_endpoint_basic(monkeypatch):
     data = response.json()
     assert data["count"] == 1
     assert len(data["detections"]) == 1
-    
-    # Verify defaults passed to repo
-    _, kwargs = mock_list.call_args
+
+    _, kwargs = fake_repo.list_fire_detections_bbox_time.call_args
     assert kwargs["include_noise"] is False
     assert kwargs["min_confidence"] is None
     assert "denoised_score" not in kwargs["columns"]
@@ -44,8 +67,10 @@ def test_get_detections_endpoint_basic(monkeypatch):
 
 def test_get_fires_endpoint_alias(monkeypatch):
     """Test that the /fires endpoint aliases /fires/detections."""
-    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
-    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+    fake_repo = _make_repo(
+        list_fire_detections_bbox_time={"data": [], "next_cursor": None, "has_more": False, "limit": 1000}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get(
         "/fires",
@@ -67,8 +92,10 @@ def test_get_fires_endpoint_alias(monkeypatch):
 
 def test_get_detections_endpoint_with_min_confidence(monkeypatch):
     """Test that min_confidence is passed to repo."""
-    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
-    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+    fake_repo = _make_repo(
+        list_fire_detections_bbox_time={"data": [], "next_cursor": None, "has_more": False, "limit": 1000}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     client.get(
         "/fires/detections",
@@ -83,14 +110,16 @@ def test_get_detections_endpoint_with_min_confidence(monkeypatch):
         },
     )
 
-    _, kwargs = mock_list.call_args
+    _, kwargs = fake_repo.list_fire_detections_bbox_time.call_args
     assert kwargs["min_confidence"] == 80.0
 
 
 def test_get_detections_endpoint_with_denoiser_fields(monkeypatch):
     """Test that include_denoiser_fields adds columns."""
-    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
-    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+    fake_repo = _make_repo(
+        list_fire_detections_bbox_time={"data": [], "next_cursor": None, "has_more": False, "limit": 1000}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     client.get(
         "/fires/detections",
@@ -102,7 +131,7 @@ def test_get_detections_endpoint_with_denoiser_fields(monkeypatch):
         },
     )
 
-    _, kwargs = mock_list.call_args
+    _, kwargs = fake_repo.list_fire_detections_bbox_time.call_args
     assert "denoised_score" in kwargs["columns"]
     assert "is_noise" in kwargs["columns"]
     assert "event_id" in kwargs["columns"]
@@ -113,8 +142,10 @@ def test_get_detections_endpoint_with_denoiser_fields(monkeypatch):
 
 def test_get_detections_endpoint_with_include_noise(monkeypatch):
     """Test that include_noise is passed to repo."""
-    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
-    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+    fake_repo = _make_repo(
+        list_fire_detections_bbox_time={"data": [], "next_cursor": None, "has_more": False, "limit": 1000}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     client.get(
         "/fires/detections",
@@ -126,14 +157,20 @@ def test_get_detections_endpoint_with_include_noise(monkeypatch):
         },
     )
 
-    _, kwargs = mock_list.call_args
+    _, kwargs = fake_repo.list_fire_detections_bbox_time.call_args
     assert kwargs["include_noise"] is True
 
 
+# ---------------------------------------------------------------------------
+# Tests — events
+# ---------------------------------------------------------------------------
+
 def test_get_events_endpoint(monkeypatch):
-    """Test that /fires/events delegates to list_fire_events_bbox_time."""
-    mock_events = MagicMock(return_value={"data": [{"event_id": "evt_1", "event_score": 0.95}], "next_cursor": None, "has_more": False, "limit": 1000})
-    monkeypatch.setattr(fires, "list_fire_events_bbox_time", mock_events)
+    """Test that /fires/events delegates to repo.list_fire_events_bbox_time."""
+    fake_repo = _make_repo(
+        list_fire_events_bbox_time={"data": [{"event_id": "evt_1", "event_score": 0.95}], "next_cursor": None, "has_more": False, "limit": 1000}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get(
         "/fires/events",
@@ -156,15 +193,15 @@ def test_get_events_endpoint(monkeypatch):
     assert payload["next_cursor"] is None
     assert payload["has_more"] is False
 
-    _, kwargs = mock_events.call_args
+    _, kwargs = fake_repo.list_fire_events_bbox_time.call_args
     assert kwargs["min_event_score"] == 0.5
     assert kwargs["include_review_required"] is False
 
 
 def test_get_events_endpoint_passthrough_geom_geojson(monkeypatch):
     """Test that /fires/events returns event geometry payload when provided by repo."""
-    mock_events = MagicMock(
-        return_value={"data": [
+    fake_repo = _make_repo(
+        list_fire_events_bbox_time={"data": [
             {
                 "event_id": "evt_geom_1",
                 "event_score": 0.93,
@@ -172,7 +209,7 @@ def test_get_events_endpoint_passthrough_geom_geojson(monkeypatch):
             }
         ], "next_cursor": None, "has_more": False, "limit": 1000}
     )
-    monkeypatch.setattr(fires, "list_fire_events_bbox_time", mock_events)
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get(
         "/fires/events",
@@ -195,8 +232,8 @@ def test_get_events_endpoint_passthrough_geom_geojson(monkeypatch):
 
 def test_get_events_endpoint_passthrough_geom_provenance(monkeypatch):
     """Test that /fires/events preserves geometry provenance fields from repo."""
-    mock_events = MagicMock(
-        return_value={"data": [
+    fake_repo = _make_repo(
+        list_fire_events_bbox_time={"data": [
             {
                 "event_id": "evt_geom_2",
                 "geom_source": "estimated",
@@ -207,7 +244,7 @@ def test_get_events_endpoint_passthrough_geom_provenance(monkeypatch):
             }
         ], "next_cursor": None, "has_more": False, "limit": 1000}
     )
-    monkeypatch.setattr(fires, "list_fire_events_bbox_time", mock_events)
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get(
         "/fires/events",
@@ -232,10 +269,16 @@ def test_get_events_endpoint_passthrough_geom_provenance(monkeypatch):
     assert event["authoritative_perimeter_id"] is None
 
 
+# ---------------------------------------------------------------------------
+# Tests — fronts
+# ---------------------------------------------------------------------------
+
 def test_get_fronts_endpoint(monkeypatch):
-    """Test that /fires/fronts delegates to list_fire_fronts_bbox_time."""
-    mock_fronts = MagicMock(return_value={"data": [{"front_id": "front_1", "event_id": "evt_1"}], "next_cursor": None, "has_more": False, "limit": 800})
-    monkeypatch.setattr(fires, "list_fire_fronts_bbox_time", mock_fronts)
+    """Test that /fires/fronts delegates to repo.list_fire_fronts_bbox_time."""
+    fake_repo = _make_repo(
+        list_fire_fronts_bbox_time={"data": [{"front_id": "front_1", "event_id": "evt_1"}], "next_cursor": None, "has_more": False, "limit": 800}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get(
         "/fires/fronts",
@@ -258,15 +301,15 @@ def test_get_fronts_endpoint(monkeypatch):
     assert payload["next_cursor"] is None
     assert payload["has_more"] is False
 
-    _, kwargs = mock_fronts.call_args
+    _, kwargs = fake_repo.list_fire_fronts_bbox_time.call_args
     assert kwargs["min_event_score"] == 0.5
     assert kwargs["include_review_required"] is False
 
 
 def test_get_fronts_endpoint_passthrough_geom_provenance(monkeypatch):
     """Test that /fires/fronts preserves geometry provenance fields from repo."""
-    mock_fronts = MagicMock(
-        return_value={"data": [
+    fake_repo = _make_repo(
+        list_fire_fronts_bbox_time={"data": [
             {
                 "front_id": "front_geom_1",
                 "event_id": "evt_geom_2",
@@ -278,7 +321,7 @@ def test_get_fronts_endpoint_passthrough_geom_provenance(monkeypatch):
             }
         ], "next_cursor": None, "has_more": False, "limit": 800}
     )
-    monkeypatch.setattr(fires, "list_fire_fronts_bbox_time", mock_fronts)
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get(
         "/fires/fronts",
@@ -303,10 +346,16 @@ def test_get_fronts_endpoint_passthrough_geom_provenance(monkeypatch):
     assert front["authoritative_perimeter_id"] == 12345
 
 
+# ---------------------------------------------------------------------------
+# Tests — cache control headers
+# ---------------------------------------------------------------------------
+
 def test_detections_cache_control_header(monkeypatch):
     """Verify /fires/detections sets Cache-Control: max-age=60 (E4)."""
-    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
-    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+    fake_repo = _make_repo(
+        list_fire_detections_bbox_time={"data": [], "next_cursor": None, "has_more": False, "limit": 1000}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get(
         "/fires/detections",
@@ -323,8 +372,10 @@ def test_detections_cache_control_header(monkeypatch):
 
 def test_fires_alias_cache_control_header(monkeypatch):
     """Verify /fires alias also sets Cache-Control: max-age=60 (E4)."""
-    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
-    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+    fake_repo = _make_repo(
+        list_fire_detections_bbox_time={"data": [], "next_cursor": None, "has_more": False, "limit": 1000}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get(
         "/fires",
@@ -339,8 +390,14 @@ def test_fires_alias_cache_control_header(monkeypatch):
     assert response.headers.get("cache-control") == "max-age=60"
 
 
+# ---------------------------------------------------------------------------
+# Tests — reverse geocode
+# ---------------------------------------------------------------------------
+
 def test_get_reverse_geocode_endpoint(monkeypatch):
     """Test that /fires/reverse-geocode delegates to reverse_geocode_point."""
+    import api.routes.fires as fires_module
+
     mock_reverse = MagicMock(
         return_value={
             "lat": 34.1,
@@ -351,7 +408,7 @@ def test_get_reverse_geocode_endpoint(monkeypatch):
             "location_name": "California, United States",
         }
     )
-    monkeypatch.setattr(fires, "reverse_geocode_point", mock_reverse)
+    monkeypatch.setattr(fires_module, "reverse_geocode_point", mock_reverse)
 
     response = client.get(
         "/fires/reverse-geocode",
@@ -369,8 +426,10 @@ def test_get_reverse_geocode_endpoint(monkeypatch):
 
 def test_get_reverse_geocode_endpoint_bad_request(monkeypatch):
     """Test ValueError from service is mapped to HTTP 400."""
+    import api.routes.fires as fires_module
+
     mock_reverse = MagicMock(side_effect=ValueError("Unsupported geocoding provider: bad"))
-    monkeypatch.setattr(fires, "reverse_geocode_point", mock_reverse)
+    monkeypatch.setattr(fires_module, "reverse_geocode_point", mock_reverse)
 
     response = client.get(
         "/fires/reverse-geocode",
@@ -381,7 +440,54 @@ def test_get_reverse_geocode_endpoint_bad_request(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Cursor pagination tests
+# Tests — FakeFireRepo injection (acceptance criterion: no DB required)
+# ---------------------------------------------------------------------------
+
+class FakeFireRepo:
+    """Minimal hand-written stub used to verify Depends injection works end-to-end."""
+
+    def validate_bbox(self, bbox):
+        pass
+
+    def list_fire_detections_bbox_time(self, bbox, start_time, end_time, **kwargs):
+        return {
+            "data": [{"id": 99, "lat": 50.0, "lon": 10.0}],
+            "next_cursor": None,
+            "has_more": False,
+            "limit": 500,
+        }
+
+    def list_fire_events_bbox_time(self, bbox, start_time, end_time, **kwargs):
+        return {"data": [], "next_cursor": None, "has_more": False, "limit": 1000}
+
+    def list_fire_fronts_bbox_time(self, bbox, start_time, end_time, **kwargs):
+        return {"data": [], "next_cursor": None, "has_more": False, "limit": 2000}
+
+
+def test_fake_fire_repo_injection_no_db(monkeypatch):
+    """Routes must work with a hand-written FakeFireRepo — no database needed."""
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: FakeFireRepo())
+
+    response = client.get(
+        "/fires/detections",
+        params={
+            "min_lon": 9.0,
+            "min_lat": 49.0,
+            "max_lon": 11.0,
+            "max_lat": 51.0,
+            "start_time": "2025-06-01T00:00:00Z",
+            "end_time": "2025-06-02T00:00:00Z",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    assert payload["detections"][0]["id"] == 99
+
+
+# ---------------------------------------------------------------------------
+# Tests — cursor pagination
 # ---------------------------------------------------------------------------
 
 _BASE_PARAMS = {
@@ -396,8 +502,10 @@ _BASE_PARAMS = {
 
 def test_detections_response_includes_pagination_fields(monkeypatch):
     """Response must include next_cursor and has_more even when empty."""
-    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
-    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+    fake_repo = _make_repo(
+        list_fire_detections_bbox_time={"data": [], "next_cursor": None, "has_more": False, "limit": 1000}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get("/fires/detections", params=_BASE_PARAMS)
 
@@ -410,36 +518,42 @@ def test_detections_response_includes_pagination_fields(monkeypatch):
 
 
 def test_detections_cursor_param_forwarded_to_repo(monkeypatch):
-    """cursor query param must be forwarded to list_fire_detections_bbox_time."""
-    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
-    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+    """cursor query param must be forwarded to repo.list_fire_detections_bbox_time."""
+    fake_repo = _make_repo(
+        list_fire_detections_bbox_time={"data": [], "next_cursor": None, "has_more": False, "limit": 1000}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     client.get("/fires/detections", params={**_BASE_PARAMS, "cursor": "abc123"})
 
-    _, kwargs = mock_list.call_args
+    _, kwargs = fake_repo.list_fire_detections_bbox_time.call_args
     assert kwargs["cursor"] == "abc123"
 
 
 def test_detections_offset_param_forwarded_to_repo(monkeypatch):
     """Deprecated offset query param must be forwarded to repo."""
-    mock_list = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
-    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+    fake_repo = _make_repo(
+        list_fire_detections_bbox_time={"data": [], "next_cursor": None, "has_more": False, "limit": 1000}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     client.get("/fires/detections", params={**_BASE_PARAMS, "offset": 500})
 
-    _, kwargs = mock_list.call_args
+    _, kwargs = fake_repo.list_fire_detections_bbox_time.call_args
     assert kwargs["offset"] == 500
 
 
 def test_detections_response_has_more_true(monkeypatch):
     """When repo signals has_more=True, next_cursor must be non-None in the response."""
-    mock_list = MagicMock(return_value={
-        "data": [{"id": 42, "lat": 41.0, "lon": 21.0}],
-        "next_cursor": "dGVzdGN1cnNvcg==",
-        "has_more": True,
-        "limit": 1000,
-    })
-    monkeypatch.setattr(fires, "list_fire_detections_bbox_time", mock_list)
+    fake_repo = _make_repo(
+        list_fire_detections_bbox_time={
+            "data": [{"id": 42, "lat": 41.0, "lon": 21.0}],
+            "next_cursor": "dGVzdGN1cnNvcg==",
+            "has_more": True,
+            "limit": 1000,
+        }
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get("/fires/detections", params=_BASE_PARAMS)
 
@@ -451,11 +565,9 @@ def test_detections_response_has_more_true(monkeypatch):
 
 def test_detections_invalid_cursor_returns_400(monkeypatch):
     """A malformed cursor must produce HTTP 400."""
-    monkeypatch.setattr(
-        fires,
-        "list_fire_detections_bbox_time",
-        MagicMock(side_effect=ValueError("Invalid cursor: ...")),
-    )
+    fake_repo = _make_repo()
+    fake_repo.list_fire_detections_bbox_time.side_effect = ValueError("Invalid cursor: ...")
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get("/fires/detections", params={**_BASE_PARAMS, "cursor": "!!!notvalid!!!"})
 
@@ -464,35 +576,41 @@ def test_detections_invalid_cursor_returns_400(monkeypatch):
 
 def test_events_cursor_param_forwarded_to_repo(monkeypatch):
     """cursor query param on /fires/events must be forwarded to repo."""
-    mock_events = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
-    monkeypatch.setattr(fires, "list_fire_events_bbox_time", mock_events)
+    fake_repo = _make_repo(
+        list_fire_events_bbox_time={"data": [], "next_cursor": None, "has_more": False, "limit": 1000}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     client.get("/fires/events", params={**_BASE_PARAMS, "cursor": "evtcursor"})
 
-    _, kwargs = mock_events.call_args
+    _, kwargs = fake_repo.list_fire_events_bbox_time.call_args
     assert kwargs["cursor"] == "evtcursor"
 
 
 def test_events_offset_param_forwarded_to_repo(monkeypatch):
     """Deprecated offset query param on /fires/events must be forwarded to repo."""
-    mock_events = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 1000})
-    monkeypatch.setattr(fires, "list_fire_events_bbox_time", mock_events)
+    fake_repo = _make_repo(
+        list_fire_events_bbox_time={"data": [], "next_cursor": None, "has_more": False, "limit": 1000}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     client.get("/fires/events", params={**_BASE_PARAMS, "offset": 200})
 
-    _, kwargs = mock_events.call_args
+    _, kwargs = fake_repo.list_fire_events_bbox_time.call_args
     assert kwargs["offset"] == 200
 
 
 def test_events_response_has_more_true(monkeypatch):
     """When repo signals has_more=True, next_cursor must appear in events response."""
-    mock_events = MagicMock(return_value={
-        "data": [{"event_id": "evt_x"}],
-        "next_cursor": "ZXZ0Y3Vyc29y",
-        "has_more": True,
-        "limit": 1000,
-    })
-    monkeypatch.setattr(fires, "list_fire_events_bbox_time", mock_events)
+    fake_repo = _make_repo(
+        list_fire_events_bbox_time={
+            "data": [{"event_id": "evt_x"}],
+            "next_cursor": "ZXZ0Y3Vyc29y",
+            "has_more": True,
+            "limit": 1000,
+        }
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get("/fires/events", params=_BASE_PARAMS)
 
@@ -504,35 +622,41 @@ def test_events_response_has_more_true(monkeypatch):
 
 def test_fronts_cursor_param_forwarded_to_repo(monkeypatch):
     """cursor query param on /fires/fronts must be forwarded to repo."""
-    mock_fronts = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 800})
-    monkeypatch.setattr(fires, "list_fire_fronts_bbox_time", mock_fronts)
+    fake_repo = _make_repo(
+        list_fire_fronts_bbox_time={"data": [], "next_cursor": None, "has_more": False, "limit": 800}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     client.get("/fires/fronts", params={**_BASE_PARAMS, "cursor": "frontcursor"})
 
-    _, kwargs = mock_fronts.call_args
+    _, kwargs = fake_repo.list_fire_fronts_bbox_time.call_args
     assert kwargs["cursor"] == "frontcursor"
 
 
 def test_fronts_offset_param_forwarded_to_repo(monkeypatch):
     """Deprecated offset query param on /fires/fronts must be forwarded to repo."""
-    mock_fronts = MagicMock(return_value={"data": [], "next_cursor": None, "has_more": False, "limit": 800})
-    monkeypatch.setattr(fires, "list_fire_fronts_bbox_time", mock_fronts)
+    fake_repo = _make_repo(
+        list_fire_fronts_bbox_time={"data": [], "next_cursor": None, "has_more": False, "limit": 800}
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     client.get("/fires/fronts", params={**_BASE_PARAMS, "offset": 100})
 
-    _, kwargs = mock_fronts.call_args
+    _, kwargs = fake_repo.list_fire_fronts_bbox_time.call_args
     assert kwargs["offset"] == 100
 
 
 def test_fronts_response_has_more_true(monkeypatch):
     """When repo signals has_more=True, next_cursor must appear in fronts response."""
-    mock_fronts = MagicMock(return_value={
-        "data": [{"front_id": "front_z"}],
-        "next_cursor": "ZnJvbnRjdXJzb3I=",
-        "has_more": True,
-        "limit": 800,
-    })
-    monkeypatch.setattr(fires, "list_fire_fronts_bbox_time", mock_fronts)
+    fake_repo = _make_repo(
+        list_fire_fronts_bbox_time={
+            "data": [{"front_id": "front_z"}],
+            "next_cursor": "ZnJvbnRjdXJzb3I=",
+            "has_more": True,
+            "limit": 800,
+        }
+    )
+    monkeypatch.setitem(app.dependency_overrides, get_fire_repo, lambda: fake_repo)
 
     response = client.get("/fires/fronts", params=_BASE_PARAMS)
 


### PR DESCRIPTION
## Summary

Introduce a `FireRepository` class to wrap fire detection query functions and enable FastAPI dependency injection, improving testability and decoupling.

## Changes

- **New file: `api/fires/repository.py`**
  - `FireRepository` class wraps existing fire query functions from `api.fires.repo`
  - Stores SQLAlchemy `Engine` instance for future database operations
  - Delegates all methods to underlying repo module functions

- **Updated: `api/deps.py`**
  - Add `get_fire_repo()` FastAPI dependency that returns a `FireRepository` bound to the current database engine
  - Import necessary SQLAlchemy and repository types

- **Updated: `api/routes/fires.py`**
  - Inject `FireRepository` via `Depends(get_fire_repo)` in `/fires`, `/fires/detections`, `/fires/events`, and `/fires/fronts` endpoints
  - Replace direct function calls with repository method calls
  - Update `_list_detections()` helper to accept repo as first parameter

- **Updated: `api/tests/conftest.py`**
  - Improve `disable_rate_limiter` fixture documentation
  - Fix rate limiter mock signature to match `RateLimiter.__call__` expectations with proper type hints

- **Updated: `api/tests/test_fires_endpoint.py`**
  - Refactor all tests to use `app.dependency_overrides` for injection instead of monkeypatching module functions
  - Add `_make_repo()` helper to create mock repositories
  - Add `FakeFireRepo` class demonstrating end-to-end injection without database
  - Organize tests into logical sections with clearer comments
  - All tests continue to pass without database access

## Benefits

- ✅ Cleaner dependency injection pattern using FastAPI's `Depends`
- ✅ Easier to test with mock repositories
- ✅ Better separation of concerns between routes and query logic
- ✅ Foundation for future database transaction management
