### PR TITLE
Simplify async engine setup and add shutdown safeguards

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -111,12 +111,10 @@ class AppSettings(BaseSettings):
     @property
     def async_database_url(self) -> str:
         """Async connection URL for asyncpg.  Derived from *database_url* by swapping the dialect."""
-        url = self.database_url
-        if url.startswith("postgresql+psycopg2://"):
-            return url.replace("postgresql+psycopg2://", "postgresql+asyncpg://", 1)
-        if url.startswith("postgresql://"):
-            return url.replace("postgresql://", "postgresql+asyncpg://", 1)
-        return url
+        from sqlalchemy.engine import make_url
+
+        url = make_url(self.database_url)
+        return str(url.set(drivername="postgresql+asyncpg"))
 
     # TiTiler settings
     titiler_public_base_url: str = Field(

--- a/api/db.py
+++ b/api/db.py
@@ -62,3 +62,11 @@ def get_async_engine() -> AsyncEngine:
             echo=settings.environment == "dev",
         )
     return _async_engine
+
+
+async def dispose_async_engine() -> None:
+    """Dispose the async engine if it was created.  Safe to call unconditionally."""
+    global _async_engine
+    if _async_engine is not None:
+        await _async_engine.dispose()
+        _async_engine = None

--- a/api/fires/repo.py
+++ b/api/fires/repo.py
@@ -29,8 +29,6 @@ from api.fires.scoring_pipeline import (
 BBox = tuple[float, float, float, float]  # (min_lon, min_lat, max_lon, max_lat)
 LOGGER = logging.getLogger(__name__)
 
-# Shared statement timeout applied to all spatial queries to keep API latency bounded.
-# Pre-constructed as a TextClause so call sites avoid re-creating it on every request.
 _SPATIAL_QUERY_TIMEOUT = text("SET LOCAL statement_timeout = '5000ms'")
 
 # Stateless singletons — strategies hold no mutable state so one instance suffices.
@@ -281,6 +279,7 @@ def list_fire_detections_bbox_time(
     )
 
     with get_engine().begin() as conn:
+        conn.execute(_SPATIAL_QUERY_TIMEOUT)
         result = conn.execute(stmt, params)
         rows = result.mappings().all()
 
@@ -315,6 +314,7 @@ async def async_list_fire_detections_bbox_time(
     )
 
     async with get_async_engine().begin() as conn:
+        await conn.execute(_SPATIAL_QUERY_TIMEOUT)
         result = await conn.execute(stmt, params)
         rows = result.mappings().all()
 

--- a/api/main.py
+++ b/api/main.py
@@ -76,6 +76,14 @@ async def startup():
             return None
         RateLimiter.__call__ = _noop_rate_limiter
 
+
+@app.on_event("shutdown")
+async def shutdown():
+    from api.db import dispose_async_engine
+
+    await dispose_async_engine()
+
+
 app.add_exception_handler(WildfireError, wildfire_error_handler)
 
 

--- a/api/tests/test_domain_exceptions.py
+++ b/api/tests/test_domain_exceptions.py
@@ -7,8 +7,6 @@ Each test verifies that:
 from __future__ import annotations
 
 from datetime import date, timedelta
-from unittest.mock import MagicMock
-
 import pytest
 from fastapi.testclient import TestClient
 
@@ -22,8 +20,8 @@ from api.errors import (
     WildfireError,
     _STATUS_MAP,
 )
-from api.fires.repository import FireRepository
 from api.main import app
+from api.tests.conftest import make_fire_repo
 
 client = TestClient(app, raise_server_exceptions=False)
 
@@ -65,12 +63,10 @@ _FIRES_PARAMS = {
 }
 
 
-def _make_bbox_repo(raise_on_validate: str | None = None) -> FireRepository:
-    repo = MagicMock(spec=FireRepository)
+def _make_bbox_repo(raise_on_validate: str | None = None):
+    repo = make_fire_repo()
     if raise_on_validate:
         repo.validate_bbox.side_effect = ValueError(raise_on_validate)
-    else:
-        repo.validate_bbox.return_value = None
     return repo
 
 

--- a/api/tests/test_fire_repo_denoiser_filter.py
+++ b/api/tests/test_fire_repo_denoiser_filter.py
@@ -18,8 +18,10 @@ def test_list_fire_detections_bbox_time_filters_noise_by_default(monkeypatch):
         nonlocal executed_stmt
         context = MagicMock()
 
-        def execute(stmt, params):
+        def execute(stmt, params=None):
             nonlocal executed_stmt
+            if "SET LOCAL statement_timeout" in str(stmt):
+                return MagicMock()
             executed_stmt = stmt
             return MagicMock()
 
@@ -49,8 +51,10 @@ def test_list_fire_detections_bbox_time_includes_noise_when_requested(monkeypatc
         nonlocal executed_stmt
         context = MagicMock()
 
-        def execute(stmt, params):
+        def execute(stmt, params=None):
             nonlocal executed_stmt
+            if "SET LOCAL statement_timeout" in str(stmt):
+                return MagicMock()
             executed_stmt = stmt
             return MagicMock()
 

--- a/api/tests/test_fire_repo_false_source_filter.py
+++ b/api/tests/test_fire_repo_false_source_filter.py
@@ -18,8 +18,10 @@ def test_list_fire_detections_bbox_time_filters_masked_by_default(monkeypatch):
         nonlocal executed_stmt
         context = MagicMock()
 
-        def execute(stmt, params):
+        def execute(stmt, params=None):
             nonlocal executed_stmt
+            if "SET LOCAL statement_timeout" in str(stmt):
+                return MagicMock()
             executed_stmt = stmt
             return MagicMock()
 
@@ -49,8 +51,10 @@ def test_list_fire_detections_bbox_time_includes_masked_when_requested(monkeypat
         nonlocal executed_stmt
         context = MagicMock()
 
-        def execute(stmt, params):
+        def execute(stmt, params=None):
             nonlocal executed_stmt
+            if "SET LOCAL statement_timeout" in str(stmt):
+                return MagicMock()
             executed_stmt = stmt
             return MagicMock()
 


### PR DESCRIPTION
## Changes

- **config.py**: Refactor `async_database_url` to use SQLAlchemy's `make_url()` utility instead of string replacement, making it more robust and maintainable
- **db.py**: Add `dispose_async_engine()` function to safely clean up the async engine on shutdown
- **main.py**: Add shutdown event handler to properly dispose of the async engine
- **fires/repo.py**: Move `_SPATIAL_QUERY_TIMEOUT` execution into query methods (both sync and async) and remove outdated comment
- **tests/test_domain_exceptions.py**: Simplify test setup by using shared `make_fire_repo()` helper and remove unnecessary mock imports