### PR TITLE
refactor(api): extract weather point lookup into shared module

### DIFF
--- a/api/core/weather.py
+++ b/api/core/weather.py
@@ -1,0 +1,150 @@
+"""Shared weather point-lookup helpers.
+
+Extracted from ``api.fires.scoring`` so that both the fire-scoring pipeline
+and the risk-grid module can use the same logic without a cross-package
+dependency on fire internals.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+from sqlalchemy import text
+
+from api.db import get_engine
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _to_numpy_datetime64(dt: datetime) -> np.datetime64:
+    """Convert a datetime to numpy datetime64 with proper UTC handling.
+
+    This helper centralizes timezone handling to avoid inconsistencies when
+    converting timezone-aware datetimes to numpy datetime64.
+
+    Args:
+        dt: A timezone-aware or naive datetime. If naive, assumed to be UTC.
+
+    Returns:
+        numpy.datetime64 in millisecond precision UTC.
+    """
+    if dt.tzinfo is None:
+        dt_utc = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt_utc = dt.astimezone(timezone.utc)
+
+    # Using 'ms' precision to avoid nanosecond overflow issues with some xarray versions
+    return np.datetime64(dt_utc.replace(tzinfo=None), "ms")
+
+
+def get_weather_data_for_point(
+    *,
+    lat: float,
+    lon: float,
+    ref_time: datetime,
+    time_tolerance_hours: float,
+    precip_lookback_hours: float,
+) -> dict[str, float] | None:
+    """Query weather data for a specific point and time.
+
+    Args:
+        lat: Latitude of the point
+        lon: Longitude of the point
+        ref_time: Reference time for weather data
+        time_tolerance_hours: Maximum time difference allowed for matching
+        precip_lookback_hours: Hours to look back for precipitation accumulation
+
+    Returns:
+        Dict with weather variables or None if data unavailable:
+        - rh2m: Relative humidity at 2m (%)
+        - precip_recent_mm: Recent precipitation accumulation (mm)
+        - wind_speed_ms: Wind speed (m/s)
+    """
+    stmt = text("""
+        SELECT id, storage_path, run_time
+        FROM weather_runs
+        WHERE status = 'completed'
+          AND run_time <= :ref_time
+          AND run_time >= :ref_time - INTERVAL '1 hour' * :tolerance_hours
+          AND COALESCE(bbox_min_lon, -180.0) <= :lon AND COALESCE(bbox_max_lon, 180.0) >= :lon
+          AND COALESCE(bbox_min_lat, -90.0) <= :lat AND COALESCE(bbox_max_lat, 90.0) >= :lat
+        ORDER BY run_time DESC, created_at DESC
+        LIMIT 1
+    """)
+
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            stmt,
+            {
+                "ref_time": ref_time,
+                "tolerance_hours": time_tolerance_hours,
+                "lat": lat,
+                "lon": lon,
+            },
+        ).mappings().first()
+
+    if not row:
+        LOGGER.debug(
+            "No weather run found for point (lat=%s, lon=%s) at time %s",
+            lat, lon, ref_time
+        )
+        return None
+
+    storage_path = Path(row["storage_path"])
+    if not storage_path.is_absolute():
+        storage_path = Path.cwd() / storage_path
+
+    ds = None
+    try:
+        ds = xr.open_dataset(storage_path)
+        ds_point = ds.sel(lat=lat, lon=lon, method="nearest")
+
+        ref_time_64 = _to_numpy_datetime64(ref_time)
+        if "time" in ds_point.coords:
+            ds_point = ds_point.sel(time=ref_time_64, method="nearest")
+
+        result: dict[str, float] = {}
+
+        if "rh2m" in ds_point.data_vars:
+            rh_val = float(ds_point["rh2m"].values)
+            if not np.isnan(rh_val):
+                result["rh2m"] = rh_val
+
+        if "u10" in ds_point.data_vars and "v10" in ds_point.data_vars:
+            u10_val = float(ds_point["u10"].values)
+            v10_val = float(ds_point["v10"].values)
+            if not np.isnan(u10_val) and not np.isnan(v10_val):
+                result["wind_speed_ms"] = float(np.sqrt(u10_val**2 + v10_val**2))
+
+        if "tp" in ds_point.data_vars and "time" in ds.coords:
+            try:
+                precip_start_64 = _to_numpy_datetime64(
+                    ref_time - timedelta(hours=precip_lookback_hours)
+                )
+                ds_precip = ds_point.sel(time=slice(precip_start_64, ref_time_64))
+
+                if "tp" in ds_precip.data_vars and len(ds_precip.time) > 0:
+                    precip_sum = float(ds_precip["tp"].sum().values)
+                    if not np.isnan(precip_sum):
+                        # GFS outputs precipitation in meters; convert to mm
+                        result["precip_recent_mm"] = precip_sum * 1000.0
+            except Exception as e:
+                LOGGER.debug(
+                    "Failed to compute precipitation accumulation: %s", e
+                )
+
+        return result if result else None
+
+    except Exception as e:
+        LOGGER.warning(
+            "Failed to load weather data from %s: %s",
+            storage_path, e
+        )
+        return None
+    finally:
+        if ds is not None:
+            ds.close()

--- a/api/fires/scoring.py
+++ b/api/fires/scoring.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime, timedelta
-from pathlib import Path
+from datetime import datetime
 from typing import Iterable
 
-import numpy as np
-import xarray as xr
 from sqlalchemy import text
 
+from api.core.weather import get_weather_data_for_point
 from api.db import get_engine
 
 LOGGER = logging.getLogger(__name__)
@@ -621,7 +619,7 @@ def compute_weather_plausibility_scores(
         acq_time = det["acq_time"]
 
         # Query weather data for this detection
-        weather_data = _get_weather_data_for_point(
+        weather_data = get_weather_data_for_point(
             lat=lat,
             lon=lon,
             ref_time=acq_time,
@@ -661,162 +659,3 @@ def compute_weather_plausibility_scores(
         scores[det_id] = score
 
     return scores
-
-
-def _to_numpy_datetime64(dt: datetime) -> np.datetime64:
-    """Convert a datetime to numpy datetime64 with proper UTC handling.
-
-    This helper centralizes timezone handling to avoid inconsistencies when
-    converting timezone-aware datetimes to numpy datetime64.
-
-    Args:
-        dt: A timezone-aware or naive datetime. If naive, assumed to be UTC.
-
-    Returns:
-        numpy.datetime64 in nanosecond precision UTC.
-    """
-    from datetime import timezone
-
-    # Ensure UTC timezone
-    if dt.tzinfo is None:
-        dt_utc = dt.replace(tzinfo=timezone.utc)
-    else:
-        dt_utc = dt.astimezone(timezone.utc)
-
-    # Convert to numpy datetime64 with explicit UTC semantics
-    # Using 'ms' precision to avoid nanosecond overflow issues with some xarray versions
-    return np.datetime64(dt_utc.replace(tzinfo=None), "ms")
-
-
-def _get_weather_data_for_point(
-    *,
-    lat: float,
-    lon: float,
-    ref_time: datetime,
-    time_tolerance_hours: float,
-    precip_lookback_hours: float,
-) -> dict[str, float] | None:
-    """Query weather data for a specific point and time.
-
-    Args:
-        lat: Latitude of the point
-        lon: Longitude of the point
-        ref_time: Reference time for weather data
-        time_tolerance_hours: Maximum time difference allowed for matching
-        precip_lookback_hours: Hours to look back for precipitation accumulation
-
-    Returns:
-        Dict with weather variables or None if data unavailable:
-        - rh2m: Relative humidity at 2m (%)
-        - precip_recent_mm: Recent precipitation accumulation (mm)
-        - wind_speed_ms: Wind speed (m/s)
-    """
-    # Query weather runs that cover this point and time
-    stmt = text("""
-        SELECT id, storage_path, run_time
-        FROM weather_runs
-        WHERE status = 'completed'
-          AND run_time <= :ref_time
-          AND run_time >= :ref_time - INTERVAL '1 hour' * :tolerance_hours
-          AND COALESCE(bbox_min_lon, -180.0) <= :lon AND COALESCE(bbox_max_lon, 180.0) >= :lon
-          AND COALESCE(bbox_min_lat, -90.0) <= :lat AND COALESCE(bbox_max_lat, 90.0) >= :lat
-        ORDER BY run_time DESC, created_at DESC
-        LIMIT 1
-    """)
-
-    with get_engine().connect() as conn:
-        row = conn.execute(
-            stmt,
-            {
-                "ref_time": ref_time,
-                "tolerance_hours": time_tolerance_hours,
-                "lat": lat,
-                "lon": lon,
-            },
-        ).mappings().first()
-
-    if not row:
-        LOGGER.debug(
-            "No weather run found for point (lat=%s, lon=%s) at time %s",
-            lat, lon, ref_time
-        )
-        return None
-
-    storage_path = Path(row["storage_path"])
-    if not storage_path.is_absolute():
-        storage_path = Path.cwd() / storage_path
-
-    if not storage_path.exists():
-        LOGGER.warning(
-            "Weather run %s file missing at %s",
-            row["id"], storage_path
-        )
-        return None
-
-    ds = None
-    try:
-        # Load weather dataset
-        ds = xr.open_dataset(storage_path)
-
-        # Select nearest point spatially
-        ds_point = ds.sel(lat=lat, lon=lon, method="nearest")
-
-        # Select time closest to ref_time
-        if "time" in ds_point.coords:
-            # Convert ref_time to numpy datetime64 with explicit UTC handling
-            ref_time_64 = _to_numpy_datetime64(ref_time)
-            ds_point = ds_point.sel(time=ref_time_64, method="nearest")
-
-        # Extract weather variables
-        result: dict[str, float] = {}
-
-        # Relative humidity at 2m
-        if "rh2m" in ds_point.data_vars:
-            rh_val = float(ds_point["rh2m"].values)
-            if not np.isnan(rh_val):
-                result["rh2m"] = rh_val
-
-        # Wind speed (compute from u10 and v10 components)
-        if "u10" in ds_point.data_vars and "v10" in ds_point.data_vars:
-            u10_val = float(ds_point["u10"].values)
-            v10_val = float(ds_point["v10"].values)
-            if not np.isnan(u10_val) and not np.isnan(v10_val):
-                wind_speed = np.sqrt(u10_val**2 + v10_val**2)
-                result["wind_speed_ms"] = float(wind_speed)
-
-        # Precipitation accumulation (if available)
-        # Note: GFS may not always have precipitation data in all runs
-        # If 'tp' (total precipitation) is available, accumulate recent values
-        if "tp" in ds_point.data_vars and "time" in ds.coords:
-            try:
-                # Select time range for precipitation lookback
-                precip_start = ref_time - timedelta(hours=precip_lookback_hours)
-                # Use centralized helper for consistent UTC handling
-                precip_start_64 = _to_numpy_datetime64(precip_start)
-                ref_time_64 = _to_numpy_datetime64(ref_time)
-
-                ds_precip = ds.sel(lat=lat, lon=lon, method="nearest")
-                ds_precip = ds_precip.sel(time=slice(precip_start_64, ref_time_64))
-
-                if "tp" in ds_precip.data_vars and len(ds_precip.time) > 0:
-                    # Sum precipitation over the lookback period
-                    precip_sum = float(ds_precip["tp"].sum().values)
-                    if not np.isnan(precip_sum):
-                        # Convert from meters to mm (GFS typically outputs in meters)
-                        result["precip_recent_mm"] = precip_sum * 1000.0
-            except Exception as e:
-                LOGGER.debug(
-                    "Failed to compute precipitation accumulation: %s", e
-                )
-
-        return result if result else None
-
-    except Exception as e:
-        LOGGER.warning(
-            "Failed to load weather data from %s: %s",
-            storage_path, e
-        )
-        return None
-    finally:
-        if ds is not None:
-            ds.close()

--- a/api/fires/scoring.py
+++ b/api/fires/scoring.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime
 from typing import Iterable
 
 from sqlalchemy import text

--- a/api/risk/grid.py
+++ b/api/risk/grid.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from api.fires.landcover import LANDCOVER_SCORES, get_landcover_path
-from api.fires.scoring import _get_weather_data_for_point
+from api.core.weather import get_weather_data_for_point
 
 try:
     import rasterio
@@ -235,7 +235,7 @@ def _compute_dynamic_risk(lat: float, lon: float, ref_time: datetime) -> Optiona
         Dynamic risk score in range [0, 1] or None if weather unavailable
     """
     # Reuse weather plausibility scoring logic
-    weather_data = _get_weather_data_for_point(
+    weather_data = get_weather_data_for_point(
         lat=lat,
         lon=lon,
         ref_time=ref_time,

--- a/api/tests/test_fire_weather_plausibility.py
+++ b/api/tests/test_fire_weather_plausibility.py
@@ -58,9 +58,9 @@ def test_compute_weather_plausibility_high_rh_penalty():
         "run_time": datetime(2025, 1, 1, 6, 0, tzinfo=timezone.utc),
     }
 
-    with patch("api.fires.scoring.get_engine") as mock_engine, \
-         patch("api.fires.scoring.xr.open_dataset", return_value=mock_ds), \
-         patch("api.fires.scoring.Path") as mock_path:
+    with patch("api.core.weather.get_engine") as mock_engine, \
+         patch("api.core.weather.xr.open_dataset", return_value=mock_ds), \
+         patch("api.core.weather.Path") as mock_path:
 
         mock_path.return_value.is_absolute.return_value = True
         mock_path.return_value.exists.return_value = True
@@ -97,9 +97,9 @@ def test_compute_weather_plausibility_low_rh_bonus():
         "run_time": datetime(2025, 1, 1, 6, 0, tzinfo=timezone.utc),
     }
 
-    with patch("api.fires.scoring.get_engine") as mock_engine, \
-         patch("api.fires.scoring.xr.open_dataset", return_value=mock_ds), \
-         patch("api.fires.scoring.Path") as mock_path:
+    with patch("api.core.weather.get_engine") as mock_engine, \
+         patch("api.core.weather.xr.open_dataset", return_value=mock_ds), \
+         patch("api.core.weather.Path") as mock_path:
 
         mock_path.return_value.is_absolute.return_value = True
         mock_path.return_value.exists.return_value = True
@@ -136,9 +136,9 @@ def test_compute_weather_plausibility_high_wind_bonus():
         "run_time": datetime(2025, 1, 1, 6, 0, tzinfo=timezone.utc),
     }
 
-    with patch("api.fires.scoring.get_engine") as mock_engine, \
-         patch("api.fires.scoring.xr.open_dataset", return_value=mock_ds), \
-         patch("api.fires.scoring.Path") as mock_path:
+    with patch("api.core.weather.get_engine") as mock_engine, \
+         patch("api.core.weather.xr.open_dataset", return_value=mock_ds), \
+         patch("api.core.weather.Path") as mock_path:
 
         mock_path.return_value.is_absolute.return_value = True
         mock_path.return_value.exists.return_value = True
@@ -169,7 +169,7 @@ def test_compute_weather_plausibility_no_weather_data():
     mock_db_result = MagicMock()
     mock_db_result.mappings.return_value.first.return_value = None
 
-    with patch("api.fires.scoring.get_engine") as mock_engine:
+    with patch("api.core.weather.get_engine") as mock_engine:
         mock_conn = MagicMock()
         mock_conn.__enter__.return_value.execute.return_value = mock_db_result
         mock_engine.return_value.connect.return_value = mock_conn
@@ -202,9 +202,9 @@ def test_compute_weather_plausibility_combined_effects():
         "run_time": datetime(2025, 1, 1, 6, 0, tzinfo=timezone.utc),
     }
 
-    with patch("api.fires.scoring.get_engine") as mock_engine, \
-         patch("api.fires.scoring.xr.open_dataset", return_value=mock_ds), \
-         patch("api.fires.scoring.Path") as mock_path:
+    with patch("api.core.weather.get_engine") as mock_engine, \
+         patch("api.core.weather.xr.open_dataset", return_value=mock_ds), \
+         patch("api.core.weather.Path") as mock_path:
 
         mock_path.return_value.is_absolute.return_value = True
         mock_path.return_value.exists.return_value = True
@@ -248,9 +248,9 @@ def test_compute_weather_plausibility_score_clamping():
         "run_time": datetime(2025, 1, 1, 6, 0, tzinfo=timezone.utc),
     }
 
-    with patch("api.fires.scoring.get_engine") as mock_engine, \
-         patch("api.fires.scoring.xr.open_dataset", return_value=mock_ds), \
-         patch("api.fires.scoring.Path") as mock_path:
+    with patch("api.core.weather.get_engine") as mock_engine, \
+         patch("api.core.weather.xr.open_dataset", return_value=mock_ds), \
+         patch("api.core.weather.Path") as mock_path:
 
         mock_path.return_value.is_absolute.return_value = True
         mock_path.return_value.exists.return_value = True


### PR DESCRIPTION
## Summary
- Move `get_weather_data_for_point` and `_to_numpy_datetime64` from `api/fires/scoring.py` into a new shared module `api/core/weather.py`
- Eliminates cross-package dependency where `api/risk/grid.py` imported a private function from `api/fires/scoring`
- Minor cleanup: removed TOCTOU file-existence check, eliminated redundant spatial re-selection in precipitation branch

## Test plan
- [x] All 60 scoring-related tests pass (persistence, likelihood, false-source masking, weather plausibility, scoring pipeline)
- [ ] Verify no import errors in `api.core.weather`, `api.fires.scoring`, `api.risk.grid`
- [ ] Smoke test fire scoring and risk grid endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)