### PR TITLE
refactor: extract cursor pagination into shared module

### DIFF
--- a/api/fires/repo.py
+++ b/api/fires/repo.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import base64
-import json as _json
 import logging
 import time
 from datetime import datetime, timezone
-from typing import Callable, Iterable, Literal, TYPE_CHECKING
+from typing import Iterable, Literal, TYPE_CHECKING
 
 from sqlalchemy import text, column as sa_column
 
@@ -15,6 +13,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Connection
 
 from api.config import settings
+from api.pagination import encode_cursor, decode_cursor, build_page
 from api.db import get_engine
 from api.fires.scoring import compute_fire_likelihood
 from api.fires.scoring_pipeline import (
@@ -51,54 +50,6 @@ def validate_bbox(bbox: BBox) -> None:
     if min_lat >= max_lat:
         raise ValueError(f"min_lat ({min_lat}) must be less than max_lat ({max_lat})")
 
-
-def _encode_cursor(**fields: object) -> str:
-    """Encode cursor fields as a URL-safe base64 JSON string."""
-    serialized: dict[str, object] = {}
-    for k, v in fields.items():
-        serialized[k] = v.isoformat() if isinstance(v, datetime) else v
-    return base64.urlsafe_b64encode(_json.dumps(serialized).encode()).decode()
-
-
-def _decode_cursor(cursor: str) -> dict:
-    """Decode a cursor string produced by _encode_cursor.
-
-    Returns a dict with field ``t`` parsed as a timezone-aware datetime (or
-    None) and all other fields left as-is.
-
-    Raises ValueError on malformed input.
-    """
-    try:
-        data = _json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
-    except Exception as exc:
-        raise ValueError(f"Invalid cursor: {exc}") from exc
-    if data.get("t") is not None:
-        try:
-            t = datetime.fromisoformat(data["t"])
-            data["t"] = t if t.tzinfo else t.replace(tzinfo=timezone.utc)
-        except Exception as exc:
-            raise ValueError(f"Invalid cursor timestamp: {exc}") from exc
-    return data
-
-
-def _build_page(
-    rows: list,
-    limit: int,
-    cursor_fn: Callable[[dict], str],
-) -> dict:
-    """Trim rows to limit, detect has_more, encode next_cursor, return page dict."""
-    has_more = len(rows) > limit
-    if has_more:
-        rows = rows[:limit]
-    next_cursor: str | None = None
-    if has_more and rows:
-        next_cursor = cursor_fn(dict(rows[-1]))
-    return {
-        "data": [dict(r) for r in rows],
-        "next_cursor": next_cursor,
-        "has_more": has_more,
-        "limit": limit,
-    }
 
 
 # Keep this list tight to avoid SQL injection when constructing SELECT clauses.
@@ -236,7 +187,7 @@ def list_fire_detections_bbox_time(
     cursor_id: int | None = None
     cursor_predicate = ""
     if cursor is not None:
-        parsed = _decode_cursor(cursor)
+        parsed = decode_cursor(cursor)
         cursor_acq_time = parsed["t"]
         cursor_id = int(parsed["id"])
         if order == "asc":
@@ -298,9 +249,9 @@ def list_fire_detections_bbox_time(
         result = conn.execute(stmt, params)
         rows = result.mappings().all()
 
-    return _build_page(
+    return build_page(
         rows, limit,
-        cursor_fn=lambda r: _encode_cursor(t=r["acq_time"], id=r["id"]),
+        cursor_fn=lambda r: encode_cursor(t=r["acq_time"], id=r["id"]),
     )
 
 
@@ -503,7 +454,7 @@ def list_fire_events_bbox_time(
     # Cursor encodes {"t": iso_datetime_or_null, "id": event_id_string}.
     cursor_predicate = ""
     if cursor is not None:
-        parsed = _decode_cursor(cursor)
+        parsed = decode_cursor(cursor)
         cursor_event_time: datetime | None = parsed.get("t")
         cursor_event_id: str = str(parsed["id"])
         if cursor_event_time is not None:
@@ -628,9 +579,9 @@ def list_fire_events_bbox_time(
         conn.execute(text("SET LOCAL statement_timeout = '5000ms'"))
         rows = conn.execute(stmt, params).mappings().all()
 
-    return _build_page(
+    return build_page(
         rows, limit,
-        cursor_fn=lambda r: _encode_cursor(
+        cursor_fn=lambda r: encode_cursor(
             t=r.get("start_time") or r.get("end_time"), id=r["event_id"]
         ),
     )
@@ -675,7 +626,7 @@ def list_fire_fronts_bbox_time(
     # Cursor encodes {"t": iso_datetime_or_null, "id": front_id_string}.
     cursor_predicate = ""
     if cursor is not None:
-        parsed = _decode_cursor(cursor)
+        parsed = decode_cursor(cursor)
         cursor_front_time: datetime | None = parsed.get("t")
         cursor_front_id: str = str(parsed["id"])
         if cursor_front_time is not None:
@@ -836,9 +787,9 @@ def list_fire_fronts_bbox_time(
         conn.execute(text("SET LOCAL statement_timeout = '5000ms'"))
         rows = conn.execute(stmt, params).mappings().all()
 
-    return _build_page(
+    return build_page(
         rows, effective_limit,
-        cursor_fn=lambda r: _encode_cursor(
+        cursor_fn=lambda r: encode_cursor(
             t=r.get("overpass_end") or r.get("overpass_start"), id=r["front_id"]
         ),
     )

--- a/api/pagination.py
+++ b/api/pagination.py
@@ -1,0 +1,74 @@
+"""Shared cursor-pagination utilities.
+
+Cursors are opaque to callers — the internal representation (currently keyset
+with ``t`` + ``id``) can change without breaking the API contract.  All
+encoding/decoding is centralised here so that ``decode_cursor`` is the single
+place to update if the format changes.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timezone
+from typing import Callable
+
+
+def encode_cursor(**fields: object) -> str:
+    """Encode cursor fields as a URL-safe base64 JSON string.
+
+    :class:`datetime` values are serialised as ISO-8601 strings; all other
+    values are passed through as-is (must be JSON-serialisable).
+    """
+    serialized: dict[str, object] = {}
+    for k, v in fields.items():
+        serialized[k] = v.isoformat() if isinstance(v, datetime) else v
+    return base64.urlsafe_b64encode(json.dumps(serialized).encode()).decode()
+
+
+def decode_cursor(cursor: str) -> dict:
+    """Decode a cursor string produced by :func:`encode_cursor`.
+
+    Returns a dict with field ``t`` parsed as a timezone-aware
+    :class:`datetime` (or ``None``) and all other fields left as-is.
+
+    Raises :exc:`ValueError` on malformed input.
+    """
+    try:
+        data = json.loads(base64.urlsafe_b64decode(cursor.encode()))
+    except Exception as exc:
+        raise ValueError(f"Invalid cursor: {exc}") from exc
+    if data.get("t") is not None:
+        try:
+            t = datetime.fromisoformat(data["t"])
+            data["t"] = t if t.tzinfo else t.replace(tzinfo=timezone.utc)
+        except Exception as exc:
+            raise ValueError(f"Invalid cursor timestamp: {exc}") from exc
+    return data
+
+
+def build_page(
+    rows: list,
+    limit: int,
+    cursor_fn: Callable[[dict], str],
+) -> dict:
+    """Trim *rows* to *limit*, detect ``has_more``, encode ``next_cursor``.
+
+    Returns a plain dict with keys ``data``, ``next_cursor``, ``has_more``,
+    and ``limit`` suitable for use as a JSON response body.
+
+    *cursor_fn* receives the last row (as a plain ``dict``) and must return an
+    opaque cursor string via :func:`encode_cursor`.
+    """
+    has_more = len(rows) > limit
+    if has_more:
+        rows = rows[:limit]
+    next_cursor: str | None = None
+    if has_more and rows:
+        next_cursor = cursor_fn(dict(rows[-1]))
+    return {
+        "data": [dict(r) for r in rows],
+        "next_cursor": next_cursor,
+        "has_more": has_more,
+        "limit": limit,
+    }

--- a/api/tests/test_pagination.py
+++ b/api/tests/test_pagination.py
@@ -1,0 +1,101 @@
+"""Unit tests for api.pagination."""
+
+import base64
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from api.pagination import build_page, decode_cursor, encode_cursor
+
+
+# ---------------------------------------------------------------------------
+# encode_cursor / decode_cursor round-trip
+# ---------------------------------------------------------------------------
+
+def test_roundtrip_plain_fields():
+    cursor = encode_cursor(id=42, offset=100)
+    data = decode_cursor(cursor)
+    assert data == {"id": 42, "offset": 100}
+
+
+def test_roundtrip_datetime_becomes_aware():
+    dt = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    cursor = encode_cursor(t=dt, id=7)
+    data = decode_cursor(cursor)
+    assert data["t"] == dt
+    assert data["t"].tzinfo is not None
+
+
+def test_roundtrip_naive_datetime_gets_utc():
+    naive = datetime(2024, 6, 1, 12, 0, 0)
+    cursor = encode_cursor(t=naive, id=3)
+    data = decode_cursor(cursor)
+    assert data["t"].tzinfo == timezone.utc
+
+
+def test_cursor_is_opaque_string():
+    cursor = encode_cursor(id=1)
+    assert isinstance(cursor, str)
+    assert len(cursor) > 0
+
+
+def test_decode_invalid_cursor_raises_value_error():
+    with pytest.raises(ValueError, match="Invalid cursor"):
+        decode_cursor("not-valid-base64!!!")
+
+
+def test_decode_invalid_timestamp_raises_value_error():
+    bad = base64.urlsafe_b64encode(json.dumps({"t": "not-a-date"}).encode()).decode()
+    with pytest.raises(ValueError, match="Invalid cursor timestamp"):
+        decode_cursor(bad)
+
+
+def test_no_t_field_not_parsed_as_datetime():
+    cursor = encode_cursor(id=99)
+    data = decode_cursor(cursor)
+    assert "t" not in data
+
+
+# ---------------------------------------------------------------------------
+# build_page
+# ---------------------------------------------------------------------------
+
+class _Row(dict):
+    """dict subclass — verifies build_page doesn't require plain dict input."""
+
+
+def _make_rows(n: int) -> list[_Row]:
+    return [_Row(id=i, val=f"v{i}") for i in range(n)]
+
+
+def test_build_page_no_more():
+    rows = _make_rows(3)
+    page = build_page(rows, limit=5, cursor_fn=lambda r: encode_cursor(id=r["id"]))
+    assert page["has_more"] is False
+    assert page["next_cursor"] is None
+    assert len(page["data"]) == 3
+    assert page["limit"] == 5
+
+
+def test_build_page_has_more():
+    rows = _make_rows(6)
+    page = build_page(rows, limit=5, cursor_fn=lambda r: encode_cursor(id=r["id"]))
+    assert page["has_more"] is True
+    assert page["next_cursor"] is not None
+    assert len(page["data"]) == 5
+    assert decode_cursor(page["next_cursor"])["id"] == 4
+
+
+def test_build_page_empty():
+    page = build_page([], limit=10, cursor_fn=lambda r: encode_cursor(id=r["id"]))
+    assert page["has_more"] is False
+    assert page["next_cursor"] is None
+    assert page["data"] == []
+
+
+def test_build_page_data_are_plain_dicts():
+    rows = _make_rows(2)
+    page = build_page(rows, limit=5, cursor_fn=lambda r: encode_cursor(id=r["id"]))
+    for item in page["data"]:
+        assert type(item) is dict


### PR DESCRIPTION
Extract cursor pagination helpers from `api/fires/repo.py` into a new shared `api/pagination.py` module.

## Changes

- **New module `api/pagination.py`**: Contains reusable pagination utilities:
  - `encode_cursor()`: URL-safe base64 JSON encoding with datetime support
  - `decode_cursor()`: Decoding with timezone-aware datetime parsing
  - `build_page()`: Page dict construction with has_more detection

- **`api/fires/repo.py`**: Removed private helper functions (`_encode_cursor`, `_decode_cursor`, `_build_page`) and replaced with imports from `api.pagination`. Updated 6 call sites across fire detection, event, and front listing functions.

- **`api/tests/test_pagination.py`**: Comprehensive unit tests covering:
  - Round-trip encoding/decoding with various field types
  - Datetime handling (aware/naive UTC conversion)
  - Error cases (invalid cursors, malformed timestamps)
  - Page building with has_more detection

## Benefits

- Centralizes pagination logic for reuse across API endpoints
- Improves testability with dedicated test suite
- Reduces code duplication in `repo.py` (~60 LOC removed)