### PR TITLE
refactor: centralise magic numbers into constants.py

### DIFF
--- a/api/constants.py
+++ b/api/constants.py
@@ -1,0 +1,42 @@
+# api/constants.py
+# Fixed-by-design values shared across routes and workers.
+# Values that differ between deployments belong in api/config.py (Pydantic settings).
+
+# Forecast horizons
+DEFAULT_HORIZONS_HOURS: list[int] = [24, 48, 72]
+MAX_HORIZON_HOURS: int = 72
+
+# Fire detection columns
+FIRE_DETECTION_BASE_COLUMNS: list[str] = [
+    "id",
+    "lat",
+    "lon",
+    "acq_time",
+    "confidence",
+    "brightness",
+    "bright_t31",
+    "frp",
+    "sensor",
+    "source",
+    "confidence_score",
+    "persistence_score",
+    "landcover_score",
+    "weather_score",
+    "false_source_masked",
+    "fire_likelihood",
+]
+
+FIRE_DETECTION_DENOISER_COLUMNS: list[str] = [
+    "denoised_score",
+    "is_noise",
+    "event_id",
+    "event_score",
+    "denoiser_decision",
+    "review_required",
+]
+
+# Bounding box
+MAX_BBOX_AREA_DEG2: float = 25.0  # 5° × 5° hard cap
+
+# Archive — default only; runtime value is read from MAX_ARCHIVE_RANGE_DAYS env var
+MAX_ARCHIVE_RANGE_DAYS_DEFAULT: int = 7

--- a/api/forecast/worker.py
+++ b/api/forecast/worker.py
@@ -17,6 +17,7 @@ from rq import Queue, Retry
 
 from api.cache import get_redis
 from api.config import settings
+from api.constants import DEFAULT_HORIZONS_HOURS
 from api.notifications import notify
 from api.forecast import repo
 from api.forecast.cache_lock import acquire_forecast_result_lock, release_forecast_result_lock
@@ -52,8 +53,6 @@ _FORECAST_RETRY = Retry(
     else list(_DEFAULT_FORECAST_JOB_RETRY_INTERVALS),
 )
 del _intervals_raw
-
-DEFAULT_HORIZONS_HOURS = [24, 48, 72]
 
 
 def _env_bool(name: str, default: bool = False) -> bool:

--- a/api/routes/fires.py
+++ b/api/routes/fires.py
@@ -4,41 +4,12 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from fastapi_limiter.depends import RateLimiter
 
+from api.constants import FIRE_DETECTION_BASE_COLUMNS, FIRE_DETECTION_DENOISER_COLUMNS
 from api.core.weather import get_weather_context_for_point
 from api.deps import cache_60, get_fire_repo
 from api.errors import InvalidBoundingBoxError
 from api.fires.repository import FireRepository
 from api.fires.geocoding import reverse_geocode_point
-
-
-# Standard fire detection columns - defined centrally to stay in sync with schema
-FIRE_DETECTION_BASE_COLUMNS = [
-    "id",
-    "lat",
-    "lon",
-    "acq_time",
-    "confidence",
-    "brightness",
-    "bright_t31",
-    "frp",
-    "sensor",
-    "source",
-    "confidence_score",
-    "persistence_score",
-    "landcover_score",
-    "weather_score",
-    "false_source_masked",
-    "fire_likelihood",
-]
-
-FIRE_DETECTION_DENOISER_COLUMNS = [
-    "denoised_score",
-    "is_noise",
-    "event_id",
-    "event_score",
-    "denoiser_decision",
-    "review_required",
-]
 
 fires_router = APIRouter(prefix="/fires", tags=["fires"])
 

--- a/api/routes/forecast.py
+++ b/api/routes/forecast.py
@@ -18,6 +18,7 @@ from fastapi_limiter.depends import RateLimiter
 from pydantic import BaseModel, ConfigDict
 
 from api.config import settings
+from api.constants import DEFAULT_HORIZONS_HOURS
 from api.deps import no_cache
 from api.errors import InvalidBoundingBoxError
 from api.fires.repo import get_fire_front_by_id, validate_bbox
@@ -29,7 +30,6 @@ from ml.spread.region_key import bbox_region_name
 from ml.spread.service import ForecastInputFallbackError, STRICT_FORECAST_INPUTS_ENV
 
 forecast_router = APIRouter(prefix="/forecast", tags=["forecast"])
-DEFAULT_HORIZONS_HOURS = [24, 48, 72]
 
 # Fire probability colormap: transparent at 0, yellow → orange → red for probabilities 0→1.
 # Keys are integer pixel values 0-255 (after TiTiler rescales the float raster with rescale=0,1).


### PR DESCRIPTION
## Changes

- Created new `api/constants.py` module to centralise fixed-by-design values
- Moved fire detection column definitions from `api/routes/fires.py`
- Moved `DEFAULT_HORIZONS_HOURS` from `api/forecast/worker.py` and `api/routes/forecast.py`
- Added constants for max horizon, bbox area, and archive range defaults

## Benefits

- Single source of truth for shared magic numbers across routes and workers
- Improves maintainability and reduces duplication
- Clear separation between fixed values and deployment-specific config