### PR TITLE
fix(ui): use isBriefingRef to prevent stale closure dropping briefings (closes #222)

### DIFF
--- a/ui/src/components/AIChatAssistant.tsx
+++ b/ui/src/components/AIChatAssistant.tsx
@@ -98,6 +98,7 @@ export default function AIChatAssistant(): JSX.Element {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const lastBriefedEventId = useRef<string | null>(null);
   const lastBriefedPrompt = useRef<string | null>(null);
+  const isBriefingRef = useRef(false);
 
   const selectedEvent = useAppStore((s) => s.selectedEvent);
   const filters = useAppStore((s) => s.filters);
@@ -182,7 +183,8 @@ export default function AIChatAssistant(): JSX.Element {
   );
 
   const triggerBriefing = useCallback(async (prompt: string): Promise<void> => {
-    if (!assistantConfigured || isBriefing) return;
+    if (!assistantConfigured || isBriefingRef.current) return;
+    isBriefingRef.current = true;
     setIsBriefing(true);
     setAutoBriefing(null);
     try {
@@ -213,9 +215,10 @@ export default function AIChatAssistant(): JSX.Element {
       console.error("[AIChatAssistant] auto-briefing failed:", err);
       setCircuitDegraded(true);
     } finally {
+      isBriefingRef.current = false;
       setIsBriefing(false);
     }
-  }, [assistantConfigured, isBriefing, isSafetyMode, viewingContext]);
+  }, [assistantConfigured, isSafetyMode, viewingContext]);
 
   // Auto-briefing when a new event is selected
   useEffect(() => {
@@ -227,8 +230,7 @@ export default function AIChatAssistant(): JSX.Element {
       ? "Give a 2-sentence safety briefing for this fire. Plain language only: risk level and what the person should do right now."
       : "Give a 2-sentence analyst briefing: fire behavior context, intensity interpretation, and spread risk.";
     void triggerBriefing(prompt);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedEvent?.event_id]);
+  }, [selectedEvent, selectedEvent?.event_id, assistantConfigured, isSafetyMode, triggerBriefing]);
 
   // Watch for imperatively requested briefings (from FireDetailsPanel "Get Safety Info")
   useEffect(() => {
@@ -237,8 +239,7 @@ export default function AIChatAssistant(): JSX.Element {
     lastBriefedPrompt.current = prompt;
     clearAssistantBriefingPrompt();
     void triggerBriefing(prompt);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [safety.pendingBriefingPrompt]);
+  }, [safety.pendingBriefingPrompt, triggerBriefing, clearAssistantBriefingPrompt]);
 
   useEffect(() => {
     if (!scrollRef.current) {


### PR DESCRIPTION
## Summary
Fixes #222

`triggerBriefing` was declared with `useCallback` and listed `isBriefing` state as a dependency, so its reference changed on every briefing start/end render. Two `useEffect` hooks omitted `triggerBriefing` from their dep arrays (suppressed via `eslint-disable`) and therefore captured a stale closure — when a briefing was already in flight, the stale `isBriefing=true` caused `triggerBriefing` to return early, silently dropping the new briefing and marking it as already-delivered via the `lastBriefedEventId.current` / `lastBriefedPrompt.current` refs, so it could never be retried.

Fix: replace the `isBriefing` state guard in `triggerBriefing` with `isBriefingRef.current`, removing `isBriefing` from the `useCallback` dep array so the callback reference stays stable across briefing renders. Both `useEffect` hooks now correctly include `triggerBriefing` (and their other consumed values) in their dependency arrays; the `eslint-disable` suppression comments are removed.

## Test plan
- [x] All 96 existing UI tests pass (`npm run test:run`)
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] ESLint clean on changed file (`npx eslint src/components/AIChatAssistant.tsx`)
- [ ] Manual: select fire event A while event B briefing is in flight — event A should receive its briefing after B completes
- [ ] Manual: trigger "Get Safety Info" from FireDetailsPanel during an active briefing — safety briefing should queue and fire after current briefing finishes