### PR TITLE
perf(review-queue): cap to top-10 items sorted by FRP descending

### DIFF
--- a/api/fires/repo.py
+++ b/api/fires/repo.py
@@ -1372,7 +1372,7 @@ def _format_nearest_place(name: str | None, dist_km: float | None, bearing_deg: 
     return f"{int(dist_km)} km {_COMPASS[idx]} of {name}"
 
 
-def list_denoiser_review_queue(limit: int = 200, status: str = "open") -> list[dict]:
+def list_denoiser_review_queue(limit: int = 10, status: str = "open") -> list[dict]:
     """List denoiser review queue rows enriched with location context."""
     stmt = text(
         """
@@ -1392,7 +1392,7 @@ def list_denoiser_review_queue(limit: int = 200, status: str = "open") -> list[d
                 updated_at
             FROM denoiser_review_queue
             WHERE status = :status
-            ORDER BY created_at DESC, id DESC
+            ORDER BY (payload_json->>'frp_max')::float DESC NULLS LAST, created_at DESC, id DESC
             LIMIT :limit
         ),
         event_centroids AS (

--- a/api/routes/internal.py
+++ b/api/routes/internal.py
@@ -347,7 +347,7 @@ async def denoiser_drift(limit: int = 50) -> dict:
 
 
 @internal_router.get("/internal/denoiser/review-queue")
-async def denoiser_review_queue(limit: int = 200, status: str = "open") -> dict:
+async def denoiser_review_queue(limit: int = 10, status: str = "open") -> dict:
     """Return denoiser review queue items."""
     as_of = datetime.now(timezone.utc).isoformat()
     try:

--- a/ui/src/api/review.ts
+++ b/ui/src/api/review.ts
@@ -7,7 +7,7 @@ import type {
 import { getJson, postJson } from "./http";
 
 export async function getDenoiserReviewQueue(): Promise<ReviewQueueResponse> {
-  return getJson<ReviewQueueResponse>("/internal/denoiser/review-queue", { limit: 200, status: "open" });
+  return getJson<ReviewQueueResponse>("/internal/denoiser/review-queue", { limit: 10, status: "open" });
 }
 
 export async function resolveDenoiserReviewItem(args: {


### PR DESCRIPTION
## Changes

- Reduce review queue limit from 200 to 10 items for better performance
- Change sort order to prioritize highest Fire Radiative Power (FRP) values
- Update sorting: `(payload_json->>'frp_max')::float DESC NULLS LAST, created_at DESC, id DESC`
- Apply changes across backend (repo.py, internal.py) and frontend (review.ts)

## Impact

Review queue now returns only the top 10 most critical items by FRP, improving page load performance and focusing reviewer attention on highest-priority fires.