### PR TITLE
fix+feat(ui): Review Queue triage UX — confidence fix, plain labels, sort, sections

### DIFF
--- a/ui/src/components/ReviewQueuePanel.tsx
+++ b/ui/src/components/ReviewQueuePanel.tsx
@@ -46,7 +46,7 @@ function formatFrp(value: unknown): string {
 
 function formatConfidence(value: unknown): string {
   const num = safeFloat(value);
-  return num === null ? "n/a" : `${(num * 100).toFixed(0)}%`;
+  return num === null ? "n/a" : `${num.toFixed(0)}%`;
 }
 
 function ReasonChip({ reason }: { reason: string }) {

--- a/ui/src/components/ReviewQueuePanel.tsx
+++ b/ui/src/components/ReviewQueuePanel.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Chip,
   CircularProgress,
+  Collapse,
   Divider,
   Stack,
   Tooltip,
@@ -12,6 +13,8 @@ import {
 } from "@mui/material";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import DoNotDisturbOnIcon from "@mui/icons-material/DoNotDisturbOn";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -24,6 +27,28 @@ type ResolutionNote = "confirmed_fire" | "marked_noise";
 
 interface ReviewQueuePanelProps {
   visibleEvents: FireEvent[];
+}
+
+const HARD_BYPASS = "fail_closed_hard_bypass";
+
+const REASON_META: Record<string, { label: string; color: string; tooltip: string }> = {
+  fail_closed_hard_bypass: {
+    label: "High-Energy Alert",
+    color: "#ef4444",
+    tooltip:
+      "Exceptionally high fire energy or confirmed forest conditions — treated as fire until reviewed."
+  },
+  fail_closed_or_uncertainty: {
+    label: "Model Uncertain",
+    color: "#f97316",
+    tooltip: "Classifier score was borderline — human judgment required."
+  }
+};
+
+function getReasonMeta(reason: string) {
+  return (
+    REASON_META[reason] ?? { label: reason, color: "#6b7280", tooltip: "" }
+  );
 }
 
 function formatTimestamp(iso: string): string {
@@ -49,10 +74,27 @@ function formatConfidence(value: unknown): string {
   return num === null ? "n/a" : `${num.toFixed(0)}%`;
 }
 
+function formatScoreBand(score: number): string {
+  if (score < 0.35) return "Low confidence";
+  if (score < 0.45) return "Below threshold";
+  if (score < 0.55) return "Borderline";
+  if (score < 0.65) return "Above threshold";
+  return "High confidence";
+}
+
+function sortItems(items: DenoiserReviewItem[]): DenoiserReviewItem[] {
+  return [...items].sort((a, b) => {
+    const frpA = safeFloat(a.payload_json?.frp_max) ?? 0;
+    const frpB = safeFloat(b.payload_json?.frp_max) ?? 0;
+    if (frpB !== frpA) return frpB - frpA;
+    // oldest first within same FRP tier
+    return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+  });
+}
+
 function ReasonChip({ reason }: { reason: string }) {
-  const label = reason === "fail_closed_hard_bypass" ? "Hard Bypass" : "Uncertainty";
-  const color = reason === "fail_closed_hard_bypass" ? "#ef4444" : "#f97316";
-  return (
+  const { label, color, tooltip } = getReasonMeta(reason);
+  const chip = (
     <Box
       component="span"
       sx={{
@@ -71,6 +113,13 @@ function ReasonChip({ reason }: { reason: string }) {
       {label}
     </Box>
   );
+  return tooltip ? (
+    <Tooltip title={tooltip} arrow placement="top">
+      {chip}
+    </Tooltip>
+  ) : (
+    chip
+  );
 }
 
 interface ReviewItemRowProps {
@@ -85,8 +134,11 @@ function ReviewItemRow({ item, matchedEvent, onResolve, isResolving }: ReviewIte
 
   const frp = item.payload_json?.frp_max;
   const confidence = item.payload_json?.confidence_max;
+  const score = item.payload_json?.event_score;
   const sensor = matchedEvent?.sensor ?? null;
   const time = matchedEvent?.end_time ?? item.created_at;
+  const isHardBypass = item.reason === HARD_BYPASS;
+  const { color: reasonColor } = getReasonMeta(item.reason);
 
   function handleFocus() {
     const lat = safeFloat(matchedEvent?.lat);
@@ -104,10 +156,10 @@ function ReviewItemRow({ item, matchedEvent, onResolve, isResolving }: ReviewIte
         p: 1.25,
         borderRadius: 1.5,
         bgcolor: "#0d1117",
-        border: "1px solid rgba(251,146,60,0.25)",
+        border: `1px solid ${reasonColor}40`,
         cursor: canFocus ? "pointer" : "default",
         transition: "border-color 0.15s",
-        "&:hover": canFocus ? { borderColor: "rgba(251,146,60,0.55)" } : {}
+        "&:hover": canFocus ? { borderColor: `${reasonColor}88` } : {}
       }}
       onClick={handleFocus}
     >
@@ -142,13 +194,13 @@ function ReviewItemRow({ item, matchedEvent, onResolve, isResolving }: ReviewIte
             {formatConfidence(confidence)}
           </Typography>
         </Box>
-        {item.payload_json?.event_score != null && (
+        {!isHardBypass && score != null && (
           <Box>
             <Typography sx={{ fontSize: 9, color: "#4b5563", textTransform: "uppercase", letterSpacing: "0.1em", fontWeight: 700 }}>
-              Score
+              Model
             </Typography>
             <Typography sx={{ fontSize: 13, color: "#e5e7eb", fontWeight: 700 }}>
-              {item.payload_json.event_score.toFixed(3)}
+              {formatScoreBand(score)}
             </Typography>
           </Box>
         )}
@@ -213,6 +265,101 @@ function ReviewItemRow({ item, matchedEvent, onResolve, isResolving }: ReviewIte
   );
 }
 
+interface QueueSectionProps {
+  title: string;
+  color: string;
+  items: DenoiserReviewItem[];
+  visibleEventIndex: Map<string, FireEvent>;
+  onResolve: (eventId: string, notes: ResolutionNote) => void;
+  resolvingIds: Set<string>;
+  emptyText: string;
+}
+
+function QueueSection({
+  title,
+  color,
+  items,
+  visibleEventIndex,
+  onResolve,
+  resolvingIds,
+  emptyText
+}: QueueSectionProps) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          px: 0.5,
+          py: 0.75,
+          cursor: "pointer",
+          userSelect: "none"
+        }}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+          <Typography
+            sx={{
+              fontSize: 10,
+              fontWeight: 800,
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              color
+            }}
+          >
+            {title}
+          </Typography>
+          <Box
+            sx={{
+              px: 0.6,
+              py: 0.1,
+              borderRadius: 0.6,
+              fontSize: 9,
+              fontWeight: 800,
+              lineHeight: 1.6,
+              bgcolor: `${color}22`,
+              border: `1px solid ${color}44`,
+              color
+            }}
+          >
+            {items.length}
+          </Box>
+        </Box>
+        <Box sx={{ fontSize: 14, color: "#4b5563", display: "flex" }}>
+          {open ? (
+            <ExpandLessIcon fontSize="inherit" />
+          ) : (
+            <ExpandMoreIcon fontSize="inherit" />
+          )}
+        </Box>
+      </Box>
+
+      <Collapse in={open}>
+        {items.length === 0 ? (
+          <Typography sx={{ fontSize: 11, color: "#4b5563", py: 1, px: 0.5 }}>
+            {emptyText}
+          </Typography>
+        ) : (
+          <Stack spacing={1}>
+            {items.map((item) => (
+              <ReviewItemRow
+                key={item.event_id}
+                item={item}
+                matchedEvent={visibleEventIndex.get(item.event_id) ?? null}
+                onResolve={onResolve}
+                isResolving={resolvingIds.has(item.event_id)}
+              />
+            ))}
+          </Stack>
+        )}
+      </Collapse>
+    </Box>
+  );
+}
+
 export default function ReviewQueuePanel({ visibleEvents }: ReviewQueuePanelProps) {
   const queryClient = useQueryClient();
   const [resolvingIds, setResolvingIds] = useState<Set<string>>(new Set());
@@ -251,6 +398,15 @@ export default function ReviewQueuePanel({ visibleEvents }: ReviewQueuePanelProp
 
   const rows = data?.rows ?? [];
   const count = rows.length;
+
+  const hardBypassItems = useMemo(
+    () => sortItems(rows.filter((r) => r.reason === HARD_BYPASS)),
+    [rows]
+  );
+  const uncertaintyItems = useMemo(
+    () => sortItems(rows.filter((r) => r.reason !== HARD_BYPASS)),
+    [rows]
+  );
 
   function handleResolve(eventId: string, notes: ResolutionNote) {
     resolveMutation.mutate({ eventId, resolvedBy: "operator", resolvedNotes: notes });
@@ -326,19 +482,25 @@ export default function ReviewQueuePanel({ visibleEvents }: ReviewQueuePanelProp
         )}
 
         {count > 0 && (
-          <Stack
-            spacing={1}
-            divider={<Divider sx={{ borderColor: "rgba(255,255,255,0.04)" }} />}
-          >
-            {rows.map((item) => (
-              <ReviewItemRow
-                key={item.event_id}
-                item={item}
-                matchedEvent={visibleEventIndex.get(item.event_id) ?? null}
-                onResolve={handleResolve}
-                isResolving={resolvingIds.has(item.event_id)}
-              />
-            ))}
+          <Stack spacing={0.5} divider={<Divider sx={{ borderColor: "rgba(255,255,255,0.05)" }} />}>
+            <QueueSection
+              title="High-Energy Alerts"
+              color="#ef4444"
+              items={hardBypassItems}
+              visibleEventIndex={visibleEventIndex}
+              onResolve={handleResolve}
+              resolvingIds={resolvingIds}
+              emptyText="No high-energy alerts pending"
+            />
+            <QueueSection
+              title="Uncertain Detections"
+              color="#f97316"
+              items={uncertaintyItems}
+              visibleEventIndex={visibleEventIndex}
+              onResolve={handleResolve}
+              resolvingIds={resolvingIds}
+              emptyText="No uncertain detections pending"
+            />
           </Stack>
         )}
       </Box>

--- a/ui/src/components/ReviewQueuePanel.tsx
+++ b/ui/src/components/ReviewQueuePanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   Alert,
   Box,
@@ -83,13 +83,14 @@ function formatScoreBand(score: number): string {
 }
 
 function sortItems(items: DenoiserReviewItem[]): DenoiserReviewItem[] {
-  return [...items].sort((a, b) => {
-    const frpA = safeFloat(a.payload_json?.frp_max) ?? 0;
-    const frpB = safeFloat(b.payload_json?.frp_max) ?? 0;
-    if (frpB !== frpA) return frpB - frpA;
-    // oldest first within same FRP tier
-    return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
-  });
+  type Keyed = { item: DenoiserReviewItem; frp: number; ts: number };
+  const keyed: Keyed[] = items.map((item) => ({
+    item,
+    frp: safeFloat(item.payload_json?.frp_max) ?? 0,
+    ts: new Date(item.created_at).getTime()
+  }));
+  keyed.sort((a, b) => b.frp !== a.frp ? b.frp - a.frp : a.ts - b.ts);
+  return keyed.map((k) => k.item);
 }
 
 function ReasonChip({ reason }: { reason: string }) {
@@ -119,6 +120,48 @@ function ReasonChip({ reason }: { reason: string }) {
     </Tooltip>
   ) : (
     chip
+  );
+}
+
+interface ActionButtonProps {
+  tooltip: string;
+  icon: React.ReactNode;
+  label: string;
+  color: string;
+  hoverBg: string;
+  borderColor: string;
+  hoverBorderColor: string;
+  isResolving: boolean;
+  onClick: () => void;
+}
+
+function ActionButton({ tooltip, icon, label, color, hoverBg, borderColor, hoverBorderColor, isResolving, onClick }: ActionButtonProps) {
+  return (
+    <Tooltip title={tooltip}>
+      <span>
+        <Button
+          size="small"
+          disabled={isResolving}
+          startIcon={isResolving ? <CircularProgress size={12} /> : icon}
+          onClick={onClick}
+          sx={{
+            fontSize: 10,
+            fontWeight: 700,
+            py: 0.4,
+            px: 1,
+            color,
+            borderColor,
+            border: "1px solid",
+            borderRadius: 1,
+            textTransform: "none",
+            "&:hover": { bgcolor: hoverBg, borderColor: hoverBorderColor },
+            "&:disabled": { opacity: 0.4 }
+          }}
+        >
+          {label}
+        </Button>
+      </span>
+    </Tooltip>
   );
 }
 
@@ -210,56 +253,28 @@ function ReviewItemRow({ item, matchedEvent, onResolve, isResolving }: ReviewIte
         sx={{ display: "flex", gap: 0.75 }}
         onClick={(e) => e.stopPropagation()}
       >
-        <Tooltip title="Confirm this detection as a real fire">
-          <span>
-            <Button
-              size="small"
-              disabled={isResolving}
-              startIcon={isResolving ? <CircularProgress size={12} /> : <CheckCircleOutlineIcon />}
-              onClick={() => onResolve(item.event_id, "confirmed_fire")}
-              sx={{
-                fontSize: 10,
-                fontWeight: 700,
-                py: 0.4,
-                px: 1,
-                color: "#4ade80",
-                borderColor: "rgba(74,222,128,0.35)",
-                border: "1px solid",
-                borderRadius: 1,
-                textTransform: "none",
-                "&:hover": { bgcolor: "rgba(74,222,128,0.1)", borderColor: "rgba(74,222,128,0.6)" },
-                "&:disabled": { opacity: 0.4 }
-              }}
-            >
-              Confirm Fire
-            </Button>
-          </span>
-        </Tooltip>
-        <Tooltip title="Mark this detection as noise / false positive">
-          <span>
-            <Button
-              size="small"
-              disabled={isResolving}
-              startIcon={isResolving ? <CircularProgress size={12} /> : <DoNotDisturbOnIcon />}
-              onClick={() => onResolve(item.event_id, "marked_noise")}
-              sx={{
-                fontSize: 10,
-                fontWeight: 700,
-                py: 0.4,
-                px: 1,
-                color: "#9ca3af",
-                borderColor: "rgba(156,163,175,0.3)",
-                border: "1px solid",
-                borderRadius: 1,
-                textTransform: "none",
-                "&:hover": { bgcolor: "rgba(156,163,175,0.08)", borderColor: "rgba(156,163,175,0.5)" },
-                "&:disabled": { opacity: 0.4 }
-              }}
-            >
-              Mark as Noise
-            </Button>
-          </span>
-        </Tooltip>
+        <ActionButton
+          tooltip="Confirm this detection as a real fire"
+          icon={<CheckCircleOutlineIcon />}
+          label="Confirm Fire"
+          color="#4ade80"
+          hoverBg="rgba(74,222,128,0.1)"
+          borderColor="rgba(74,222,128,0.35)"
+          hoverBorderColor="rgba(74,222,128,0.6)"
+          isResolving={isResolving}
+          onClick={() => onResolve(item.event_id, "confirmed_fire")}
+        />
+        <ActionButton
+          tooltip="Mark this detection as noise / false positive"
+          icon={<DoNotDisturbOnIcon />}
+          label="Mark as Noise"
+          color="#9ca3af"
+          hoverBg="rgba(156,163,175,0.08)"
+          borderColor="rgba(156,163,175,0.3)"
+          hoverBorderColor="rgba(156,163,175,0.5)"
+          isResolving={isResolving}
+          onClick={() => onResolve(item.event_id, "marked_noise")}
+        />
       </Box>
     </Box>
   );
@@ -399,14 +414,14 @@ export default function ReviewQueuePanel({ visibleEvents }: ReviewQueuePanelProp
   const rows = data?.rows ?? [];
   const count = rows.length;
 
-  const hardBypassItems = useMemo(
-    () => sortItems(rows.filter((r) => r.reason === HARD_BYPASS)),
-    [rows]
-  );
-  const uncertaintyItems = useMemo(
-    () => sortItems(rows.filter((r) => r.reason !== HARD_BYPASS)),
-    [rows]
-  );
+  const [hardBypassItems, uncertaintyItems] = useMemo(() => {
+    const hard: DenoiserReviewItem[] = [];
+    const uncertain: DenoiserReviewItem[] = [];
+    for (const row of rows) {
+      (row.reason === HARD_BYPASS ? hard : uncertain).push(row);
+    }
+    return [sortItems(hard), sortItems(uncertain)];
+  }, [rows]);
 
   function handleResolve(eventId: string, notes: ResolutionNote) {
     resolveMutation.mutate({ eventId, resolvedBy: "operator", resolvedNotes: notes });
@@ -485,7 +500,7 @@ export default function ReviewQueuePanel({ visibleEvents }: ReviewQueuePanelProp
           <Stack spacing={0.5} divider={<Divider sx={{ borderColor: "rgba(255,255,255,0.05)" }} />}>
             <QueueSection
               title="High-Energy Alerts"
-              color="#ef4444"
+              color={REASON_META.fail_closed_hard_bypass.color}
               items={hardBypassItems}
               visibleEventIndex={visibleEventIndex}
               onResolve={handleResolve}
@@ -494,7 +509,7 @@ export default function ReviewQueuePanel({ visibleEvents }: ReviewQueuePanelProp
             />
             <QueueSection
               title="Uncertain Detections"
-              color="#f97316"
+              color={REASON_META.fail_closed_or_uncertainty.color}
               items={uncertaintyItems}
               visibleEventIndex={visibleEventIndex}
               onResolve={handleResolve}


### PR DESCRIPTION
## Summary

- **Bug fix:** Confidence values were rendering as `5000%` instead of `50%` — `confidence_max` is stored as a 0–100 float but the formatter was multiplying by 100 again
- **Plain-language labels:** ML-internal reason codes replaced with operator-facing text (`fail_closed_hard_bypass` → "High-Energy Alert" in red, `fail_closed_or_uncertainty` → "Model Uncertain" in amber), each with a one-sentence operational tooltip
- **Urgency sort:** Items sorted by FRP descending, then oldest-first within the same FRP tier — high-energy events no longer buried by recency
- **Two collapsible sections:** Queue split into "High-Energy Alerts" and "Uncertain Detections" with per-section item counts; both open by default
- **Score bands:** Raw `event_score` float replaced with plain-language confidence bands (Low confidence / Below threshold / Borderline / Above threshold / High confidence); hidden for Hard Bypass items where the model forces score=1.0

## Test plan

- [ ] Confirm a queue item with a known `confidence_max` (e.g. `50.0`) renders as `50%`, not `5000%`
- [ ] Verify "High-Energy Alert" chip renders red with tooltip on hover
- [ ] Verify "Model Uncertain" chip renders amber with tooltip on hover
- [ ] Verify Hard Bypass items appear before uncertainty items in the queue
- [ ] Within each section, verify higher-FRP items appear first
- [ ] Verify both sections collapse/expand on header click
- [ ] Verify Hard Bypass items show no "Model" score band
- [ ] Verify "Confirm Fire" and "Mark as Noise" buttons still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)