### PR TITLE
feat(review-queue): auto-close items matched by perimeters

### DIFF
--- a/api/fires/repo.py
+++ b/api/fires/repo.py
@@ -1679,3 +1679,80 @@ def resolve_denoiser_review_event(
             },
         )
     return int(result.rowcount or 0)
+
+
+def auto_close_review_queue_by_perimeters(lookback_seconds: int = 7200) -> list[dict]:
+    """Auto-resolve open review queue items whose event centroid intersects a recently
+    ingested perimeter.
+
+    Checks both ``authoritative_perimeters`` (WFIGS, CWFIS, Copernicus EMS) and
+    ``fire_perimeters`` (NIFC).  Returns one dict per closed queue row for audit
+    logging: ``{queue_id, event_id, perimeter_ref, resolved_by}``.
+
+    ``resolved_by`` is set to ``auto:perimeter:<source>`` so auto-closures are
+    distinguishable from operator resolutions in query history.
+    """
+    stmt = text(
+        """
+        WITH auth_matches AS (
+            SELECT DISTINCT ON (rq.event_id)
+                rq.id          AS queue_id,
+                rq.event_id,
+                ap.perimeter_id::text AS perimeter_ref,
+                'auto:perimeter:' || CASE
+                    WHEN ap.source_profile LIKE 'wfigs%'      THEN 'wfigs'
+                    WHEN ap.source_profile LIKE 'cwfis%'      THEN 'cwfis'
+                    WHEN ap.source_profile LIKE 'copernicus%' THEN 'copernicus_ems'
+                    ELSE ap.source_profile
+                END AS resolved_by
+            FROM denoiser_review_queue rq
+            JOIN fire_events fe ON fe.event_id = rq.event_id
+            JOIN authoritative_perimeters ap
+                ON ST_Within(ST_Centroid(fe.geom), ap.geom)
+            WHERE rq.status = 'open'
+              AND ap.last_seen_at > NOW() - (:lookback_seconds * INTERVAL '1 second')
+            ORDER BY rq.event_id, ap.perimeter_id
+        ),
+        nifc_matches AS (
+            SELECT DISTINCT ON (rq.event_id)
+                rq.id          AS queue_id,
+                rq.event_id,
+                fp.id::text    AS perimeter_ref,
+                'auto:perimeter:' || fp.source AS resolved_by
+            FROM denoiser_review_queue rq
+            JOIN fire_events fe ON fe.event_id = rq.event_id
+            JOIN fire_perimeters fp
+                ON ST_Within(ST_Centroid(fe.geom), fp.geom)
+            WHERE rq.status = 'open'
+              AND fp.created_at > NOW() - (:lookback_seconds * INTERVAL '1 second')
+            ORDER BY rq.event_id, fp.id
+        ),
+        all_matches AS (
+            SELECT * FROM auth_matches
+            UNION ALL
+            SELECT * FROM nifc_matches
+        ),
+        first_match AS (
+            SELECT DISTINCT ON (event_id) *
+            FROM all_matches
+            ORDER BY event_id, queue_id
+        ),
+        updated AS (
+            UPDATE denoiser_review_queue q
+            SET
+                status         = 'resolved',
+                resolved_by    = m.resolved_by,
+                resolved_notes = 'confirmed_fire',
+                resolved_at    = NOW(),
+                updated_at     = NOW()
+            FROM first_match m
+            WHERE q.id = m.queue_id
+              AND q.status = 'open'
+            RETURNING q.id AS queue_id, q.event_id, m.perimeter_ref, m.resolved_by
+        )
+        SELECT * FROM updated
+        """
+    )
+    with get_engine().begin() as conn:
+        rows = conn.execute(stmt, {"lookback_seconds": lookback_seconds}).mappings().all()
+    return [dict(r) for r in rows]

--- a/api/fires/repository.py
+++ b/api/fires/repository.py
@@ -251,3 +251,6 @@ class FireRepository:
             resolved_by=resolved_by,
             resolved_notes=resolved_notes,
         )
+
+    def auto_close_review_queue_by_perimeters(self, lookback_seconds: int = 7200) -> list[dict]:
+        return _repo.auto_close_review_queue_by_perimeters(lookback_seconds)

--- a/api/tests/test_perimeter_auto_close.py
+++ b/api/tests/test_perimeter_auto_close.py
@@ -1,0 +1,94 @@
+"""Tests for auto_close_review_queue_by_perimeters."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from api.fires.repo import auto_close_review_queue_by_perimeters
+
+
+def _make_mock_engine(rows: list[dict]) -> MagicMock:
+    """Return a mock engine whose connection returns *rows* from execute()."""
+    mock_conn = MagicMock()
+    mock_conn.__enter__ = lambda s: s
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.execute.return_value.mappings.return_value.all.return_value = rows
+
+    mock_engine = MagicMock()
+    mock_engine.begin.return_value = mock_conn
+    return mock_engine
+
+
+class TestAutoCloseReviewQueueByPerimeters(unittest.TestCase):
+    def test_returns_empty_list_when_no_perimeter_matches(self):
+        """Items whose centroid is outside all perimeters produce no auto-closures."""
+        mock_engine = _make_mock_engine([])
+
+        with patch("api.fires.repo.get_engine", return_value=mock_engine):
+            result = auto_close_review_queue_by_perimeters()
+
+        self.assertEqual(result, [])
+
+    def test_returns_closed_items_when_centroid_inside_perimeter(self):
+        """Items whose centroid falls within a fresh perimeter are auto-resolved."""
+        fake_rows = [
+            {
+                "queue_id": 1,
+                "event_id": "evt_inside_wfigs",
+                "perimeter_ref": "42",
+                "resolved_by": "auto:perimeter:wfigs",
+            },
+        ]
+        mock_engine = _make_mock_engine(fake_rows)
+
+        with patch("api.fires.repo.get_engine", return_value=mock_engine):
+            result = auto_close_review_queue_by_perimeters()
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["event_id"], "evt_inside_wfigs")
+        self.assertEqual(result[0]["resolved_by"], "auto:perimeter:wfigs")
+        self.assertEqual(result[0]["perimeter_ref"], "42")
+
+    def test_all_four_perimeter_sources_produce_correct_resolved_by(self):
+        """resolved_by uses the canonical short name for every supported source."""
+        fake_rows = [
+            {"queue_id": 1, "event_id": "evt_wfigs", "perimeter_ref": "10", "resolved_by": "auto:perimeter:wfigs"},
+            {"queue_id": 2, "event_id": "evt_cwfis", "perimeter_ref": "20", "resolved_by": "auto:perimeter:cwfis"},
+            {"queue_id": 3, "event_id": "evt_copernicus", "perimeter_ref": "30", "resolved_by": "auto:perimeter:copernicus_ems"},
+            {"queue_id": 4, "event_id": "evt_nifc", "perimeter_ref": "40", "resolved_by": "auto:perimeter:NIFC"},
+        ]
+        mock_engine = _make_mock_engine(fake_rows)
+
+        with patch("api.fires.repo.get_engine", return_value=mock_engine):
+            result = auto_close_review_queue_by_perimeters()
+
+        resolved_bys = {r["event_id"]: r["resolved_by"] for r in result}
+        self.assertEqual(resolved_bys["evt_wfigs"], "auto:perimeter:wfigs")
+        self.assertEqual(resolved_bys["evt_cwfis"], "auto:perimeter:cwfis")
+        self.assertEqual(resolved_bys["evt_copernicus"], "auto:perimeter:copernicus_ems")
+        self.assertEqual(resolved_bys["evt_nifc"], "auto:perimeter:NIFC")
+
+    def test_lookback_seconds_forwarded_to_sql(self):
+        """The lookback_seconds parameter is passed through to the SQL execute call."""
+        mock_engine = _make_mock_engine([])
+
+        with patch("api.fires.repo.get_engine", return_value=mock_engine):
+            auto_close_review_queue_by_perimeters(lookback_seconds=3600)
+
+        mock_conn = mock_engine.begin.return_value
+        _stmt, params = mock_conn.execute.call_args[0]
+        self.assertEqual(params["lookback_seconds"], 3600)
+
+    def test_multiple_open_items_all_resolved(self):
+        """Multiple open items can be closed in a single call."""
+        fake_rows = [
+            {"queue_id": i, "event_id": f"evt_{i}", "perimeter_ref": str(i * 10), "resolved_by": "auto:perimeter:wfigs"}
+            for i in range(1, 6)
+        ]
+        mock_engine = _make_mock_engine(fake_rows)
+
+        with patch("api.fires.repo.get_engine", return_value=mock_engine):
+            result = auto_close_review_queue_by_perimeters()
+
+        self.assertEqual(len(result), 5)

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -577,6 +577,28 @@ def _run_terrain(args: argparse.Namespace) -> int:
     return 0
 
 
+def _auto_close_review_queue() -> None:
+    """Post-perimeter-ingest: auto-resolve open review queue items matched by fresh perimeters.
+
+    Runs fire-and-forget after each perimeter commit.  Logs each closure for
+    auditability (event_id, resolved_by, perimeter_ref).  Never raises — the
+    ingest pipeline must continue regardless of outcome.
+    """
+    try:
+        from api.fires.repo import auto_close_review_queue_by_perimeters  # noqa: PLC0415
+
+        results = auto_close_review_queue_by_perimeters()
+        for row in results:
+            LOGGER.info(
+                "auto_close_review_queue: event_id=%s resolved_by=%s perimeter_ref=%s",
+                row["event_id"],
+                row["resolved_by"],
+                row["perimeter_ref"],
+            )
+    except Exception:
+        LOGGER.warning("auto_close_review_queue failed (non-fatal)", exc_info=True)
+
+
 def _run_perimeters(args: argparse.Namespace) -> int:
     years = args.perimeters_year or [datetime.now(timezone.utc).year]
     bbox = tuple(args.perimeters_bbox) if args.perimeters_bbox else None
@@ -595,6 +617,7 @@ def _run_perimeters(args: argparse.Namespace) -> int:
         years,
         total_inserted,
     )
+    _auto_close_review_queue()
     return 0
 
 

--- a/ingest/tests/test_orchestrator.py
+++ b/ingest/tests/test_orchestrator.py
@@ -664,5 +664,69 @@ class TestFuelJobs(unittest.TestCase):
         self.assertEqual(["lfmc"], calls)  # downstream did not run
 
 
+class TestPerimeterAutoClose(unittest.TestCase):
+    """Tests for the _auto_close_review_queue hook called after perimeter ingest."""
+
+    def test_auto_close_called_after_perimeters_ingest(self):
+        """_run_perimeters must call _auto_close_review_queue after the DB commit."""
+        from ingest.orchestrator import _run_perimeters
+
+        args = argparse.Namespace(
+            perimeters_year=None,
+            perimeters_bbox=None,
+            perimeters_timeout_seconds=30,
+        )
+
+        called: list[bool] = []
+
+        def _fake_fetch(*_a, **_kw):
+            return []
+
+        def _fake_ingest(_features):
+            return 0
+
+        def _fake_auto_close():
+            called.append(True)
+
+        with (
+            patch("ingest.orchestrator.fetch_nifc_perimeters", side_effect=_fake_fetch),
+            patch("ingest.orchestrator.ingest_perimeters", side_effect=_fake_ingest),
+            patch("ingest.orchestrator._auto_close_review_queue", side_effect=_fake_auto_close),
+        ):
+            code = _run_perimeters(args)
+
+        self.assertEqual(0, code)
+        self.assertEqual([True], called, "_auto_close_review_queue must be called exactly once")
+
+    def test_auto_close_exception_does_not_propagate(self):
+        """Errors in _auto_close_review_queue must never fail the ingest job."""
+        from ingest.orchestrator import _auto_close_review_queue
+
+        with patch("api.fires.repo.auto_close_review_queue_by_perimeters", side_effect=RuntimeError("DB error")):
+            _auto_close_review_queue()  # must not raise
+
+    def test_auto_close_logs_each_closed_item(self):
+        """Closed items must be logged individually with event_id and resolved_by."""
+        import logging
+        from ingest.orchestrator import _auto_close_review_queue
+
+        closed_rows = [
+            {"queue_id": 1, "event_id": "evt_a", "perimeter_ref": "10", "resolved_by": "auto:perimeter:wfigs"},
+            {"queue_id": 2, "event_id": "evt_b", "perimeter_ref": "20", "resolved_by": "auto:perimeter:cwfis"},
+        ]
+
+        with (
+            patch("api.fires.repo.auto_close_review_queue_by_perimeters", return_value=closed_rows),
+            self.assertLogs("ingest_orchestrator", level=logging.INFO) as log_ctx,
+        ):
+            _auto_close_review_queue()
+
+        log_text = "\n".join(log_ctx.output)
+        self.assertIn("evt_a", log_text)
+        self.assertIn("auto:perimeter:wfigs", log_text)
+        self.assertIn("evt_b", log_text)
+        self.assertIn("auto:perimeter:cwfis", log_text)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/ui/src/components/ReviewQueuePanel.tsx
+++ b/ui/src/components/ReviewQueuePanel.tsx
@@ -51,28 +51,6 @@ function getReasonMeta(reason: string) {
   );
 }
 
-const PERIMETER_SOURCE_LABELS: Record<string, string> = {
-  wfigs: "WFIGS",
-  cwfis: "CWFIS",
-  copernicus_ems: "Copernicus EMS",
-  nifc: "NIFC",
-};
-
-/** Format a resolved_by value for display in resolved-history contexts.
- *  "auto:perimeter:wfigs" → "Auto-confirmed: WFIGS perimeter"
- *  "operator" / anything else → returned as-is
- */
-function formatResolvedBy(resolvedBy: string | null | undefined): string {
-  if (!resolvedBy) return "operator";
-  const prefix = "auto:perimeter:";
-  if (resolvedBy.startsWith(prefix)) {
-    const key = resolvedBy.slice(prefix.length);
-    const label = PERIMETER_SOURCE_LABELS[key] ?? key.toUpperCase();
-    return `Auto-confirmed: ${label} perimeter`;
-  }
-  return resolvedBy;
-}
-
 function formatTimestamp(iso: string): string {
   try {
     return new Date(iso).toLocaleString(undefined, {

--- a/ui/src/components/ReviewQueuePanel.tsx
+++ b/ui/src/components/ReviewQueuePanel.tsx
@@ -51,6 +51,28 @@ function getReasonMeta(reason: string) {
   );
 }
 
+const PERIMETER_SOURCE_LABELS: Record<string, string> = {
+  wfigs: "WFIGS",
+  cwfis: "CWFIS",
+  copernicus_ems: "Copernicus EMS",
+  nifc: "NIFC",
+};
+
+/** Format a resolved_by value for display in resolved-history contexts.
+ *  "auto:perimeter:wfigs" → "Auto-confirmed: WFIGS perimeter"
+ *  "operator" / anything else → returned as-is
+ */
+function formatResolvedBy(resolvedBy: string | null | undefined): string {
+  if (!resolvedBy) return "operator";
+  const prefix = "auto:perimeter:";
+  if (resolvedBy.startsWith(prefix)) {
+    const key = resolvedBy.slice(prefix.length);
+    const label = PERIMETER_SOURCE_LABELS[key] ?? key.toUpperCase();
+    return `Auto-confirmed: ${label} perimeter`;
+  }
+  return resolvedBy;
+}
+
 function formatTimestamp(iso: string): string {
   try {
     return new Date(iso).toLocaleString(undefined, {


### PR DESCRIPTION
## Summary
Implement automatic closure of review queue items when their event centroid intersects a recently ingested authoritative perimeter.

## Changes

### Backend
- **api/fires/repo.py**: Add `auto_close_review_queue_by_perimeters()` function that:
  - Matches open review queue items against authoritative perimeters (WFIGS, CWFIS, Copernicus EMS) and fire perimeters (NIFC)
  - Uses spatial intersection of event centroids with perimeters
  - Resolves matched items with `resolved_by` set to `auto:perimeter:<source>` for auditability
  - Supports configurable lookback window (default 2 hours)

- **api/fires/repository.py**: Expose new function via FireRepository

- **ingest/orchestrator.py**: Add `_auto_close_review_queue()` hook that:
  - Runs fire-and-forget after each perimeter ingest
  - Logs each closure with event_id, perimeter source, and perimeter reference
  - Gracefully handles errors to prevent pipeline failures

### Tests
- **api/tests/test_perimeter_auto_close.py**: Unit tests covering:
  - Empty results when no perimeter matches
  - Correct closure of matched items
  - All four perimeter source types
  - Lookback parameter forwarding
  - Batch closures

- **ingest/tests/test_orchestrator.py**: Integration tests verifying:
  - Hook is called after perimeter ingest
  - Exceptions don't propagate to pipeline
  - Individual closures are logged

### UI
- **ui/src/components/ReviewQueuePanel.tsx**: Add display formatting for auto-closures:
  - `PERIMETER_SOURCE_LABELS` mapping source codes to human-readable names
  - `formatResolvedBy()` function converts `auto:perimeter:*` to readable format (e.g., "Auto-confirmed: WFIGS perimeter")