### PR TITLE
feat(ingest): add drought and lightning proxy ingests for ignition

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,23 @@ POSTGRES_DB=wildfire
 # FIRMS_RECONCILE_MAX_BATCHES=5
 
 # =============================================================================
+# Optional: Drought Index Ingest (Copernicus GDO via CDS API)
+# =============================================================================
+# Register at https://cds.climate.copernicus.eu/how-to-api to get a free key.
+# Format: <uid>:<api_key>  (copy from your CDS profile page)
+# If unset, drought ingest is skipped with a WARNING — the orchestrator
+# continues normally and the ignition probability model degrades gracefully.
+# CDSAPI_KEY=your_uid:your_api_key_here
+# DROUGHT_DATASET=derived-drought-index-obs
+# DROUGHT_VARIABLE=soil_moisture_anomaly
+# DROUGHT_OUTPUT_DIR=data/drought/gdo
+
+# =============================================================================
+# Optional: Lightning Proxy Ingest (MeteoAlarm thunderstorm warnings)
+# =============================================================================
+# LIGHTNING_PROXY_GRID_DEG=0.1   # grid cell size in decimal degrees (default 0.1°)
+
+# =============================================================================
 # Optional: Weather Ingest Settings
 # =============================================================================
 # WEATHER_MODEL=gfs_0p25

--- a/api/migrations/versions/20260331_add_ignition_signals.py
+++ b/api/migrations/versions/20260331_add_ignition_signals.py
@@ -1,0 +1,116 @@
+"""Add drought_index_runs and ignition_lightning_proxy tables for ignition probability signals.
+
+drought_index_runs  — tracks Copernicus GDO raster ingest runs (one row per
+                      successful weekly fetch).  Mirrors the fuel_moisture_runs
+                      pattern used by lfmc_ecland_ingest.
+
+ignition_lightning_proxy — materialised staging table refreshed each ingest
+                           cycle with a boolean thunderstorm_active flag per
+                           grid cell, derived from MeteoAlarm thunderstorm
+                           warnings.  Schema is intentionally stable so future
+                           upgrades to the lightning source do not require
+                           feature extraction changes.
+
+Revision ID: 20260331_add_ignition_signals
+Revises: 20260330_add_ne_populated_places
+Create Date: 2026-03-31 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260331_add_ignition_signals"
+down_revision: Union[str, Sequence[str], None] = "20260330_add_ne_populated_places"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # ------------------------------------------------------------------ #
+    # drought_index_runs                                                   #
+    # ------------------------------------------------------------------ #
+    op.create_table(
+        "drought_index_runs",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("valid_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("bbox_min_lon", sa.Float(), nullable=False),
+        sa.Column("bbox_min_lat", sa.Float(), nullable=False),
+        sa.Column("bbox_max_lon", sa.Float(), nullable=False),
+        sa.Column("bbox_max_lat", sa.Float(), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("storage_path", sa.Text(), nullable=False),
+        sa.Column("provider", sa.String(length=255), nullable=True),
+        sa.Column("variable", sa.String(length=255), nullable=True),
+        sa.Column("coverage_fraction", sa.Float(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_drought_index_runs_valid_time",
+        "drought_index_runs",
+        ["valid_time"],
+    )
+    op.create_index(
+        "ix_drought_index_runs_provider_status",
+        "drought_index_runs",
+        ["provider", "status"],
+    )
+
+    # ------------------------------------------------------------------ #
+    # ignition_lightning_proxy                                             #
+    # ------------------------------------------------------------------ #
+    op.create_table(
+        "ignition_lightning_proxy",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("grid_lon", sa.Float(), nullable=False),
+        sa.Column("grid_lat", sa.Float(), nullable=False),
+        sa.Column("thunderstorm_active", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("valid_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_ignition_lightning_proxy_valid_time",
+        "ignition_lightning_proxy",
+        ["valid_time"],
+    )
+    op.create_index(
+        "ix_ignition_lightning_proxy_grid",
+        "ignition_lightning_proxy",
+        ["grid_lon", "grid_lat"],
+    )
+    op.create_index(
+        "ix_ignition_lightning_proxy_active",
+        "ignition_lightning_proxy",
+        ["thunderstorm_active"],
+        postgresql_where=sa.text("thunderstorm_active = true"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_ignition_lightning_proxy_active", table_name="ignition_lightning_proxy")
+    op.drop_index("ix_ignition_lightning_proxy_grid", table_name="ignition_lightning_proxy")
+    op.drop_index("ix_ignition_lightning_proxy_valid_time", table_name="ignition_lightning_proxy")
+    op.drop_table("ignition_lightning_proxy")
+
+    op.drop_index("ix_drought_index_runs_provider_status", table_name="drought_index_runs")
+    op.drop_index("ix_drought_index_runs_valid_time", table_name="drought_index_runs")
+    op.drop_table("drought_index_runs")

--- a/ingest/drought_ingest.py
+++ b/ingest/drought_ingest.py
@@ -33,11 +33,8 @@ is a slow-moving background signal.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
-import tempfile
-import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any

--- a/ingest/drought_ingest.py
+++ b/ingest/drought_ingest.py
@@ -1,0 +1,449 @@
+"""Copernicus Global Drought Observatory (GDO) drought index ingest.
+
+Downloads the Combined Drought Indicator (CDI) or Soil Moisture Anomaly (SMA)
+raster from the Copernicus Climate Data Store (CDS), clips it to a configured
+bbox, and writes a row to ``drought_index_runs`` so downstream feature
+extraction can locate the latest valid raster.
+
+Data source
+-----------
+Product: Copernicus GDO — Soil Moisture Anomaly (SMA) or CDI composite
+Resolution: ~5 km (0.04°)
+Cadence: Weekly (typically published Monday for the prior week)
+API: Copernicus Climate Data Store (CDS) — same mechanism as lfmc_ecland_ingest
+Docs: https://cds.climate.copernicus.eu/
+
+Environment
+-----------
+CDSAPI_KEY        — ``<uid>:<api_key>`` token from the Copernicus CDS portal
+                    (https://cds.climate.copernicus.eu/how-to-api).
+                    If absent the job logs a WARNING and skips — the orchestrator
+                    continues normally.
+DROUGHT_DATASET   — CDS dataset name (default: derived-drought-index-obs)
+DROUGHT_VARIABLE  — Variable within the dataset (default: soil_moisture_anomaly)
+DROUGHT_OUTPUT_DIR — Local raster cache dir (default: data/drought/gdo)
+
+Staleness
+---------
+A drought index older than 10 days emits a WARNING with a science_grade
+mitigation note.  The ignition probability model can still run; the ML
+model weights this signal accordingly.  A BLOCKER is never raised — drought
+is a slow-moving background signal.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import sqlalchemy as sa
+
+from api.db import get_engine
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+LOGGER = logging.getLogger("drought_ingest")
+
+DROUGHT_PROVIDER = "copernicus_gdo"
+_CDSAPI_KEY_ENV = "CDSAPI_KEY"
+_DATASET_ENV = "DROUGHT_DATASET"
+_VARIABLE_ENV = "DROUGHT_VARIABLE"
+_OUTPUT_DIR_ENV = "DROUGHT_OUTPUT_DIR"
+
+_DEFAULT_DATASET = "derived-drought-index-obs"
+_DEFAULT_VARIABLE = "soil_moisture_anomaly"
+_DEFAULT_OUTPUT_DIR = Path("data/drought/gdo")
+
+# A drought index older than this is considered stale (WARNING, not BLOCKER).
+_STALE_WARNING_DAYS = 10
+
+
+def _cdsapi_key() -> str | None:
+    """Return the CDS API key, or None if not configured."""
+    key = str(os.getenv(_CDSAPI_KEY_ENV, "")).strip()
+    return key if key else None
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _latest_completed_ingest(provider: str = DROUGHT_PROVIDER) -> dict[str, Any] | None:
+    """Return the most recent completed drought ingest row, or None."""
+    stmt = sa.text(
+        """
+        SELECT id, valid_time, storage_path, created_at
+        FROM drought_index_runs
+        WHERE provider = :provider
+          AND status = 'completed'
+        ORDER BY valid_time DESC
+        LIMIT 1
+        """
+    )
+    with get_engine().connect() as conn:
+        row = conn.execute(stmt, {"provider": provider}).mappings().first()
+    if row is None:
+        return None
+    return dict(row)
+
+
+def _already_ingested(valid_time: datetime, provider: str = DROUGHT_PROVIDER) -> bool:
+    """Return True if a completed run already exists for this valid_time."""
+    stmt = sa.text(
+        """
+        SELECT 1 FROM drought_index_runs
+        WHERE provider = :provider
+          AND status = 'completed'
+          AND valid_time = :valid_time
+        LIMIT 1
+        """
+    )
+    with get_engine().connect() as conn:
+        row = conn.execute(stmt, {"provider": provider, "valid_time": valid_time}).first()
+    return row is not None
+
+
+def _create_run_record(
+    *,
+    valid_time: datetime,
+    bbox: tuple[float, float, float, float],
+    storage_path: str,
+    variable: str,
+) -> int:
+    stmt = sa.text(
+        """
+        INSERT INTO drought_index_runs (
+            valid_time,
+            bbox_min_lon,
+            bbox_min_lat,
+            bbox_max_lon,
+            bbox_max_lat,
+            status,
+            storage_path,
+            provider,
+            variable
+        )
+        VALUES (
+            :valid_time,
+            :min_lon,
+            :min_lat,
+            :max_lon,
+            :max_lat,
+            'running',
+            :storage_path,
+            :provider,
+            :variable
+        )
+        RETURNING id
+        """
+    )
+    with get_engine().begin() as conn:
+        row = conn.execute(
+            stmt,
+            {
+                "valid_time": valid_time,
+                "min_lon": float(bbox[0]),
+                "min_lat": float(bbox[1]),
+                "max_lon": float(bbox[2]),
+                "max_lat": float(bbox[3]),
+                "storage_path": storage_path,
+                "provider": DROUGHT_PROVIDER,
+                "variable": variable,
+            },
+        ).mappings().first()
+    if row is None or row.get("id") is None:
+        raise RuntimeError("Failed to create drought_index_runs row.")
+    return int(row["id"])
+
+
+def _finalize_run_record(
+    *,
+    run_id: int,
+    status: str,
+    storage_path: str,
+    coverage_fraction: float | None = None,
+) -> None:
+    stmt = sa.text(
+        """
+        UPDATE drought_index_runs
+        SET status = :status,
+            storage_path = :storage_path,
+            coverage_fraction = :coverage_fraction
+        WHERE id = :run_id
+        """
+    )
+    with get_engine().begin() as conn:
+        conn.execute(
+            stmt,
+            {
+                "run_id": int(run_id),
+                "status": str(status),
+                "storage_path": str(storage_path),
+                "coverage_fraction": coverage_fraction,
+            },
+        )
+
+
+def _check_staleness(latest: dict[str, Any] | None) -> None:
+    """Emit a WARNING if the most recent completed ingest is older than the threshold."""
+    if latest is None:
+        LOGGER.warning(
+            "WARNING: No completed drought index ingest found in drought_index_runs. "
+            "Ignition probability model will run without a drought signal. "
+            "Mitigation: run drought ingest successfully at least once; "
+            "target: science_grade auto-alerting pipeline."
+        )
+        return
+
+    valid_time = latest.get("valid_time")
+    if valid_time is None:
+        return
+
+    if not isinstance(valid_time, datetime):
+        return
+
+    age = _utc_now() - valid_time.astimezone(timezone.utc)
+    if age > timedelta(days=_STALE_WARNING_DAYS):
+        LOGGER.warning(
+            "WARNING: Drought index is stale (valid_time=%s, age=%.1f days > threshold=%d days). "
+            "Ignition probability model will use degraded drought signal. "
+            "Mitigation: ensure CDSAPI_KEY is set and CDS API is reachable; "
+            "target: science_grade freshness alerting.",
+            valid_time.isoformat(),
+            age.total_seconds() / 86400,
+            _STALE_WARNING_DAYS,
+        )
+
+
+def _resolve_valid_time(dataset_response: dict[str, Any], fallback: datetime) -> datetime:
+    """Extract valid_time from a CDS API dataset response, or fall back."""
+    for key in ("valid_time", "data_time", "date", "time"):
+        raw = dataset_response.get(key)
+        if raw:
+            try:
+                if isinstance(raw, str):
+                    return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(timezone.utc)
+                if isinstance(raw, (int, float)):
+                    return datetime.fromtimestamp(float(raw), tz=timezone.utc)
+            except (ValueError, OSError):
+                continue
+    return fallback
+
+
+def _compute_coverage(nc_path: Path, variable: str) -> float | None:
+    """Return the fraction of non-null cells in the raster, or None on error."""
+    try:
+        import xarray as xr
+
+        ds = xr.open_dataset(nc_path)
+        try:
+            candidates = [v for v in ds.data_vars if variable.lower() in v.lower()] or list(ds.data_vars)
+            if not candidates:
+                return None
+            arr = ds[candidates[0]]
+            total = int(arr.size)
+            valid = int(arr.notnull().sum())
+            return float(valid) / float(total) if total > 0 else None
+        finally:
+            ds.close()
+    except Exception as exc:
+        LOGGER.debug("Coverage computation skipped: %s", exc)
+        return None
+
+
+def _fetch_via_cdsapi(
+    *,
+    api_key: str,
+    dataset: str,
+    variable: str,
+    bbox: tuple[float, float, float, float],
+    output_path: Path,
+) -> dict[str, Any]:
+    """Submit a CDS API request and download the result to output_path.
+
+    Returns the metadata dict from the CDS client result object so the caller
+    can extract valid_time.  Uses the ``cdsapi`` Python package (must be
+    installed in the environment).
+    """
+    import cdsapi  # type: ignore[import]
+
+    # CDS area order: North / West / South / East
+    area = [
+        float(bbox[3]),  # North (max_lat)
+        float(bbox[0]),  # West (min_lon)
+        float(bbox[1]),  # South (min_lat)
+        float(bbox[2]),  # East (max_lon)
+    ]
+
+    # Construct the URL from key for the CDS client.
+    # The cdsapi.Client accepts a ``key`` kwarg directly.
+    client = cdsapi.Client(
+        url="https://cds.climate.copernicus.eu/api",
+        key=api_key,
+        quiet=True,
+        wait_until_complete=True,
+        delete=True,
+    )
+
+    result = client.retrieve(
+        dataset,
+        {
+            "variable": variable,
+            "format": "netcdf",
+            "area": area,
+        },
+        str(output_path),
+    )
+
+    meta: dict[str, Any] = {}
+    try:
+        meta = dict(result.__dict__) if hasattr(result, "__dict__") else {}
+    except Exception:
+        pass
+    return meta
+
+
+def ingest_drought_index(
+    *,
+    bbox: tuple[float, float, float, float] | None = None,
+    output_dir: Path | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Fetch the latest Copernicus GDO drought index raster and store it.
+
+    Parameters
+    ----------
+    bbox:
+        WGS84 bounding box (min_lon, min_lat, max_lon, max_lat).
+        Defaults to global coverage (-180, -90, 180, 90).
+    output_dir:
+        Local directory for raster files.
+        Defaults to ``data/drought/gdo``.
+    force:
+        Re-ingest even if a completed record for the same valid_time exists.
+
+    Returns a dict with run metadata.
+    Raises RuntimeError on hard failures.
+    Logs a WARNING and returns a skip dict if CDSAPI_KEY is absent.
+    """
+    api_key = _cdsapi_key()
+    if api_key is None:
+        LOGGER.warning(
+            "WARNING: CDSAPI_KEY is not set. Drought index ingest skipped. "
+            "Register at https://cds.climate.copernicus.eu/how-to-api and set CDSAPI_KEY. "
+            "Mitigation: set the key and rerun; target: science_grade automated ingest."
+        )
+        return {"skipped": True, "reason": "CDSAPI_KEY not configured"}
+
+    dataset = str(os.getenv(_DATASET_ENV, _DEFAULT_DATASET)).strip() or _DEFAULT_DATASET
+    variable = str(os.getenv(_VARIABLE_ENV, _DEFAULT_VARIABLE)).strip() or _DEFAULT_VARIABLE
+    resolved_bbox: tuple[float, float, float, float] = bbox or (-180.0, -90.0, 180.0, 90.0)
+    out_root = output_dir or (Path(os.getenv(_OUTPUT_DIR_ENV, "")) or _DEFAULT_OUTPUT_DIR)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    latest = _latest_completed_ingest()
+    _check_staleness(latest)
+
+    run_ts = _utc_now()
+    tmp_name = f"drought_{dataset}_{variable}_{run_ts:%Y%m%dT%HZ}.nc.tmp"
+    tmp_path = out_root / tmp_name
+    run_id: int | None = None
+    coverage_fraction: float | None = None
+
+    try:
+        meta = _fetch_via_cdsapi(
+            api_key=api_key,
+            dataset=dataset,
+            variable=variable,
+            bbox=resolved_bbox,
+            output_path=tmp_path,
+        )
+
+        valid_time = _resolve_valid_time(meta, fallback=run_ts)
+
+        # Idempotency: skip if a completed record already exists for this valid_time.
+        if not force and _already_ingested(valid_time):
+            tmp_path.unlink(missing_ok=True)
+            LOGGER.info(
+                "Drought ingest skipped (already ingested valid_time=%s)", valid_time.isoformat()
+            )
+            return {
+                "skipped": True,
+                "reason": "already_ingested",
+                "valid_time": valid_time.isoformat(),
+            }
+
+        final_name = (
+            f"drought_{dataset}_{variable}_{valid_time:%Y%m%dT%HZ}_"
+            f"bbox_{resolved_bbox[0]:.2f}_{resolved_bbox[1]:.2f}_"
+            f"{resolved_bbox[2]:.2f}_{resolved_bbox[3]:.2f}.nc"
+        )
+        final_path = out_root / final_name
+        tmp_path.rename(final_path)
+
+        coverage_fraction = _compute_coverage(final_path, variable)
+
+        run_id = _create_run_record(
+            valid_time=valid_time,
+            bbox=resolved_bbox,
+            storage_path=str(final_path),
+            variable=variable,
+        )
+        _finalize_run_record(
+            run_id=run_id,
+            status="completed",
+            storage_path=str(final_path),
+            coverage_fraction=coverage_fraction,
+        )
+
+    except Exception:
+        if run_id is not None:
+            _finalize_run_record(
+                run_id=run_id,
+                status="failed",
+                storage_path=str(tmp_path),
+                coverage_fraction=None,
+            )
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+    result = {
+        "run_id": int(run_id),
+        "provider": DROUGHT_PROVIDER,
+        "dataset": dataset,
+        "variable": variable,
+        "storage_path": str(final_path),
+        "bbox": [float(v) for v in resolved_bbox],
+        "valid_time": valid_time.isoformat(),
+        "coverage_fraction": coverage_fraction,
+    }
+    LOGGER.info(
+        "Drought index ingest completed: source=%s variable=%s valid_time=%s path=%s coverage=%.2f",
+        dataset,
+        variable,
+        valid_time.isoformat(),
+        final_path,
+        coverage_fraction or 0.0,
+    )
+    return result
+
+
+def run_drought_ingest() -> int:
+    """Orchestrator-compatible entry point. Returns 0 on success, 1 on failure."""
+    try:
+        result = ingest_drought_index()
+        if result.get("skipped"):
+            # A missing key or duplicate is not a pipeline failure.
+            return 0
+        return 0
+    except Exception as exc:
+        LOGGER.error("Drought ingest failed: %s", exc)
+        return 1

--- a/ingest/lightning_proxy_ingest.py
+++ b/ingest/lightning_proxy_ingest.py
@@ -1,0 +1,276 @@
+"""Lightning / thunderstorm proximity proxy ingest.
+
+Materialises a lightweight ``ignition_lightning_proxy`` staging table that
+flags grid cells where active thunderstorm-type MeteoAlarm warnings intersect.
+This is the ``mvp_operational`` proxy for lightning ignition signal; it will be
+superseded by NOAA LIS/OTD or a proper lightning forecast product in a future
+``science_grade`` iteration.
+
+Design
+------
+- Query ``api.core.meteoalarm_provider.MeteoAlarmProvider`` (or the existing
+  in-memory warning provider) for all active ``thunderstorm`` warnings.
+- Project each warning polygon onto a regular 0.1° grid over the configured
+  bbox and write one row per cell with a boolean ``thunderstorm_active`` flag.
+- Each run is a complete refresh: delete the previous proxy rows and insert new
+  ones.  This is safe because the proxy is a staging table used only by the
+  ignition probability feature extraction; downstream reads always take the
+  latest snapshot.
+- The interface (table name ``ignition_lightning_proxy``, columns
+  ``grid_lon``, ``grid_lat``, ``thunderstorm_active``, ``valid_time``) is
+  intentionally stable so future upgrades to the lightning signal source do not
+  require changes to the ML feature extraction layer.
+
+Limitations (mvp_operational)
+------------------------------
+- MeteoAlarm covers Europe only; cells outside that coverage area will always
+  have ``thunderstorm_active = false``.
+- Polygon resolution is country/region-level, not point-level.
+- No temporal interpolation: a warning active at any point during the next
+  6 hours is treated as active for the entire current cycle.
+
+Science-grade upgrade path
+--------------------------
+Replace ``_fetch_thunderstorm_warnings`` with a NOAA LIS/OTD or ENTLN adapter
+that returns the same ``list[dict]`` schema (``geometry``, ``onset``,
+``expires``).  The grid materialisation and DB write logic below is provider-
+agnostic and does not need to change.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import sqlalchemy as sa
+
+from api.db import get_engine
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+LOGGER = logging.getLogger("lightning_proxy_ingest")
+
+_DEFAULT_GRID_RESOLUTION_DEG = 0.1
+_GRID_RESOLUTION_ENV = "LIGHTNING_PROXY_GRID_DEG"
+
+# Default bbox: global (same as drought ingest default; narrows to MeteoAlarm
+# coverage in practice since non-European cells will simply have no warnings).
+_DEFAULT_BBOX: tuple[float, float, float, float] = (-180.0, -90.0, 180.0, 90.0)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _grid_resolution() -> float:
+    raw = os.getenv(_GRID_RESOLUTION_ENV, "")
+    try:
+        val = float(raw)
+        if val > 0:
+            return val
+    except (ValueError, TypeError):
+        pass
+    return _DEFAULT_GRID_RESOLUTION_DEG
+
+
+def _generate_grid_cells(
+    bbox: tuple[float, float, float, float],
+    resolution: float,
+) -> list[tuple[float, float]]:
+    """Return (lon, lat) cell centre points for the given bbox and resolution."""
+    min_lon, min_lat, max_lon, max_lat = bbox
+    lons: list[float] = []
+    n_lon = max(1, math.ceil((max_lon - min_lon) / resolution))
+    for i in range(n_lon):
+        lons.append(round(min_lon + (i + 0.5) * resolution, 6))
+
+    lats: list[float] = []
+    n_lat = max(1, math.ceil((max_lat - min_lat) / resolution))
+    for j in range(n_lat):
+        lats.append(round(min_lat + (j + 0.5) * resolution, 6))
+
+    return [(lon, lat) for lat in lats for lon in lons]
+
+
+def _point_in_polygon(lon: float, lat: float, polygon_coords: list[list[list[float]]]) -> bool:
+    """Ray-casting point-in-polygon test for a GeoJSON Polygon ring list."""
+    for ring in polygon_coords:
+        inside = False
+        n = len(ring)
+        j = n - 1
+        for i in range(n):
+            xi, yi = ring[i][0], ring[i][1]
+            xj, yj = ring[j][0], ring[j][1]
+            if ((yi > lat) != (yj > lat)) and (lon < (xj - xi) * (lat - yi) / (yj - yi + 1e-12) + xi):
+                inside = not inside
+            j = i
+        if inside:
+            return True
+    return False
+
+
+def _geometry_covers_point(geometry: dict[str, Any], lon: float, lat: float) -> bool:
+    """Return True if a GeoJSON geometry (Polygon or MultiPolygon) covers the point."""
+    geom_type = geometry.get("type", "")
+    coords = geometry.get("coordinates", [])
+    if geom_type == "Polygon":
+        return _point_in_polygon(lon, lat, coords)
+    if geom_type == "MultiPolygon":
+        return any(_point_in_polygon(lon, lat, poly) for poly in coords)
+    return False
+
+
+def _fetch_thunderstorm_warnings(now: datetime) -> list[dict[str, Any]]:
+    """Return active thunderstorm-type MeteoAlarm warnings as plain dicts.
+
+    Each dict has keys: ``geometry`` (GeoJSON), ``onset`` (datetime), ``expires`` (datetime).
+    Errors from individual country feeds are suppressed (MeteoAlarmProvider contract).
+    """
+    from api.core.meteoalarm_provider import MeteoAlarmProvider
+
+    provider = MeteoAlarmProvider()
+    try:
+        warnings = asyncio.run(provider.get_warnings_for_region())
+    except Exception as exc:
+        LOGGER.warning(
+            "MeteoAlarm fetch failed: %s — lightning proxy will be empty this cycle. "
+            "Mitigation: check network connectivity; target: science_grade retry logic.",
+            exc,
+        )
+        return []
+
+    active: list[dict[str, Any]] = []
+    for w in warnings:
+        if w.warning_type != "thunderstorm":
+            continue
+        if w.expires < now:
+            continue
+        if w.geometry is None:
+            continue
+        active.append({"geometry": w.geometry, "onset": w.onset, "expires": w.expires})
+
+    return active
+
+
+def _materialise_proxy(
+    *,
+    bbox: tuple[float, float, float, float],
+    warnings: list[dict[str, Any]],
+    valid_time: datetime,
+    grid_resolution: float,
+) -> tuple[int, int]:
+    """Refresh ``ignition_lightning_proxy`` with the current thunderstorm grid.
+
+    Performs a delete-then-insert inside a single transaction so the table is
+    never empty between cycles (the delete and insert are atomic).
+
+    Returns ``(active_cells, total_cells)``.
+    """
+    cells = _generate_grid_cells(bbox, grid_resolution)
+    total_cells = len(cells)
+
+    lons: list[float] = []
+    lats: list[float] = []
+    active_flags: list[bool] = []
+    active_count = 0
+    for lon, lat in cells:
+        active = any(_geometry_covers_point(w["geometry"], lon, lat) for w in warnings)
+        if active:
+            active_count += 1
+        lons.append(lon)
+        lats.append(lat)
+        active_flags.append(active)
+
+    with get_engine().begin() as conn:
+        conn.execute(sa.text("DELETE FROM ignition_lightning_proxy"))
+        if cells:
+            conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO ignition_lightning_proxy (grid_lon, grid_lat, thunderstorm_active, valid_time)
+                    SELECT unnest(:lons::double precision[]),
+                           unnest(:lats::double precision[]),
+                           unnest(:active::boolean[]),
+                           :valid_time
+                    """
+                ),
+                {
+                    "lons": lons,
+                    "lats": lats,
+                    "active": active_flags,
+                    "valid_time": valid_time,
+                },
+            )
+
+    return active_count, total_cells
+
+
+def ingest_lightning_proxy(
+    *,
+    bbox: tuple[float, float, float, float] | None = None,
+    grid_resolution: float | None = None,
+) -> dict[str, Any]:
+    """Materialise the thunderstorm-active grid from MeteoAlarm warnings.
+
+    Parameters
+    ----------
+    bbox:
+        WGS84 bounding box (min_lon, min_lat, max_lon, max_lat).
+        Defaults to global coverage; MeteoAlarm data covers Europe only.
+    grid_resolution:
+        Grid cell size in decimal degrees.
+        Defaults to ``LIGHTNING_PROXY_GRID_DEG`` env var or 0.1°.
+
+    Returns a summary dict with ``valid_time``, ``total_cells``,
+    ``active_cells``, and ``warning_count``.
+    Raises RuntimeError on unrecoverable failures.
+    """
+    resolved_bbox = bbox or _DEFAULT_BBOX
+    resolution = grid_resolution or _grid_resolution()
+    now = _utc_now()
+
+    warnings = _fetch_thunderstorm_warnings(now)
+    LOGGER.info(
+        "Lightning proxy: fetched %d active thunderstorm warning(s) from MeteoAlarm",
+        len(warnings),
+    )
+
+    active_cells, total_cells = _materialise_proxy(
+        bbox=resolved_bbox,
+        warnings=warnings,
+        valid_time=now,
+        grid_resolution=resolution,
+    )
+
+    result = {
+        "valid_time": now.isoformat(),
+        "warning_count": len(warnings),
+        "total_cells": total_cells,
+        "active_cells": active_cells,
+        "grid_resolution_deg": resolution,
+        "bbox": list(resolved_bbox),
+    }
+    LOGGER.info(
+        "Lightning proxy materialised: active_cells=%d / total_cells=%d warnings=%d valid_time=%s",
+        active_cells,
+        total_cells,
+        len(warnings),
+        now.isoformat(),
+    )
+    return result
+
+
+def run_lightning_proxy_ingest() -> int:
+    """Orchestrator-compatible entry point. Returns 0 on success, 1 on failure."""
+    try:
+        ingest_lightning_proxy()
+        return 0
+    except Exception as exc:
+        LOGGER.error("Lightning proxy ingest failed: %s", exc)
+        return 1

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -33,13 +33,15 @@ JOB_FIRMS = "firms"
 JOB_WEATHER = "weather"
 JOB_LFMC = "lfmc"
 JOB_LULC = "lulc"
+JOB_DROUGHT = "drought"
+JOB_LIGHTNING_PROXY = "lightning_proxy"
 JOB_TERRAIN = "terrain"
 JOB_PERIMETERS = "perimeters"
 JOB_INDUSTRIAL = "industrial"
 JOB_DENOISER_DRIFT = "denoiser_drift"
 JOB_CLEANUP = "cleanup"
 JOB_AOI_WATCH = "aoi_watch"
-JOB_ORDER = (JOB_FIRMS, JOB_WEATHER, JOB_LFMC, JOB_LULC, JOB_TERRAIN, JOB_PERIMETERS, JOB_INDUSTRIAL, JOB_DENOISER_DRIFT, JOB_CLEANUP, JOB_AOI_WATCH)
+JOB_ORDER = (JOB_FIRMS, JOB_WEATHER, JOB_LFMC, JOB_LULC, JOB_DROUGHT, JOB_LIGHTNING_PROXY, JOB_TERRAIN, JOB_PERIMETERS, JOB_INDUSTRIAL, JOB_DENOISER_DRIFT, JOB_CLEANUP, JOB_AOI_WATCH)
 DEFAULT_DASHBOARD_PATH = REPO_ROOT / "data" / "ingest" / "orchestrator_dashboard.json"
 
 # Watermarks whose source name ends with _NRT are near-real-time feeds.
@@ -210,6 +212,24 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=float,
         default=10080.0,
         help="LULC WorldCover backfill interval in minutes (loop mode). Weekly; tiles are static.",
+    )
+    parser.add_argument(
+        "--drought-interval-minutes",
+        type=float,
+        default=1440.0,
+        help=(
+            "Drought index (Copernicus GDO) ingest interval in minutes (loop mode). "
+            "Data is weekly; daily checks detect new releases promptly."
+        ),
+    )
+    parser.add_argument(
+        "--lightning-proxy-interval-minutes",
+        type=float,
+        default=360.0,
+        help=(
+            "Lightning proxy (MeteoAlarm thunderstorm warnings) ingest interval in minutes (loop mode). "
+            "Aligned to GFS cycles (~6h) to keep the ignition signal fresh."
+        ),
     )
     parser.add_argument(
         "--cleanup-interval-minutes",
@@ -456,6 +476,8 @@ def _validate_args(args: argparse.Namespace) -> None:
         ("--weather-interval-minutes", args.weather_interval_minutes),
         ("--lfmc-interval-minutes", args.lfmc_interval_minutes),
         ("--lulc-interval-minutes", args.lulc_interval_minutes),
+        ("--drought-interval-minutes", args.drought_interval_minutes),
+        ("--lightning-proxy-interval-minutes", args.lightning_proxy_interval_minutes),
         ("--terrain-interval-minutes", args.terrain_interval_minutes),
         ("--perimeters-interval-minutes", args.perimeters_interval_minutes),
         ("--industrial-interval-minutes", args.industrial_interval_minutes),
@@ -561,6 +583,24 @@ def _run_lulc(args: argparse.Namespace) -> int:
     )
     LOGGER.info("LULC WorldCover backfill complete: %s", result)
     return 0
+
+
+def _run_drought(args: argparse.Namespace) -> int:
+    """Run Copernicus GDO drought index ingest.
+
+    Missing CDSAPI_KEY is a WARNING (not a BLOCKER) — the orchestrator
+    continues normally and the ignition probability model degrades gracefully.
+    """
+    from ingest.drought_ingest import run_drought_ingest  # noqa: PLC0415
+
+    return run_drought_ingest()
+
+
+def _run_lightning_proxy(args: argparse.Namespace) -> int:
+    """Materialise the thunderstorm-active grid from MeteoAlarm warnings."""
+    from ingest.lightning_proxy_ingest import run_lightning_proxy_ingest  # noqa: PLC0415
+
+    return run_lightning_proxy_ingest()
 
 
 def _run_terrain(args: argparse.Namespace) -> int:
@@ -773,6 +813,8 @@ def build_jobs(args: argparse.Namespace) -> list[ScheduledJob]:
         JOB_WEATHER: lambda: _run_weather(args),
         JOB_LFMC: lambda: _run_lfmc(args),
         JOB_LULC: lambda: _run_lulc(args),
+        JOB_DROUGHT: lambda: _run_drought(args),
+        JOB_LIGHTNING_PROXY: lambda: _run_lightning_proxy(args),
         JOB_TERRAIN: lambda: _run_terrain(args),
         JOB_PERIMETERS: lambda: _run_perimeters(args),
         JOB_INDUSTRIAL: lambda: _run_industrial(args),
@@ -786,6 +828,8 @@ def build_jobs(args: argparse.Namespace) -> list[ScheduledJob]:
         JOB_WEATHER: args.weather_interval_minutes * 60.0,
         JOB_LFMC: args.lfmc_interval_minutes * 60.0,
         JOB_LULC: args.lulc_interval_minutes * 60.0,
+        JOB_DROUGHT: args.drought_interval_minutes * 60.0,
+        JOB_LIGHTNING_PROXY: args.lightning_proxy_interval_minutes * 60.0,
         JOB_TERRAIN: args.terrain_interval_minutes * 60.0,
         JOB_PERIMETERS: args.perimeters_interval_minutes * 60.0,
         JOB_INDUSTRIAL: args.industrial_interval_minutes * 60.0,

--- a/ingest/tests/test_drought_ingest.py
+++ b/ingest/tests/test_drought_ingest.py
@@ -1,0 +1,211 @@
+"""Unit tests for ingest/drought_ingest.py.
+
+Tests focus on:
+- Idempotency: rerunning does not duplicate rows when valid_time already exists.
+- Stale WARNING: emitted when the latest completed run is older than threshold.
+- CDSAPI_KEY absent: job skips gracefully without raising.
+- run_drought_ingest: returns 0 on success and on a skip, 1 on failure.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _utc(days_ago: float = 0) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=days_ago)
+
+
+# ---------------------------------------------------------------------------
+# _check_staleness
+# ---------------------------------------------------------------------------
+
+class TestCheckStaleness(unittest.TestCase):
+    def test_no_completed_run_logs_warning(self):
+        from ingest.drought_ingest import _check_staleness
+
+        with self.assertLogs("drought_ingest", level="WARNING") as cm:
+            _check_staleness(None)
+
+        self.assertTrue(any("No completed drought index" in line for line in cm.output))
+
+    def test_fresh_run_does_not_warn(self):
+        from ingest.drought_ingest import _check_staleness
+
+        latest = {"valid_time": _utc(days_ago=1)}
+        # Should produce no WARNING logs.
+        with self.assertLogs("drought_ingest", level="INFO") as cm:
+            import logging
+            logging.getLogger("drought_ingest").info("probe")  # ensure logger fires
+            _check_staleness(latest)
+
+        warning_lines = [l for l in cm.output if "WARNING" in l and "stale" in l.lower()]
+        self.assertEqual([], warning_lines)
+
+    def test_stale_run_logs_warning(self):
+        from ingest.drought_ingest import _check_staleness
+
+        latest = {"valid_time": _utc(days_ago=11)}
+        with self.assertLogs("drought_ingest", level="WARNING") as cm:
+            _check_staleness(latest)
+
+        self.assertTrue(any("stale" in line.lower() for line in cm.output))
+        self.assertTrue(any("science_grade" in line for line in cm.output))
+
+    def test_just_under_threshold_does_not_warn(self):
+        from ingest.drought_ingest import _check_staleness
+
+        # 9.9 days ago: clearly within the 10-day threshold, must not warn.
+        latest = {"valid_time": _utc(days_ago=9.9)}
+        with self.assertNoLogs("drought_ingest", level="WARNING"):
+            _check_staleness(latest)
+
+
+# ---------------------------------------------------------------------------
+# _already_ingested (idempotency)
+# ---------------------------------------------------------------------------
+
+class TestAlreadyIngested(unittest.TestCase):
+    def test_returns_false_when_db_empty(self):
+        from ingest.drought_ingest import _already_ingested
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = lambda s: mock_conn
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.first.return_value = None
+
+        mock_engine = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        with patch("ingest.drought_ingest.get_engine", return_value=mock_engine):
+            result = _already_ingested(_utc())
+
+        self.assertFalse(result)
+
+    def test_returns_true_when_row_exists(self):
+        from ingest.drought_ingest import _already_ingested
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = lambda s: mock_conn
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.first.return_value = (1,)
+
+        mock_engine = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        with patch("ingest.drought_ingest.get_engine", return_value=mock_engine):
+            result = _already_ingested(_utc())
+
+        self.assertTrue(result)
+
+
+# ---------------------------------------------------------------------------
+# ingest_drought_index — key-absent skip
+# ---------------------------------------------------------------------------
+
+class TestIngestDroughtIndexNoKey(unittest.TestCase):
+    def test_skips_gracefully_when_cdsapi_key_missing(self):
+        from ingest.drought_ingest import ingest_drought_index
+
+        with patch.dict("os.environ", {}, clear=False):
+            # Ensure the key is absent regardless of host environment.
+            import os
+            os.environ.pop("CDSAPI_KEY", None)
+
+            with self.assertLogs("drought_ingest", level="WARNING") as cm:
+                result = ingest_drought_index()
+
+        self.assertTrue(result.get("skipped"))
+        self.assertEqual(result.get("reason"), "CDSAPI_KEY not configured")
+        self.assertTrue(any("CDSAPI_KEY" in line for line in cm.output))
+
+
+# ---------------------------------------------------------------------------
+# ingest_drought_index — idempotency (already ingested)
+# ---------------------------------------------------------------------------
+
+class TestIngestDroughtIndexIdempotency(unittest.TestCase):
+    def test_skips_when_valid_time_already_ingested(self):
+        from ingest.drought_ingest import ingest_drought_index
+
+        valid_time = _utc()
+
+        with (
+            patch.dict("os.environ", {"CDSAPI_KEY": "123:abc"}),
+            patch("ingest.drought_ingest._latest_completed_ingest", return_value=None),
+            patch("ingest.drought_ingest._check_staleness"),
+            patch("ingest.drought_ingest._fetch_via_cdsapi", return_value={"valid_time": valid_time.isoformat()}),
+            patch("ingest.drought_ingest._resolve_valid_time", return_value=valid_time),
+            patch("ingest.drought_ingest._already_ingested", return_value=True),
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.unlink"),
+        ):
+            result = ingest_drought_index()
+
+        self.assertTrue(result.get("skipped"))
+        self.assertEqual(result.get("reason"), "already_ingested")
+
+
+# ---------------------------------------------------------------------------
+# run_drought_ingest
+# ---------------------------------------------------------------------------
+
+class TestRunDroughtIngest(unittest.TestCase):
+    def test_returns_0_on_success(self):
+        from ingest.drought_ingest import run_drought_ingest
+
+        with patch("ingest.drought_ingest.ingest_drought_index", return_value={"run_id": 1}):
+            self.assertEqual(0, run_drought_ingest())
+
+    def test_returns_0_on_skip(self):
+        from ingest.drought_ingest import run_drought_ingest
+
+        with patch(
+            "ingest.drought_ingest.ingest_drought_index",
+            return_value={"skipped": True, "reason": "CDSAPI_KEY not configured"},
+        ):
+            self.assertEqual(0, run_drought_ingest())
+
+    def test_returns_1_on_exception(self):
+        from ingest.drought_ingest import run_drought_ingest
+
+        with patch(
+            "ingest.drought_ingest.ingest_drought_index",
+            side_effect=RuntimeError("CDS API down"),
+        ):
+            self.assertEqual(1, run_drought_ingest())
+
+
+# ---------------------------------------------------------------------------
+# _resolve_valid_time
+# ---------------------------------------------------------------------------
+
+class TestResolveValidTime(unittest.TestCase):
+    def test_extracts_from_valid_time_key(self):
+        from ingest.drought_ingest import _resolve_valid_time
+
+        ts = datetime(2026, 3, 1, 0, 0, tzinfo=timezone.utc)
+        meta = {"valid_time": "2026-03-01T00:00:00+00:00"}
+        result = _resolve_valid_time(meta, fallback=_utc())
+        self.assertEqual(ts, result)
+
+    def test_falls_back_when_no_key(self):
+        from ingest.drought_ingest import _resolve_valid_time
+
+        fallback = _utc()
+        result = _resolve_valid_time({}, fallback=fallback)
+        self.assertEqual(fallback, result)
+
+    def test_falls_back_on_unparseable_value(self):
+        from ingest.drought_ingest import _resolve_valid_time
+
+        fallback = _utc()
+        result = _resolve_valid_time({"valid_time": "not-a-date"}, fallback=fallback)
+        self.assertEqual(fallback, result)

--- a/ingest/tests/test_drought_ingest.py
+++ b/ingest/tests/test_drought_ingest.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import unittest
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
@@ -46,7 +45,7 @@ class TestCheckStaleness(unittest.TestCase):
             logging.getLogger("drought_ingest").info("probe")  # ensure logger fires
             _check_staleness(latest)
 
-        warning_lines = [l for l in cm.output if "WARNING" in l and "stale" in l.lower()]
+        warning_lines = [line for line in cm.output if "WARNING" in line and "stale" in line.lower()]
         self.assertEqual([], warning_lines)
 
     def test_stale_run_logs_warning(self):

--- a/ingest/tests/test_lightning_proxy_ingest.py
+++ b/ingest/tests/test_lightning_proxy_ingest.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import unittest
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 
 def _utc() -> datetime:

--- a/ingest/tests/test_lightning_proxy_ingest.py
+++ b/ingest/tests/test_lightning_proxy_ingest.py
@@ -1,0 +1,299 @@
+"""Unit tests for ingest/lightning_proxy_ingest.py.
+
+Tests focus on:
+- Grid generation: correct number of cells and cell centres.
+- Point-in-polygon: ray-casting correctness.
+- _materialise_proxy: correct delete-then-insert, active cell count.
+- ingest_lightning_proxy: MeteoAlarm fetch failure degrades gracefully.
+- run_lightning_proxy_ingest: returns 0 on success, 1 on unhandled failure.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, call, patch
+
+
+def _utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# _generate_grid_cells
+# ---------------------------------------------------------------------------
+
+class TestGenerateGridCells(unittest.TestCase):
+    def test_single_cell(self):
+        from ingest.lightning_proxy_ingest import _generate_grid_cells
+
+        cells = _generate_grid_cells((0.0, 0.0, 0.1, 0.1), 0.1)
+        self.assertEqual(1, len(cells))
+        lon, lat = cells[0]
+        self.assertAlmostEqual(0.05, lon, places=5)
+        self.assertAlmostEqual(0.05, lat, places=5)
+
+    def test_two_by_two_grid(self):
+        from ingest.lightning_proxy_ingest import _generate_grid_cells
+
+        cells = _generate_grid_cells((0.0, 0.0, 0.2, 0.2), 0.1)
+        self.assertEqual(4, len(cells))
+
+    def test_correct_lon_lat_ordering(self):
+        """Cells should iterate lat in outer loop, lon in inner loop."""
+        from ingest.lightning_proxy_ingest import _generate_grid_cells
+
+        cells = _generate_grid_cells((0.0, 0.0, 0.3, 0.2), 0.1)
+        # 3 lon × 2 lat = 6 cells
+        self.assertEqual(6, len(cells))
+
+    def test_global_bbox_approximate_count(self):
+        from ingest.lightning_proxy_ingest import _generate_grid_cells
+
+        cells = _generate_grid_cells((-180.0, -90.0, 180.0, 90.0), 1.0)
+        # 360 × 180 = 64800 cells at 1° resolution
+        self.assertEqual(64800, len(cells))
+
+
+# ---------------------------------------------------------------------------
+# _point_in_polygon
+# ---------------------------------------------------------------------------
+
+class TestPointInPolygon(unittest.TestCase):
+    # Simple unit square [0,0]-[1,1]
+    _SQUARE = [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]]
+
+    def test_inside(self):
+        from ingest.lightning_proxy_ingest import _point_in_polygon
+
+        self.assertTrue(_point_in_polygon(0.5, 0.5, self._SQUARE))
+
+    def test_outside(self):
+        from ingest.lightning_proxy_ingest import _point_in_polygon
+
+        self.assertFalse(_point_in_polygon(1.5, 0.5, self._SQUARE))
+        self.assertFalse(_point_in_polygon(0.5, 1.5, self._SQUARE))
+        self.assertFalse(_point_in_polygon(-0.1, 0.5, self._SQUARE))
+
+    def test_near_edge(self):
+        from ingest.lightning_proxy_ingest import _point_in_polygon
+
+        # Just inside
+        self.assertTrue(_point_in_polygon(0.01, 0.5, self._SQUARE))
+        # Just outside
+        self.assertFalse(_point_in_polygon(1.01, 0.5, self._SQUARE))
+
+
+# ---------------------------------------------------------------------------
+# _geometry_covers_point
+# ---------------------------------------------------------------------------
+
+class TestGeometryCoversPoint(unittest.TestCase):
+    _POLYGON_GEOM = {
+        "type": "Polygon",
+        "coordinates": [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]],
+    }
+    _MULTIPOLYGON_GEOM = {
+        "type": "MultiPolygon",
+        "coordinates": [
+            [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]],
+            [[[2.0, 2.0], [3.0, 2.0], [3.0, 3.0], [2.0, 3.0], [2.0, 2.0]]],
+        ],
+    }
+
+    def test_polygon_inside(self):
+        from ingest.lightning_proxy_ingest import _geometry_covers_point
+
+        self.assertTrue(_geometry_covers_point(self._POLYGON_GEOM, 0.5, 0.5))
+
+    def test_polygon_outside(self):
+        from ingest.lightning_proxy_ingest import _geometry_covers_point
+
+        self.assertFalse(_geometry_covers_point(self._POLYGON_GEOM, 1.5, 0.5))
+
+    def test_multipolygon_first_ring(self):
+        from ingest.lightning_proxy_ingest import _geometry_covers_point
+
+        self.assertTrue(_geometry_covers_point(self._MULTIPOLYGON_GEOM, 0.5, 0.5))
+
+    def test_multipolygon_second_ring(self):
+        from ingest.lightning_proxy_ingest import _geometry_covers_point
+
+        self.assertTrue(_geometry_covers_point(self._MULTIPOLYGON_GEOM, 2.5, 2.5))
+
+    def test_multipolygon_between_rings(self):
+        from ingest.lightning_proxy_ingest import _geometry_covers_point
+
+        self.assertFalse(_geometry_covers_point(self._MULTIPOLYGON_GEOM, 1.5, 1.5))
+
+    def test_unknown_type_returns_false(self):
+        from ingest.lightning_proxy_ingest import _geometry_covers_point
+
+        self.assertFalse(_geometry_covers_point({"type": "Point", "coordinates": [0.5, 0.5]}, 0.5, 0.5))
+
+
+# ---------------------------------------------------------------------------
+# _materialise_proxy — grid materialisation
+# ---------------------------------------------------------------------------
+
+class TestMaterialiseProxy(unittest.TestCase):
+    def _make_engine_mock(self):
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = lambda s: mock_conn
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_engine = MagicMock()
+        mock_engine.begin.return_value = mock_conn
+        return mock_engine, mock_conn
+
+    def test_no_warnings_produces_zero_active_cells(self):
+        from ingest.lightning_proxy_ingest import _materialise_proxy
+
+        engine_mock, conn_mock = self._make_engine_mock()
+        with patch("ingest.lightning_proxy_ingest.get_engine", return_value=engine_mock):
+            active, total = _materialise_proxy(
+                bbox=(0.0, 0.0, 1.0, 1.0),
+                warnings=[],
+                valid_time=_utc(),
+                grid_resolution=0.5,
+            )
+        self.assertEqual(0, active)
+        self.assertEqual(4, total)
+
+    def test_warning_covering_all_cells_marks_all_active(self):
+        from ingest.lightning_proxy_ingest import _materialise_proxy
+
+        # Warning polygon covers the entire 1°×1° bbox.
+        big_warning = {
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[-1.0, -1.0], [2.0, -1.0], [2.0, 2.0], [-1.0, 2.0], [-1.0, -1.0]]],
+            },
+            "onset": _utc(),
+            "expires": _utc(),
+        }
+        engine_mock, conn_mock = self._make_engine_mock()
+        with patch("ingest.lightning_proxy_ingest.get_engine", return_value=engine_mock):
+            active, total = _materialise_proxy(
+                bbox=(0.0, 0.0, 1.0, 1.0),
+                warnings=[big_warning],
+                valid_time=_utc(),
+                grid_resolution=0.5,
+            )
+        # 2×2 = 4 cells, all inside the big polygon
+        self.assertEqual(4, active)
+        self.assertEqual(4, total)
+
+    def test_delete_called_before_insert(self):
+        from ingest.lightning_proxy_ingest import _materialise_proxy
+
+        engine_mock, conn_mock = self._make_engine_mock()
+        with patch("ingest.lightning_proxy_ingest.get_engine", return_value=engine_mock):
+            _materialise_proxy(
+                bbox=(0.0, 0.0, 0.5, 0.5),
+                warnings=[],
+                valid_time=_utc(),
+                grid_resolution=0.5,
+            )
+
+        calls = conn_mock.execute.call_args_list
+        # First call must be the DELETE
+        first_call_sql = str(calls[0].args[0])
+        self.assertIn("DELETE", first_call_sql)
+
+    def test_partial_coverage(self):
+        from ingest.lightning_proxy_ingest import _materialise_proxy
+
+        # Warning covers only the bottom-left 0.5°×0.5° cell of a 1°×1° bbox
+        # at 0.5° resolution.  Only 1 of 4 cells should be active.
+        partial_warning = {
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[-0.1, -0.1], [0.6, -0.1], [0.6, 0.6], [-0.1, 0.6], [-0.1, -0.1]]],
+            },
+            "onset": _utc(),
+            "expires": _utc(),
+        }
+        engine_mock, conn_mock = self._make_engine_mock()
+        with patch("ingest.lightning_proxy_ingest.get_engine", return_value=engine_mock):
+            active, total = _materialise_proxy(
+                bbox=(0.0, 0.0, 1.0, 1.0),
+                warnings=[partial_warning],
+                valid_time=_utc(),
+                grid_resolution=0.5,
+            )
+        self.assertEqual(1, active)
+        self.assertEqual(4, total)
+
+
+# ---------------------------------------------------------------------------
+# _fetch_thunderstorm_warnings — graceful failure
+# ---------------------------------------------------------------------------
+
+class TestFetchThunderstormWarnings(unittest.TestCase):
+    def test_returns_empty_list_on_asyncio_run_error(self):
+        """asyncio.run raising maps to a WARNING and an empty return."""
+        from ingest.lightning_proxy_ingest import _fetch_thunderstorm_warnings
+
+        with (
+            patch("ingest.lightning_proxy_ingest.asyncio.run", side_effect=RuntimeError("network down")),
+            self.assertLogs("lightning_proxy_ingest", level="WARNING"),
+        ):
+            result = _fetch_thunderstorm_warnings(_utc())
+
+        self.assertEqual([], result)
+
+    def test_filters_non_thunderstorm_warnings(self):
+        from ingest.lightning_proxy_ingest import _fetch_thunderstorm_warnings
+
+        mock_warning_ts = MagicMock()
+        mock_warning_ts.warning_type = "thunderstorm"
+        mock_warning_ts.expires = datetime(9999, 1, 1, tzinfo=timezone.utc)
+        mock_warning_ts.geometry = {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]}
+
+        mock_warning_wind = MagicMock()
+        mock_warning_wind.warning_type = "wind"
+        mock_warning_wind.expires = datetime(9999, 1, 1, tzinfo=timezone.utc)
+        mock_warning_wind.geometry = {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]}
+
+        with patch("ingest.lightning_proxy_ingest.asyncio.run", return_value=[mock_warning_ts, mock_warning_wind]):
+            result = _fetch_thunderstorm_warnings(_utc())
+
+        self.assertEqual(1, len(result))
+
+    def test_filters_expired_warnings(self):
+        from ingest.lightning_proxy_ingest import _fetch_thunderstorm_warnings
+
+        now = _utc()
+        expired_warning = MagicMock()
+        expired_warning.warning_type = "thunderstorm"
+        expired_warning.expires = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        expired_warning.geometry = {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]}
+
+        with patch("ingest.lightning_proxy_ingest.asyncio.run", return_value=[expired_warning]):
+            result = _fetch_thunderstorm_warnings(now)
+
+        self.assertEqual([], result)
+
+
+# ---------------------------------------------------------------------------
+# run_lightning_proxy_ingest
+# ---------------------------------------------------------------------------
+
+class TestRunLightningProxyIngest(unittest.TestCase):
+    def test_returns_0_on_success(self):
+        from ingest.lightning_proxy_ingest import run_lightning_proxy_ingest
+
+        with patch(
+            "ingest.lightning_proxy_ingest.ingest_lightning_proxy",
+            return_value={"active_cells": 0, "total_cells": 100},
+        ):
+            self.assertEqual(0, run_lightning_proxy_ingest())
+
+    def test_returns_1_on_exception(self):
+        from ingest.lightning_proxy_ingest import run_lightning_proxy_ingest
+
+        with patch(
+            "ingest.lightning_proxy_ingest.ingest_lightning_proxy",
+            side_effect=RuntimeError("DB down"),
+        ):
+            self.assertEqual(1, run_lightning_proxy_ingest())


### PR DESCRIPTION
## Overview
Adds two new ingest pipelines to support ignition probability modeling:

### 1. Drought Index Ingest (`ingest/drought_ingest.py`)
- Fetches Copernicus Global Drought Observatory (GDO) raster data via CDS API
- Clips to configured bounding box and stores as NetCDF
- Tracks ingests in new `drought_index_runs` table
- Optional: gracefully skips if `CDSAPI_KEY` is not configured
- Emits WARNING if data older than 10 days (non-blocking)
- Idempotent: skips if `valid_time` already ingested

### 2. Lightning Proxy Ingest (`ingest/lightning_proxy_ingest.py`)
- Materializes thunderstorm-active grid from MeteoAlarm warnings
- Projects polygon geometries onto 0.1° grid cells
- Refreshes `ignition_lightning_proxy` staging table each cycle
- Implements ray-casting point-in-polygon for geometry checks
- Handles MeteoAlarm fetch failures gracefully

### Database Schema (`api/migrations/versions/20260331_add_ignition_signals.py`)
Adds two new tables:
- `drought_index_runs`: tracks Copernicus GDO ingest runs (follows fuel_moisture_runs pattern)
- `ignition_lightning_proxy`: materialised staging table with per-cell thunderstorm flags

### Orchestrator Integration (`ingest/orchestrator.py`)
- Registers `JOB_DROUGHT` and `JOB_LIGHTNING_PROXY` jobs
- Adds configurable ingest intervals (daily for drought, 6-hourly for lightning)
- Integrates into job scheduling pipeline

### Configuration (`.env.example`)
Adds optional environment variables:
- `CDSAPI_KEY`: Copernicus CDS API credentials
- `DROUGHT_DATASET`, `DROUGHT_VARIABLE`, `DROUGHT_OUTPUT_DIR`: drought ingest config
- `LIGHTNING_PROXY_GRID_DEG`: grid resolution in decimal degrees

### Tests
- `test_drought_ingest.py`: idempotency, staleness warnings, key-absent skip, run exit codes
- `test_lightning_proxy_ingest.py`: grid generation, point-in-polygon, materialization, fetch failures

## Design Notes
- Both ingests are optional (graceful degradation if upstream APIs unavailable)
- Drought signal is slow-moving (daily checks detect weekly CDS releases)
- Lightning signal is refreshed every 6 hours to align with weather cycles
- Table schemas intentionally stable for future source upgrades without feature extraction changes