### PR TITLE
feat: enrich review queue with location context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help doctor health-check install test lint lint-fix clean clean-venv migrate revision widget-build ralph-init ralph-plan ralph-run ralph-status denoiser-label denoiser-snapshot denoiser-train denoiser-eval denoiser-eventize denoiser-label-v2 denoiser-snapshot-v2 denoiser-train-v2 denoiser-eval-v2 train-denoiser train-spread model-register model-promote model-rollback model-update-contract hindcast-build spread-champion-challenger weather-bias
+.PHONY: help doctor health-check install test lint lint-fix clean clean-venv migrate revision widget-build ralph-init ralph-plan ralph-run ralph-status denoiser-label denoiser-snapshot denoiser-train denoiser-eval denoiser-eventize denoiser-label-v2 denoiser-snapshot-v2 denoiser-train-v2 denoiser-eval-v2 train-denoiser train-spread model-register model-promote model-rollback model-update-contract hindcast-build spread-champion-challenger weather-bias seed-ne-places
 
 PYTHON ?= python3
 UV ?= uv
@@ -223,6 +223,10 @@ model-update-contract: ## Update runtime contract on a registered model (usage: 
 	$(if $(MODEL_ID),,$(error Please provide MODEL_ID=<registered model id>))
 	$(if $(RUNTIME_CONTRACT),,$(error Please provide RUNTIME_CONTRACT=@path/or-json))
 	$(UV) run --project api scripts/model_registry.py update-contract --family "$(FAMILY)" --model-id "$(MODEL_ID)" --runtime-contract '$(RUNTIME_CONTRACT)' $(if $(REPLACE),--replace,)
+
+seed-ne-places: ## Load Natural Earth populated places (usage: make seed-ne-places NE_PLACES=/path/to/ne_10m_populated_places.geojson)
+	$(if $(NE_PLACES),,$(error Please provide NE_PLACES=/path/to/ne_10m_populated_places.geojson or .shp))
+	$(UV) run --project api scripts/seed_ne_populated_places.py "$(NE_PLACES)" $(if $(TRUNCATE),--truncate,)
 
 # ── Full train pipelines ───────────────────────────────────────────────────────
 

--- a/api/fires/repo.py
+++ b/api/fires/repo.py
@@ -28,6 +28,9 @@ from api.fires.scoring_pipeline import (
 BBox = tuple[float, float, float, float]  # (min_lon, min_lat, max_lon, max_lat)
 LOGGER = logging.getLogger(__name__)
 
+# Shared statement timeout applied to all spatial queries to keep API latency bounded.
+_SPATIAL_QUERY_TIMEOUT = "SET LOCAL statement_timeout = '5000ms'"
+
 # Stateless singletons — strategies hold no mutable state so one instance suffices.
 _FALSE_SOURCE_STRATEGY = FalseSourceMaskingStrategy()
 _PERSISTENCE_STRATEGY = PersistenceScoringStrategy()
@@ -602,7 +605,7 @@ def list_fire_events_bbox_time(
     params["geocoding_precision"] = settings.geocoding_cache_precision
 
     with get_engine().begin() as conn:
-        conn.execute(text("SET LOCAL statement_timeout = '5000ms'"))
+        conn.execute(text(_SPATIAL_QUERY_TIMEOUT))
         rows = conn.execute(stmt, params).mappings().all()
 
     return build_page(
@@ -810,7 +813,7 @@ def list_fire_fronts_bbox_time(
 
     with get_engine().begin() as conn:
         # Keep request latency bounded so map interactions do not starve API health checks.
-        conn.execute(text("SET LOCAL statement_timeout = '5000ms'"))
+        conn.execute(text(_SPATIAL_QUERY_TIMEOUT))
         rows = conn.execute(stmt, params).mappings().all()
 
     return build_page(
@@ -1168,35 +1171,104 @@ def list_recent_denoiser_drift(limit: int = 50) -> list[dict]:
     return [dict(r) for r in rows]
 
 
+_COMPASS = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"]
+
+
+def _format_nearest_place(name: str | None, dist_km: float | None, bearing_deg: float | None) -> str | None:
+    if name is None or dist_km is None:
+        return None
+    idx = round((float(bearing_deg or 0) % 360) / 45) % 8
+    return f"{int(dist_km)} km {_COMPASS[idx]} of {name}"
+
+
 def list_denoiser_review_queue(limit: int = 200, status: str = "open") -> list[dict]:
-    """List denoiser review queue rows."""
+    """List denoiser review queue rows enriched with location context."""
     stmt = text(
         """
+        WITH limited_queue AS (
+            SELECT
+                id,
+                event_id,
+                fire_detection_id,
+                reason,
+                severity,
+                status,
+                payload_json,
+                resolved_by,
+                resolved_notes,
+                resolved_at,
+                created_at,
+                updated_at
+            FROM denoiser_review_queue
+            WHERE status = :status
+            ORDER BY created_at DESC, id DESC
+            LIMIT :limit
+        ),
+        event_centroids AS (
+            SELECT fe.event_id,
+                   ST_Centroid(fe.geom)            AS centroid,
+                   ST_Centroid(fe.geom)::geography AS centroid_geog
+            FROM   fire_events fe
+            INNER JOIN limited_queue lq ON lq.event_id = fe.event_id
+        )
         SELECT
-            id,
-            event_id,
-            fire_detection_id,
-            reason,
-            severity,
-            status,
-            payload_json,
-            resolved_by,
-            resolved_notes,
-            resolved_at,
-            created_at,
-            updated_at
-        FROM denoiser_review_queue
-        WHERE status = :status
-        ORDER BY created_at DESC, id DESC
-        LIMIT :limit
+            lq.*,
+            ST_Y(ec.centroid)                                                AS centroid_lat,
+            ST_X(ec.centroid)                                                AS centroid_lon,
+            UPPER(rgc.raw_payload->'address'->>'country_code')               AS country_code,
+            rgc.admin1_name                                                  AS region_name,
+            np.name                                                          AS _np_name,
+            ROUND(
+                ST_Distance(ec.centroid_geog, np.geom::geography) / 1000.0
+            )                                                                AS _np_dist_km,
+            degrees(
+                ST_Azimuth(np.geom::geography, ec.centroid_geog)
+            )                                                                AS _np_bearing_deg,
+            lc.terrain_label
+        FROM limited_queue lq
+        LEFT JOIN event_centroids ec ON ec.event_id = lq.event_id
+        LEFT JOIN reverse_geocode_cache rgc
+            ON  ec.centroid IS NOT NULL
+            AND rgc.provider      = :geocoding_provider
+            AND rgc.cached_lat    = ROUND(CAST(ST_Y(ec.centroid) AS NUMERIC), :geocoding_precision)
+            AND rgc.cached_lon    = ROUND(CAST(ST_X(ec.centroid) AS NUMERIC), :geocoding_precision)
+            AND rgc.expires_at    > NOW()
+        LEFT JOIN LATERAL (
+            SELECT pp.name, pp.geom
+            FROM   ne_populated_places pp
+            WHERE  ec.centroid IS NOT NULL
+              AND  ST_DWithin(ec.centroid_geog, pp.geom::geography, 200000)
+            ORDER BY pp.geom <-> ec.centroid
+            LIMIT 1
+        ) np ON TRUE
+        LEFT JOIN LATERAL (
+            SELECT MODE() WITHIN GROUP (ORDER BY fd.landcover_label) AS terrain_label
+            FROM   fire_detections fd
+            WHERE  fd.event_id        = lq.event_id
+              AND  fd.landcover_label IS NOT NULL
+        ) lc ON TRUE
         """
     )
+    params = {
+        "status": str(status),
+        "limit": max(1, int(limit)),
+        "geocoding_provider": settings.geocoding_provider.strip().lower(),
+        "geocoding_precision": settings.geocoding_cache_precision,
+    }
     with get_engine().begin() as conn:
-        rows = conn.execute(
-            stmt,
-            {"status": str(status), "limit": max(1, int(limit))},
-        ).mappings().all()
-    return [dict(r) for r in rows]
+        conn.execute(text(_SPATIAL_QUERY_TIMEOUT))
+        rows = conn.execute(stmt, params).mappings().all()
+
+    result = []
+    for r in rows:
+        row = dict(r)
+        row["nearest_place"] = _format_nearest_place(
+            row.pop("_np_name"),
+            row.pop("_np_dist_km"),
+            row.pop("_np_bearing_deg"),
+        )
+        result.append(row)
+    return result
 
 
 def resolve_denoiser_review_event(

--- a/api/fires/terrain_label.py
+++ b/api/fires/terrain_label.py
@@ -1,0 +1,32 @@
+"""Shared terrain label utility — maps ESA WorldCover class codes to human-readable labels.
+
+Kept in sync with ingest/lulc_worldcover_ingest.py _CLASS_LABELS.
+Used by the review queue API and the fire detail view.
+"""
+
+from __future__ import annotations
+
+# Maps ESA WorldCover class code → human-readable label.
+TERRAIN_LABELS: dict[int, str] = {
+    10: "Tree cover",
+    20: "Shrubland",
+    30: "Grassland",
+    40: "Cropland",
+    50: "Built-up",
+    60: "Bare / sparse vegetation",
+    70: "Snow and ice",
+    80: "Permanent water bodies",
+    90: "Herbaceous wetland",
+    95: "Mangroves",
+    100: "Moss and lichen",
+}
+
+
+def terrain_label_from_class(class_code: int | None) -> str | None:
+    """Return human-readable terrain label for an ESA WorldCover class code.
+
+    Returns None if class_code is None or not a known ESA WorldCover class.
+    """
+    if class_code is None:
+        return None
+    return TERRAIN_LABELS.get(int(class_code))

--- a/api/migrations/versions/20260330_add_ne_populated_places.py
+++ b/api/migrations/versions/20260330_add_ne_populated_places.py
@@ -1,0 +1,57 @@
+"""add ne_populated_places table for review queue location context
+
+Stores Natural Earth 10m populated places for nearest-place spatial queries
+in the review queue and fire detail endpoints. Populated by the seed script
+at scripts/seed_ne_populated_places.py — run once after migrating.
+
+Revision ID: 20260330_add_ne_populated_places
+Revises: 20260327_add_aoi_watch_columns
+Create Date: 2026-03-30 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+class Geometry(sa.types.UserDefinedType):
+    """Minimal PostGIS geometry type helper for migrations."""
+
+    def __init__(self, geometry_type: str, srid: int) -> None:
+        self.geometry_type = geometry_type
+        self.srid = srid
+
+    def get_col_spec(self, **kw: object) -> str:
+        return f"geometry({self.geometry_type}, {self.srid})"
+
+
+revision: str = "20260330_add_ne_populated_places"
+down_revision: Union[str, Sequence[str], None] = "20260327_add_aoi_watch_columns"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create ne_populated_places table."""
+    op.create_table(
+        "ne_populated_places",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("geom", Geometry("POINT", 4326), nullable=False),
+        sa.Column("pop_max", sa.BigInteger(), nullable=True),
+        sa.Column("adm0_a3", sa.String(length=3), nullable=True),
+        sa.Column("adm1name", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "ix_ne_populated_places_geom",
+        "ne_populated_places",
+        ["geom"],
+        postgresql_using="gist",
+    )
+
+
+def downgrade() -> None:
+    """Drop ne_populated_places table."""
+    op.drop_index("ix_ne_populated_places_geom", table_name="ne_populated_places")
+    op.drop_table("ne_populated_places")

--- a/scripts/seed_ne_populated_places.py
+++ b/scripts/seed_ne_populated_places.py
@@ -1,0 +1,165 @@
+"""Seed script to load Natural Earth 10m populated places into PostGIS.
+
+Download the Natural Earth 10m Populated Places dataset from:
+  https://www.naturalearthdata.com/downloads/10m-cultural-vectors/10m-populated-places/
+
+The zip contains ne_10m_populated_places.shp and ne_10m_populated_places.geojson.
+Pass either file as the positional argument. Shapefile input requires ogr2ogr (GDAL).
+
+Usage:
+    uv run --project api scripts/seed_ne_populated_places.py /path/to/ne_10m_populated_places.geojson
+    uv run --project api scripts/seed_ne_populated_places.py /path/to/ne_10m_populated_places.shp
+    uv run --project api scripts/seed_ne_populated_places.py /path/to/file.geojson --truncate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from sqlalchemy import text  # noqa: E402
+
+from api.db import get_engine  # noqa: E402
+
+LOGGER = logging.getLogger("seed_ne_populated_places")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+_BATCH_SIZE = 500
+
+
+def _shp_to_geojson(shp_path: Path) -> dict[str, Any]:
+    """Convert shapefile to GeoJSON via ogr2ogr (requires GDAL)."""
+    with tempfile.NamedTemporaryFile(suffix=".geojson", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+    try:
+        result = subprocess.run(
+            ["ogr2ogr", "-f", "GeoJSON", str(tmp_path), str(shp_path), "-overwrite"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        if result.stderr:
+            LOGGER.debug("ogr2ogr stderr: %s", result.stderr)
+        return json.loads(tmp_path.read_text())
+    except FileNotFoundError:
+        raise RuntimeError(
+            "ogr2ogr not found. Install GDAL or convert the shapefile to GeoJSON manually "
+            "before running this script."
+        ) from None
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _load_geojson(path: Path) -> dict[str, Any]:
+    if path.suffix.lower() == ".shp":
+        LOGGER.info("Converting shapefile to GeoJSON via ogr2ogr...")
+        return _shp_to_geojson(path)
+    return json.loads(path.read_text())
+
+
+def _extract_row(feat: dict[str, Any]) -> dict[str, Any] | None:
+    # Normalize to uppercase once — Natural Earth ships uppercase; ogr2ogr may lowercase.
+    props = {k.upper(): v for k, v in (feat.get("properties") or {}).items()}
+    geom = feat.get("geometry")
+    if not geom or geom.get("type") != "Point":
+        return None
+    coords = geom.get("coordinates") or []
+    if len(coords) < 2:
+        return None
+    lon, lat = float(coords[0]), float(coords[1])
+    name = props.get("NAME")
+    if not name:
+        return None
+    pop_raw = props.get("POP_MAX")
+    adm0 = props.get("ADM0_A3")
+    adm1 = props.get("ADM1NAME")
+    return {
+        "name": str(name),
+        "lon": lon,
+        "lat": lat,
+        "pop_max": int(pop_raw) if pop_raw is not None else None,
+        "adm0_a3": str(adm0)[:3] if adm0 else None,
+        "adm1name": str(adm1) if adm1 else None,
+    }
+
+
+def seed(path: Path, *, truncate: bool = False) -> int:
+    """Load Natural Earth populated places from GeoJSON/shapefile.
+
+    Returns number of rows inserted.
+    """
+    data = _load_geojson(path)
+    features = data.get("features") or []
+    if not features:
+        LOGGER.warning("No features found in %s", path)
+        return 0
+
+    rows = [r for f in features if (r := _extract_row(f)) is not None]
+    LOGGER.info("Parsed %d valid place records from %d features.", len(rows), len(features))
+
+    insert_stmt = text(
+        """
+        INSERT INTO ne_populated_places (name, geom, pop_max, adm0_a3, adm1name)
+        VALUES (
+            :name,
+            ST_SetSRID(ST_MakePoint(:lon, :lat), 4326),
+            :pop_max,
+            :adm0_a3,
+            :adm1name
+        )
+        """
+    )
+
+    with get_engine().begin() as conn:
+        if truncate:
+            conn.execute(text("TRUNCATE TABLE ne_populated_places RESTART IDENTITY"))
+            LOGGER.info("Truncated ne_populated_places.")
+        for batch_start in range(0, len(rows), _BATCH_SIZE):
+            batch = rows[batch_start : batch_start + _BATCH_SIZE]
+            conn.execute(insert_stmt, batch)
+            LOGGER.info(
+                "Inserted rows %d–%d / %d",
+                batch_start + 1,
+                batch_start + len(batch),
+                len(rows),
+            )
+
+    LOGGER.info("Done. %d rows loaded into ne_populated_places.", len(rows))
+    return len(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Seed Natural Earth 10m populated places into PostGIS."
+    )
+    parser.add_argument(
+        "path",
+        type=Path,
+        help="Path to ne_10m_populated_places.geojson or .shp",
+    )
+    parser.add_argument(
+        "--truncate",
+        action="store_true",
+        help="Truncate the table before inserting (safe to re-run after download update)",
+    )
+    args = parser.parse_args()
+
+    if not args.path.exists():
+        LOGGER.error("File not found: %s", args.path)
+        sys.exit(1)
+
+    seed(args.path, truncate=args.truncate)
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/src/components/ReviewQueuePanel.tsx
+++ b/ui/src/components/ReviewQueuePanel.tsx
@@ -165,6 +165,52 @@ function ActionButton({ tooltip, icon, label, color, hoverBg, borderColor, hover
   );
 }
 
+function countryFlagEmoji(countryCode: string | null | undefined): string {
+  if (!countryCode || countryCode.length !== 2) return "";
+  const code = countryCode.toUpperCase();
+  // Regional indicator symbols: A = 0x1F1E6, offset from 'A' char code 65
+  return String.fromCodePoint(
+    0x1f1e6 + code.charCodeAt(0) - 65,
+    0x1f1e6 + code.charCodeAt(1) - 65
+  );
+}
+
+function LocationContext({ item }: { item: DenoiserReviewItem }) {
+  const { country_code, region_name, nearest_place, terrain_label } = item;
+  const hasAny = country_code || region_name || nearest_place || terrain_label;
+
+  if (!hasAny) {
+    return (
+      <Typography sx={{ fontSize: 10, color: "#4b5563", mb: 0.75, fontStyle: "italic" }}>
+        Location unavailable
+      </Typography>
+    );
+  }
+
+  const flag = countryFlagEmoji(country_code);
+  const locationLine = [flag, region_name].filter(Boolean).join(" ") || null;
+
+  return (
+    <Box sx={{ mb: 0.75 }}>
+      {locationLine && (
+        <Typography sx={{ fontSize: 11, color: "#9ca3af", lineHeight: 1.4 }}>
+          {locationLine}
+        </Typography>
+      )}
+      {nearest_place && (
+        <Typography sx={{ fontSize: 10, color: "#6b7280", fontStyle: "italic", lineHeight: 1.4 }}>
+          {nearest_place}
+        </Typography>
+      )}
+      {terrain_label && (
+        <Typography sx={{ fontSize: 10, color: "#6b7280", lineHeight: 1.4 }}>
+          {terrain_label}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
 interface ReviewItemRowProps {
   item: DenoiserReviewItem;
   matchedEvent: FireEvent | null;
@@ -220,7 +266,7 @@ function ReviewItemRow({ item, matchedEvent, onResolve, isResolving }: ReviewIte
         </Typography>
       </Box>
 
-      <Box sx={{ display: "flex", gap: 2, mb: 1 }}>
+      <Box sx={{ display: "flex", gap: 2, mb: 0.75 }}>
         <Box>
           <Typography sx={{ fontSize: 9, color: "#4b5563", textTransform: "uppercase", letterSpacing: "0.1em", fontWeight: 700 }}>
             FRP
@@ -248,6 +294,8 @@ function ReviewItemRow({ item, matchedEvent, onResolve, isResolving }: ReviewIte
           </Box>
         )}
       </Box>
+
+      <LocationContext item={item} />
 
       <Box
         sx={{ display: "flex", gap: 0.75 }}

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -158,6 +158,12 @@ export interface DenoiserReviewItem {
   resolved_at?: string | null;
   created_at: string;
   updated_at: string;
+  centroid_lat?: number | null;
+  centroid_lon?: number | null;
+  country_code?: string | null;
+  region_name?: string | null;
+  nearest_place?: string | null;
+  terrain_label?: string | null;
 }
 
 export interface ReviewQueueResponse {


### PR DESCRIPTION
## Summary
Enhances the denoiser review queue with location context information to help reviewers understand fire event locations better.

## Changes

### Backend
- **Database**: Added `ne_populated_places` table (migration) to store Natural Earth 10m populated places for spatial queries
- **Repo**: Enhanced `list_denoiser_review_queue()` to enrich results with:
  - Event centroid coordinates (lat/lon)
  - Country code from reverse geocoding cache
  - Region/admin1 name
  - Nearest populated place with distance and compass bearing
  - Dominant terrain label (ESA WorldCover class) from fire detections
- **New module**: `terrain_label.py` - shared utility for mapping ESA WorldCover class codes to human-readable labels
- **Seed script**: `seed_ne_populated_places.py` - loads Natural Earth data from GeoJSON or shapefile (via ogr2ogr)
- **Makefile**: Added `seed-ne-places` target for data loading

### Frontend
- **ReviewQueuePanel**: New `LocationContext` component displays:
  - Country flag emoji + region name
  - Nearest place with distance/bearing (e.g., "42 km NE of Paris")
  - Terrain label
- **API types**: Added location context fields to `DenoiserReviewItem` interface
- **Utility**: `countryFlagEmoji()` helper converts ISO country codes to flag emoji

### Performance
- Applied 5s statement timeout to enrichment queries to bound API latency
- Uses spatial indexes and LATERAL joins for efficient nearest-place lookup
