### PR TITLE
feat(weather): implement DB-backed weather point cache

### DIFF
--- a/api/core/weather.py
+++ b/api/core/weather.py
@@ -1,8 +1,8 @@
 """Shared weather point-lookup helpers.
 
-Extracted from ``api.fires.scoring`` so that both the fire-scoring pipeline
-and the risk-grid module can use the same logic without a cross-package
-dependency on fire internals.
+Primary path: query the ``weather_point_cache`` DB table (populated by
+``ingest.weather_point_ingest``).  Fallback: open a NetCDF file from
+``weather_runs.storage_path`` (covers JIT-produced per-AOI files).
 """
 
 from __future__ import annotations
@@ -19,8 +19,13 @@ import xarray as xr
 from sqlalchemy import text
 
 from api.db import get_engine
+from ingest.weather_repository import GFS_GRID_DEG, snap_to_gfs_grid
 
 LOGGER = logging.getLogger(__name__)
+
+_RESOLUTION_NOTE = "GFS 0.25\u00b0 \u2014 nearest grid point (~25 km)"
+
+_BIAS_CORRECTED_VARS = ("u10", "v10", "t2m", "rh2m")
 
 # ---------------------------------------------------------------------------
 # RH fire-risk classification
@@ -33,13 +38,7 @@ _RH_THRESHOLDS: list[tuple[float, str]] = [
 
 
 def classify_rh_fire_risk(rh_pct: float) -> str:
-    """Return a fire-risk level based on relative humidity.
-
-    Thresholds follow standard fire-weather convention:
-    - <15 %  → ``"critical"``
-    - <25 %  → ``"elevated"``
-    - ≥25 %  → ``"normal"``
-    """
+    """Return a fire-risk level based on relative humidity."""
     for threshold, level in _RH_THRESHOLDS:
         if rh_pct < threshold:
             return level
@@ -51,23 +50,11 @@ def classify_rh_fire_risk(rh_pct: float) -> str:
 # ---------------------------------------------------------------------------
 
 def _to_numpy_datetime64(dt: datetime) -> np.datetime64:
-    """Convert a datetime to numpy datetime64 with proper UTC handling.
-
-    This helper centralizes timezone handling to avoid inconsistencies when
-    converting timezone-aware datetimes to numpy datetime64.
-
-    Args:
-        dt: A timezone-aware or naive datetime. If naive, assumed to be UTC.
-
-    Returns:
-        numpy.datetime64 in millisecond precision UTC.
-    """
+    """Convert a datetime to numpy datetime64 with proper UTC handling."""
     if dt.tzinfo is None:
         dt_utc = dt.replace(tzinfo=timezone.utc)
     else:
         dt_utc = dt.astimezone(timezone.utc)
-
-    # Using 'ms' precision to avoid nanosecond overflow issues with some xarray versions
     return np.datetime64(dt_utc.replace(tzinfo=None), "ms")
 
 
@@ -78,39 +65,152 @@ def _ensure_utc(dt: datetime) -> datetime:
     return dt.astimezone(timezone.utc)
 
 
+# ---------------------------------------------------------------------------
+# DB point-cache queries (primary path)
+# ---------------------------------------------------------------------------
+
+def _query_point_cache(
+    *,
+    lat: float,
+    lon: float,
+    ref_time: datetime,
+    time_tolerance_hours: float,
+    forecast_hour: int = 0,
+) -> dict[str, Any] | None:
+    """Query ``weather_point_cache`` for a single GFS grid point + forecast hour.
+
+    Returns a dict with keys ``u10, v10, t2m, rh2m, tp, run_time`` or ``None``
+    if no matching row exists within the tolerance window.
+    """
+    lat_g, lon_g = snap_to_gfs_grid(lat, lon)
+
+    stmt = text("""
+        SELECT wpc.u10, wpc.v10, wpc.t2m, wpc.rh2m, wpc.tp,
+               wr.run_time
+        FROM weather_point_cache wpc
+        JOIN weather_runs wr ON wr.id = wpc.run_id
+        WHERE wpc.lat_grid = :lat_g AND wpc.lon_grid = :lon_g
+          AND wpc.forecast_hour = :fh
+          AND wr.status = 'completed'
+          AND wr.run_time <= :ref_time
+          AND wr.run_time >= :ref_time - INTERVAL '1 hour' * :tol
+        ORDER BY wr.run_time DESC
+        LIMIT 1
+    """)
+
+    try:
+        with get_engine().connect() as conn:
+            row = conn.execute(
+                stmt,
+                {
+                    "lat_g": lat_g,
+                    "lon_g": lon_g,
+                    "fh": forecast_hour,
+                    "ref_time": ref_time,
+                    "tol": time_tolerance_hours,
+                },
+            ).mappings().first()
+
+        if not row:
+            return None
+
+        # Validate expected columns exist (guard against schema mismatches
+        # or mocked queries that return weather_runs columns instead).
+        if "u10" not in row:
+            return None
+
+        return {
+            "u10": row["u10"],
+            "v10": row["v10"],
+            "t2m": row["t2m"],
+            "rh2m": row["rh2m"],
+            "tp": row["tp"],
+            "run_time": row["run_time"],
+        }
+    except Exception:
+        # Point cache table may not exist yet (pre-migration) or query may
+        # fail for other reasons.  Fall through to file-based path.
+        LOGGER.debug("Point cache query failed; falling through to file path.", exc_info=True)
+        return None
+
+
+def _build_fields_from_cache_row(row: dict[str, Any]) -> dict[str, Any]:
+    """Convert a point-cache dict into the rich fields dict used by the context API."""
+    ctx: dict[str, Any] = {}
+
+    u10 = row.get("u10")
+    v10 = row.get("v10")
+    if u10 is not None and v10 is not None:
+        ctx["wind_speed_ms"] = round(float(np.sqrt(u10**2 + v10**2)), 1)
+        ctx["wind_direction_deg"] = round(
+            (math.degrees(math.atan2(-u10, -v10)) + 360) % 360, 1
+        )
+
+    rh = row.get("rh2m")
+    if rh is not None:
+        ctx["relative_humidity_pct"] = round(rh, 1)
+        ctx["rh_fire_risk"] = classify_rh_fire_risk(rh)
+
+    t2m = row.get("t2m")
+    if t2m is not None:
+        ctx["temperature_c"] = round(t2m - 273.15, 1)
+
+    tp = row.get("tp")
+    if tp is not None:
+        ctx["precip_mm_24h"] = round(tp * 1000.0, 1)
+
+    return ctx
+
+
+def _attach_provenance(ctx: dict[str, Any], run_time: datetime, ref_time: datetime) -> None:
+    """Add source provenance and bias-correction metadata to a context dict in-place."""
+    run_time_utc = _ensure_utc(run_time)
+    ref_time_utc = _ensure_utc(ref_time)
+    ctx["source_run_time"] = run_time_utc.isoformat()
+    ctx["data_age_hours"] = round(
+        (ref_time_utc - run_time_utc).total_seconds() / 3600, 1
+    )
+    ctx["resolution_note"] = _RESOLUTION_NOTE
+    ctx["bias_correction"] = {
+        "applied": True,
+        "method": "affine (fitted against ERA5 reanalysis)",
+        "variables": list(_BIAS_CORRECTED_VARS),
+    }
+
+
+# ---------------------------------------------------------------------------
+# NetCDF file-based fallback (for JIT-produced per-AOI files)
+# ---------------------------------------------------------------------------
+
 @dataclass(frozen=True)
 class _WeatherSnapshot:
     """Result of opening a weather run and selecting the nearest grid point."""
 
     ds: xr.Dataset
-    ds_spatial: xr.Dataset   # spatially selected, NOT time-selected
-    ds_point: xr.Dataset     # spatially + time-selected (nearest to ref_time)
+    ds_spatial: xr.Dataset
+    ds_point: xr.Dataset
     ref_time_64: np.datetime64
     run_time: datetime
     storage_path: Path
 
 
-def _open_weather_for_point(
+def _open_weather_file_for_point(
     *,
     lat: float,
     lon: float,
     ref_time: datetime,
     time_tolerance_hours: float,
 ) -> _WeatherSnapshot | None:
-    """Find the best weather run, open the dataset, and select the nearest point.
+    """Fallback: find a NetCDF-backed weather_runs row and open the file.
 
-    Returns ``None`` (with debug logging) when no qualifying run exists.
-    The caller is responsible for closing ``snapshot.ds``.
-
-    The snapshot exposes both ``ds_spatial`` (spatially selected, all time
-    steps) and ``ds_point`` (additionally time-selected to the nearest step
-    before or at *ref_time*).  Use ``ds_spatial`` when you need multiple
-    forecast steps; use ``ds_point`` for the current-conditions shortcut.
+    This covers JIT-produced per-AOI files from spread forecast runs.
+    Skips rows with empty storage_path (point-cache runs).
     """
     stmt = text("""
         SELECT id, storage_path, run_time
         FROM weather_runs
         WHERE status = 'completed'
+          AND storage_path != ''
           AND run_time <= :ref_time
           AND run_time >= :ref_time - INTERVAL '1 hour' * :tolerance_hours
           AND COALESCE(bbox_min_lon, -180.0) <= :lon AND COALESCE(bbox_max_lon, 180.0) >= :lon
@@ -131,15 +231,15 @@ def _open_weather_for_point(
         ).mappings().first()
 
     if not row:
-        LOGGER.debug(
-            "No weather run found for point (lat=%s, lon=%s) at time %s",
-            lat, lon, ref_time,
-        )
         return None
 
     storage_path = Path(row["storage_path"])
     if not storage_path.is_absolute():
         storage_path = Path.cwd() / storage_path
+
+    if not storage_path.exists():
+        LOGGER.debug("Weather file missing: %s", storage_path)
+        return None
 
     ds = xr.open_dataset(storage_path)
     ds_spatial = ds.sel(lat=lat, lon=lon, method="nearest")
@@ -167,7 +267,7 @@ def _extract_precip_mm(
     ref_time_64: np.datetime64,
     lookback_hours: float,
 ) -> float | None:
-    """Sum total precipitation over the lookback window, converting m → mm."""
+    """Sum total precipitation over the lookback window, converting m -> mm."""
     if "tp" not in ds_point.data_vars or "time" not in ds.coords:
         return None
     try:
@@ -191,40 +291,29 @@ def _extract_weather_fields(
     target_time_64: np.datetime64,
     precip_lookback_hours: float,
 ) -> dict[str, Any]:
-    """Extract all weather fields from a time-selected spatial point dataset.
-
-    Returns a dict with wind, humidity, temperature, precipitation, and
-    rh_fire_risk.  Missing variables are omitted rather than set to null so
-    callers can detect partial data.
-    """
+    """Extract all weather fields from a time-selected spatial point dataset."""
     ctx: dict[str, Any] = {}
 
-    # --- wind ---
     if "u10" in ds_point_at_time.data_vars and "v10" in ds_point_at_time.data_vars:
         u10 = float(ds_point_at_time["u10"].values)
         v10 = float(ds_point_at_time["v10"].values)
         if not np.isnan(u10) and not np.isnan(v10):
             ctx["wind_speed_ms"] = round(float(np.sqrt(u10**2 + v10**2)), 1)
-            # Meteorological convention: direction wind is coming *from*
             ctx["wind_direction_deg"] = round(
                 (math.degrees(math.atan2(-u10, -v10)) + 360) % 360, 1
             )
 
-    # --- humidity ---
     if "rh2m" in ds_point_at_time.data_vars:
         rh = float(ds_point_at_time["rh2m"].values)
         if not np.isnan(rh):
             ctx["relative_humidity_pct"] = round(rh, 1)
             ctx["rh_fire_risk"] = classify_rh_fire_risk(rh)
 
-    # --- temperature ---
     if "t2m" in ds_point_at_time.data_vars:
         t2m = float(ds_point_at_time["t2m"].values)
         if not np.isnan(t2m):
-            # GFS stores temperature in Kelvin
             ctx["temperature_c"] = round(t2m - 273.15, 1)
 
-    # --- precipitation ---
     precip = _extract_precip_mm(
         ds_point_at_time, ds_spatial, target_time, target_time_64,
         precip_lookback_hours,
@@ -249,12 +338,8 @@ def get_weather_data_for_point(
 ) -> dict[str, float] | None:
     """Query weather data for a specific point and time.
 
-    Args:
-        lat: Latitude of the point
-        lon: Longitude of the point
-        ref_time: Reference time for weather data
-        time_tolerance_hours: Maximum time difference allowed for matching
-        precip_lookback_hours: Hours to look back for precipitation accumulation
+    Tries the DB point cache first (fast, no file I/O).  Falls back to
+    opening a NetCDF file if the cache has no data for this location.
 
     Returns:
         Dict with weather variables or None if data unavailable:
@@ -262,45 +347,56 @@ def get_weather_data_for_point(
         - precip_recent_mm: Recent precipitation accumulation (mm)
         - wind_speed_ms: Wind speed (m/s)
     """
+    # ── 1. DB point cache (primary) ──────────────────────────────────────
+    cached = _query_point_cache(
+        lat=lat, lon=lon, ref_time=ref_time,
+        time_tolerance_hours=time_tolerance_hours,
+    )
+    if cached is not None:
+        result: dict[str, float] = {}
+        if cached.get("rh2m") is not None:
+            result["rh2m"] = cached["rh2m"]
+        u10, v10 = cached.get("u10"), cached.get("v10")
+        if u10 is not None and v10 is not None:
+            result["wind_speed_ms"] = float(np.sqrt(u10**2 + v10**2))
+        tp = cached.get("tp")
+        if tp is not None:
+            result["precip_recent_mm"] = tp * 1000.0
+        return result if result else None
+
+    # ── 2. File-based fallback (JIT per-AOI files) ───────────────────────
     try:
-        snap = _open_weather_for_point(
+        snap = _open_weather_file_for_point(
             lat=lat, lon=lon, ref_time=ref_time,
             time_tolerance_hours=time_tolerance_hours,
         )
     except Exception as exc:
-        LOGGER.warning("Failed to open weather data: %s", exc)
+        LOGGER.warning("Failed to open weather file fallback: %s", exc)
         return None
 
     if snap is None:
         return None
 
     try:
-        result: dict[str, float] = {}
-
+        result = {}
         if "rh2m" in snap.ds_point.data_vars:
             rh_val = float(snap.ds_point["rh2m"].values)
             if not np.isnan(rh_val):
                 result["rh2m"] = rh_val
-
         if "u10" in snap.ds_point.data_vars and "v10" in snap.ds_point.data_vars:
             u10_val = float(snap.ds_point["u10"].values)
             v10_val = float(snap.ds_point["v10"].values)
             if not np.isnan(u10_val) and not np.isnan(v10_val):
                 result["wind_speed_ms"] = float(np.sqrt(u10_val**2 + v10_val**2))
-
         precip = _extract_precip_mm(
             snap.ds_point, snap.ds, ref_time, snap.ref_time_64,
             precip_lookback_hours,
         )
         if precip is not None:
             result["precip_recent_mm"] = precip
-
         return result if result else None
-
     except Exception as exc:
-        LOGGER.warning(
-            "Failed to load weather data from %s: %s", snap.storage_path, exc,
-        )
+        LOGGER.warning("Failed to load weather data from %s: %s", snap.storage_path, exc)
         return None
     finally:
         snap.ds.close()
@@ -309,14 +405,6 @@ def get_weather_data_for_point(
 # ---------------------------------------------------------------------------
 # Public API — fire detail panel (rich context dict)
 # ---------------------------------------------------------------------------
-
-_RESOLUTION_NOTE = "GFS 0.25\u00b0 \u2014 nearest grid point (~25 km)"
-
-# Variables that the GFS ingest pipeline bias-corrects (affine correction
-# fitted against ERA5 reanalysis).  Listed here so the API response can
-# transparently communicate which values have been post-processed.
-_BIAS_CORRECTED_VARS = ("u10", "v10", "t2m", "rh2m")
-
 
 def get_weather_context_for_point(
     *,
@@ -328,15 +416,23 @@ def get_weather_context_for_point(
 ) -> dict[str, Any] | None:
     """Return a weather-context block suitable for the fire detail response.
 
-    Unlike :func:`get_weather_data_for_point` (which returns a flat dict of
-    numeric values for scoring), this function returns the full context
-    including wind direction, temperature, source provenance, data-age, bias
-    correction metadata, and RH fire-risk classification.
-
-    Returns ``None`` when no qualifying weather run covers the point.
+    Tries the DB point cache first.  Falls back to NetCDF file if needed.
     """
+    # ── 1. DB point cache (primary) ──────────────────────────────────────
+    cached = _query_point_cache(
+        lat=lat, lon=lon, ref_time=ref_time,
+        time_tolerance_hours=time_tolerance_hours,
+    )
+    if cached is not None:
+        ctx = _build_fields_from_cache_row(cached)
+        if not ctx:
+            return None
+        _attach_provenance(ctx, cached["run_time"], ref_time)
+        return ctx
+
+    # ── 2. File-based fallback ───────────────────────────────────────────
     try:
-        snap = _open_weather_for_point(
+        snap = _open_weather_file_for_point(
             lat=lat, lon=lon, ref_time=ref_time,
             time_tolerance_hours=time_tolerance_hours,
         )
@@ -352,30 +448,12 @@ def get_weather_context_for_point(
             snap.ds_point, snap.ds_spatial, ref_time, snap.ref_time_64,
             precip_lookback_hours,
         )
-
         if not ctx:
             return None
-
-        # --- provenance ---
-        run_time_utc = _ensure_utc(snap.run_time)
-        ref_time_utc = _ensure_utc(ref_time)
-        ctx["source_run_time"] = run_time_utc.isoformat()
-        ctx["data_age_hours"] = round(
-            (ref_time_utc - run_time_utc).total_seconds() / 3600, 1
-        )
-        ctx["resolution_note"] = _RESOLUTION_NOTE
-        ctx["bias_correction"] = {
-            "applied": True,
-            "method": "affine (fitted against ERA5 reanalysis)",
-            "variables": list(_BIAS_CORRECTED_VARS),
-        }
-
+        _attach_provenance(ctx, snap.run_time, ref_time)
         return ctx
-
     except Exception as exc:
-        LOGGER.warning(
-            "Failed to load weather context from %s: %s", snap.storage_path, exc,
-        )
+        LOGGER.warning("Failed to load weather context from %s: %s", snap.storage_path, exc)
         return None
     finally:
         snap.ds.close()
@@ -392,17 +470,32 @@ def get_weather_forecast_for_point(
 ) -> list[dict[str, Any]] | None:
     """Return near-term forecast steps for the fire detail response.
 
-    Opens the same GFS run as :func:`get_weather_context_for_point` but
-    selects additional time steps at *ref_time* + each offset in
-    *forecast_offsets_hours*.  Each step carries the same fields as the
-    current-conditions block plus ``forecast_hour`` and ``valid_time``.
-
-    Returns ``None`` when no qualifying weather run covers the point.
-    Returns a partial list when only some offsets fall within the stored
-    forecast horizon (steps beyond the dataset are silently skipped).
+    Tries the DB point cache for each offset.  Falls back to NetCDF file.
     """
+    ref_time_utc = _ensure_utc(ref_time)
+
+    # ── 1. DB point cache (primary) ──────────────────────────────────────
+    steps: list[dict[str, Any]] = []
+    for offset_h in forecast_offsets_hours:
+        cached = _query_point_cache(
+            lat=lat, lon=lon, ref_time=ref_time,
+            time_tolerance_hours=time_tolerance_hours,
+            forecast_hour=offset_h,
+        )
+        if cached is not None:
+            fields = _build_fields_from_cache_row(cached)
+            if fields:
+                target_time = ref_time_utc + timedelta(hours=offset_h)
+                fields["forecast_hour"] = offset_h
+                fields["valid_time"] = target_time.isoformat()
+                steps.append(fields)
+
+    if steps:
+        return steps
+
+    # ── 2. File-based fallback ───────────────────────────────────────────
     try:
-        snap = _open_weather_for_point(
+        snap = _open_weather_file_for_point(
             lat=lat, lon=lon, ref_time=ref_time,
             time_tolerance_hours=time_tolerance_hours,
         )
@@ -413,19 +506,14 @@ def get_weather_forecast_for_point(
     if snap is None:
         return None
 
-    ref_time_utc = _ensure_utc(ref_time)
-
-    steps: list[dict[str, Any]] = []
     try:
         for offset_h in forecast_offsets_hours:
             target_time = ref_time_utc + timedelta(hours=offset_h)
             target_time_64 = _to_numpy_datetime64(target_time)
 
-            # Select the nearest time step available; skip if no time dimension
             if "time" in snap.ds_spatial.coords:
                 ds_at_time = snap.ds_spatial.sel(time=target_time_64, method="nearest")
             else:
-                # Dataset has no time dimension — single-step file; only valid for +0
                 break
 
             fields = _extract_weather_fields(
@@ -440,9 +528,7 @@ def get_weather_forecast_for_point(
             steps.append(fields)
 
     except Exception as exc:
-        LOGGER.warning(
-            "Failed to extract forecast steps from %s: %s", snap.storage_path, exc,
-        )
+        LOGGER.warning("Failed to extract forecast steps from %s: %s", snap.storage_path, exc)
     finally:
         snap.ds.close()
 

--- a/api/core/weather.py
+++ b/api/core/weather.py
@@ -19,7 +19,7 @@ import xarray as xr
 from sqlalchemy import text
 
 from api.db import get_engine
-from ingest.weather_repository import GFS_GRID_DEG, snap_to_gfs_grid
+from ingest.weather_repository import snap_to_gfs_grid
 
 LOGGER = logging.getLogger(__name__)
 

--- a/api/forecast/worker.py
+++ b/api/forecast/worker.py
@@ -290,7 +290,6 @@ def run_jit_forecast_pipeline(job_id: UUID, bbox: tuple[float, float, float, flo
             return
 
         from ingest.dem_preprocess import ingest_terrain_for_bbox
-        from ingest.weather_ingest import ingest_weather_for_bbox
 
         # Check for cached terrain with distributed lock to prevent race conditions
         terrain_lock_key = f"jit:terrain:lock:{bbox[0]}:{bbox[1]}:{bbox[2]}:{bbox[3]}"
@@ -332,50 +331,11 @@ def run_jit_forecast_pipeline(job_id: UUID, bbox: tuple[float, float, float, flo
                         logger.info(f"JIT job {job_id}: terrain ingestion completed, terrain_id={terrain_id}")
                 finally:
                     terrain_lock.release()
-        max_horizon = max(horizons_hours)
-
-        # Check for cached weather (within 6 hour freshness window) with distributed lock
-        weather_lock_key = f"jit:weather:lock:{bbox[0]}:{bbox[1]}:{bbox[2]}:{bbox[3]}:{forecast_time.isoformat()}"
-        cached_weather = repo.find_cached_weather(bbox, freshness_hours=6, required_horizon_hours=max_horizon)
-        
-        if cached_weather:
-            weather_run_id = cached_weather["id"]
-            logger.info(f"JIT job {job_id}: cache hit for weather, weather_run_id={weather_run_id}")
-        else:
-            # Acquire lock to prevent duplicate weather ingestion
-            weather_lock = _acquire_cache_lock(weather_lock_key)
-            if weather_lock is None:
-                logger.warning(f"JIT job {job_id}: could not acquire weather lock, checking cache again")
-                # Another worker may have ingested weather, check cache again
-                cached_weather = repo.find_cached_weather(bbox, freshness_hours=6, required_horizon_hours=max_horizon)
-                if cached_weather:
-                    weather_run_id = cached_weather["id"]
-                    logger.info(f"JIT job {job_id}: cache hit for weather after lock retry, weather_run_id={weather_run_id}")
-                else:
-                    raise RuntimeError("Could not acquire weather lock and no cached weather found")
-            else:
-                try:
-                    # Double-check cache after acquiring lock
-                    cached_weather = repo.find_cached_weather(bbox, freshness_hours=6, required_horizon_hours=max_horizon)
-                    if cached_weather:
-                        weather_run_id = cached_weather["id"]
-                        logger.info(f"JIT job {job_id}: cache hit for weather after lock, weather_run_id={weather_run_id}")
-                    else:
-                        repo.update_jit_job_status(job_id, "ingesting_weather")
-                        logger.info(f"JIT job {job_id}: starting weather ingestion")
-
-                        weather_output_dir = REPO_ROOT / "data" / "weather"
-                        weather_output_dir.mkdir(parents=True, exist_ok=True)
-
-                        weather_run_id = ingest_weather_for_bbox(
-                            bbox=bbox,
-                            forecast_time=forecast_time,
-                            output_dir=weather_output_dir,
-                            horizon_hours=max_horizon,
-                        )
-                        logger.info(f"JIT job {job_id}: weather ingestion completed, weather_run_id={weather_run_id}")
-                finally:
-                    weather_lock.release()
+        # Weather data is sourced from the background weather_point_cache
+        # (populated by the orchestrator's weather job).  The spread model's
+        # _load_weather_cube queries the cache directly — no JIT download needed.
+        # If the cache has no data for this region the spread model falls back
+        # to calm-conditions weather automatically.
 
         repo.update_jit_job_status(job_id, "running_forecast")
         logger.info(f"JIT job {job_id}: starting forecast")
@@ -509,7 +469,7 @@ def run_jit_forecast_pipeline(job_id: UUID, bbox: tuple[float, float, float, flo
 
             result = {
                 "terrain_id": terrain_id,
-                "weather_run_id": weather_run_id,
+                "weather_run_id": None,  # weather sourced from point cache, no single run_id
                 "forecast_run_id": run_id,
                 "run_id": run_id,
                 "tilejson_urls": tilejson_urls,

--- a/api/migrations/versions/20260401_add_weather_point_cache.py
+++ b/api/migrations/versions/20260401_add_weather_point_cache.py
@@ -1,0 +1,71 @@
+"""Add weather_point_cache table for DB-backed weather point lookups.
+
+Stores GFS weather variable values at native 0.25° grid points near active fire
+detections.  Both the fire-detail / scoring point-lookup path and the spread
+model's weather-cube builder query this table directly, eliminating the need
+for global NetCDF files.
+
+The ``run_id`` FK cascades deletes from ``weather_runs`` so the periodic
+``db_cleanup`` retention sweep automatically prunes point-cache rows when
+their parent run expires.
+
+Revision ID: 20260401_add_weather_point_cache
+Revises: 20260331_add_ignition_signals
+Create Date: 2026-04-01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260401_add_weather_point_cache"
+down_revision = "20260331_add_ignition_signals"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "weather_point_cache",
+        sa.Column("id", sa.BigInteger, primary_key=True, autoincrement=True),
+        sa.Column(
+            "run_id",
+            sa.BigInteger,
+            sa.ForeignKey("weather_runs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("forecast_hour", sa.SmallInteger, nullable=False),
+        sa.Column("lat_grid", sa.Float, nullable=False),
+        sa.Column("lon_grid", sa.Float, nullable=False),
+        sa.Column("u10", sa.Float, nullable=True),
+        sa.Column("v10", sa.Float, nullable=True),
+        sa.Column("t2m", sa.Float, nullable=True),
+        sa.Column("rh2m", sa.Float, nullable=True),
+        sa.Column("tp", sa.Float, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+
+    # Primary lookup: point + forecast hour, ordered by recency.
+    op.create_index(
+        "ix_wpc_lookup",
+        "weather_point_cache",
+        ["lat_grid", "lon_grid", "forecast_hour", "created_at"],
+        postgresql_using="btree",
+    )
+
+    # FK index for cascade-delete performance.
+    op.create_index(
+        "ix_wpc_run_id",
+        "weather_point_cache",
+        ["run_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_wpc_run_id", table_name="weather_point_cache")
+    op.drop_index("ix_wpc_lookup", table_name="weather_point_cache")
+    op.drop_table("weather_point_cache")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,7 +181,7 @@ services:
     command: >
       uv run --project ingest -m ingest.orchestrator
       --loop
-      --jobs firms,perimeters,lfmc,lulc,cleanup
+      --jobs firms,weather,perimeters,lfmc,lulc,cleanup
       --enforce-freshness
       --max-retries 3
       --retry-backoff-seconds 20

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -21,7 +21,6 @@ from ingest.startup_check import StartupError, run_ingest_startup_checks
 from ingest.firms_ingest import run_firms_ingest
 from ingest.industrial_sources_ingest import run_industrial_ingest
 from ingest.nifc_perimeters_ingest import fetch_nifc_perimeters, ingest_perimeters
-from ingest.weather_ingest import run_weather_ingest
 
 logging.basicConfig(
     level=logging.INFO,

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -528,7 +528,14 @@ def _run_firms(args: argparse.Namespace) -> int:
 
 
 def _run_weather(args: argparse.Namespace) -> int:
-    return int(run_weather_ingest(_build_weather_argv(args)))
+    from ingest.weather_point_ingest import ingest_weather_points  # noqa: PLC0415
+
+    try:
+        ingest_weather_points()
+        return 0
+    except Exception:
+        LOGGER.exception("Weather point ingest failed")
+        return 1
 
 
 def _run_lfmc(args: argparse.Namespace) -> int:

--- a/ingest/weather_ingest.py
+++ b/ingest/weather_ingest.py
@@ -1086,10 +1086,13 @@ def ingest_weather_for_bbox(
                 selected_run_time,
                 include_precip=include_precipitation,
             )
-            # Crop to original bbox (not download_bbox with margin)
+            # Crop to original bbox (not download_bbox with margin).
+            # Stored at native GFS 0.25° resolution — no regrid here.
+            # Point lookups (fire detail, scoring) use sel(method="nearest") and
+            # work at any resolution.  Spread forecasting interpolates on-load
+            # in ml/spread_features.py::_load_weather_cube so it never needs a
+            # pre-regridded file.  Skipping regrid keeps files ~15–25 MB vs ~50 GB.
             dataset = crop_to_bbox(dataset, settings, target_bbox=bbox)
-            dataset = regrid_to_analysis_grid(dataset, grid_spec)
-            dataset = attach_grid_metadata(dataset, grid_spec)
             _validate_weather_dataset(dataset, settings, canonical_variables)
             storage_path = str(
                 save_dataset_to_netcdf(

--- a/ingest/weather_point_ingest.py
+++ b/ingest/weather_point_ingest.py
@@ -28,11 +28,9 @@ import numpy as np
 import xarray as xr
 
 from ingest.config import REPO_ROOT, WeatherIngestSettings, weather_settings
-from ingest.logging_utils import log_event
 from ingest.weather_ingest import (
     GFS_FILTER_LEVELS,
     GFS_FILTER_VARIABLES,
-    SHORT_NAME_MAP,
     build_weather_dataset,
     download_grib_files,
     snap_to_gfs_cycle,
@@ -43,7 +41,6 @@ from ingest.weather_repository import (
     create_weather_run_record,
     finalize_weather_run_record,
     query_fire_detection_grid_points,
-    snap_to_gfs_grid,
 )
 
 # Ensure the API modules are importable when running from ingest/.

--- a/ingest/weather_point_ingest.py
+++ b/ingest/weather_point_ingest.py
@@ -1,0 +1,308 @@
+"""Background weather ingestion that stores GFS values in a DB point cache.
+
+Downloads GFS GRIB files to a temporary directory, extracts weather variables
+at GFS 0.25° grid points near recent fire detections, and bulk-inserts the
+values into ``weather_point_cache``.  No persistent files are written — the
+GRIB tempdir is cleaned up automatically.
+
+A ``weather_runs`` row is created (with ``file_format='point_cache'``) so that
+``api.data_status`` freshness reporting continues to work without changes.
+
+Usage (standalone)::
+
+    uv run --project ingest -m ingest.weather_point_ingest
+
+Or via the orchestrator ``weather`` job.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import xarray as xr
+
+from ingest.config import REPO_ROOT, WeatherIngestSettings, weather_settings
+from ingest.logging_utils import log_event
+from ingest.weather_ingest import (
+    GFS_FILTER_LEVELS,
+    GFS_FILTER_VARIABLES,
+    SHORT_NAME_MAP,
+    build_weather_dataset,
+    download_grib_files,
+    snap_to_gfs_cycle,
+)
+from ingest.weather_repository import (
+    GFS_GRID_DEG,
+    bulk_insert_weather_point_cache,
+    create_weather_run_record,
+    finalize_weather_run_record,
+    query_fire_detection_grid_points,
+    snap_to_gfs_grid,
+)
+
+# Ensure the API modules are importable when running from ingest/.
+sys.path.append(str(REPO_ROOT))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+LOGGER = logging.getLogger("weather_point_ingest")
+
+# Default forecast hours to cache (analysis + up to 24 h out at 6 h steps).
+DEFAULT_FORECAST_HOURS: tuple[int, ...] = (0, 6, 12, 18, 24)
+
+
+def _extract_records_at_grid_points(
+    ds: xr.Dataset,
+    grid_points: Sequence[tuple[float, float]],
+    variables: Sequence[str],
+    forecast_hours: Sequence[int],
+) -> list[dict]:
+    """Extract weather values at *grid_points* for each *forecast_hour*.
+
+    Uses ``sel(method="nearest")`` on the native GFS grid — at 0.25° the snap
+    error is at most ~14 km, which is the intrinsic resolution.
+
+    Returns a list of dicts ready for ``bulk_insert_weather_point_cache``.
+    """
+    records: list[dict] = []
+
+    for fh in forecast_hours:
+        # Find nearest time step in the dataset for this forecast hour.
+        if "lead_time_hours" in ds.coords:
+            target_idx = int(np.argmin(np.abs(ds["lead_time_hours"].values - fh)))
+            ds_t = ds.isel(time=target_idx)
+            actual_fh = int(ds["lead_time_hours"].values[target_idx])
+        elif "time" in ds.dims and ds.dims["time"] > 0:
+            ds_t = ds.isel(time=min(fh // 6, ds.dims["time"] - 1))
+            actual_fh = fh
+        else:
+            ds_t = ds
+            actual_fh = 0
+
+        for lat_g, lon_g in grid_points:
+            pt = ds_t.sel(lat=lat_g, lon=lon_g, method="nearest")
+            rec: dict = {
+                "forecast_hour": actual_fh,
+                "lat_grid": lat_g,
+                "lon_grid": lon_g,
+            }
+            for var in variables:
+                if var in pt.data_vars:
+                    val = float(pt[var].values)
+                    rec[var] = val if not np.isnan(val) else None
+                else:
+                    rec[var] = None
+            records.append(rec)
+
+    return records
+
+
+def ingest_weather_points(
+    *,
+    forecast_time: datetime | None = None,
+    detection_lookback_hours: float = 48.0,
+    horizon_hours: int = 24,
+    step_hours: int = 6,
+    model_name: str = "gfs_0p25",
+    include_precipitation: bool = False,
+    request_timeout_seconds: int = 60,
+    max_fallback_age_hours: int = 12,
+) -> int:
+    """Download GFS and cache weather values at fire-detection grid points.
+
+    Returns the ``weather_runs.id`` of the created record.
+
+    Raises on unrecoverable download failure (after one fallback cycle attempt).
+    """
+    now = datetime.now(timezone.utc)
+    run_time = snap_to_gfs_cycle(forecast_time or now)
+
+    # ── 1. Collect target grid points ────────────────────────────────────
+    grid_points = query_fire_detection_grid_points(
+        lookback_hours=detection_lookback_hours,
+    )
+    if not grid_points:
+        LOGGER.warning(
+            "No fire detections in the last %.0f hours — nothing to cache.",
+            detection_lookback_hours,
+        )
+        # Still create a weather_runs row so data_status shows the attempt.
+        run_id = create_weather_run_record(
+            model=model_name,
+            run_time=run_time,
+            horizon_hours=horizon_hours,
+            step_hours=step_hours,
+            bbox=(None, None, None, None),
+            variables=[],
+        )
+        finalize_weather_run_record(
+            run_id=run_id,
+            storage_path="",
+            status="completed",
+            extra_metadata={"point_cache_rows": 0, "grid_points": 0},
+        )
+        return run_id
+
+    LOGGER.info(
+        "Caching weather for %d unique GFS grid points (detection lookback=%.0fh)",
+        len(grid_points),
+        detection_lookback_hours,
+    )
+
+    # ── 2. Determine bbox that covers all grid points (with margin) ──────
+    lats = [p[0] for p in grid_points]
+    lons = [p[1] for p in grid_points]
+    margin = GFS_GRID_DEG * 2  # 2-cell margin for spread model interp
+    bbox = (
+        min(lons) - margin,
+        min(lats) - margin,
+        max(lons) + margin,
+        max(lats) + margin,
+    )
+
+    # ── 3. Prepare canonical variable lists ──────────────────────────────
+    canonical_variables = ["u10", "v10", "t2m", "rh2m"]
+    if include_precipitation:
+        canonical_variables.append("tp")
+
+    gfs_variables = [GFS_FILTER_VARIABLES[name] for name in canonical_variables]
+    level_params = sorted(
+        {lvl for name in canonical_variables if (lvl := GFS_FILTER_LEVELS.get(name))}
+    )
+
+    # ── 4. Create weather_runs tracking row ──────────────────────────────
+    run_id = create_weather_run_record(
+        model=model_name,
+        run_time=run_time,
+        horizon_hours=horizon_hours,
+        step_hours=step_hours,
+        bbox=bbox,
+        variables=canonical_variables,
+    )
+
+    # ── 5. Build download settings ───────────────────────────────────────
+    settings = WeatherIngestSettings(
+        WEATHER_MODEL=model_name,
+        WEATHER_BASE_DIR=str(Path(tempfile.gettempdir()) / "gfs_point_cache"),
+        WEATHER_BBOX_MIN_LON=bbox[0],
+        WEATHER_BBOX_MIN_LAT=bbox[1],
+        WEATHER_BBOX_MAX_LON=bbox[2],
+        WEATHER_BBOX_MAX_LAT=bbox[3],
+        WEATHER_HORIZON_HOURS=horizon_hours,
+        WEATHER_STEP_HOURS=step_hours,
+        WEATHER_INCLUDE_PRECIP=include_precipitation,
+        WEATHER_REQUEST_TIMEOUT_SECONDS=request_timeout_seconds,
+    )
+
+    base_urls = [weather_settings.gfs_base_url_primary]
+    if weather_settings.gfs_base_url_fallback:
+        base_urls.append(weather_settings.gfs_base_url_fallback)
+
+    forecast_hours = tuple(range(0, horizon_hours + 1, step_hours))
+
+    # ── 6. Download, extract, insert ─────────────────────────────────────
+    def _attempt(selected_run_time: datetime) -> int:
+        with tempfile.TemporaryDirectory(prefix="gfs_point_") as tmpdir:
+            grib_paths = download_grib_files(
+                settings,
+                selected_run_time,
+                gfs_variables,
+                level_params,
+                Path(tmpdir),
+                base_urls,
+            )
+            dataset = build_weather_dataset(
+                grib_paths,
+                selected_run_time,
+                include_precip=include_precipitation,
+            )
+
+            records = _extract_records_at_grid_points(
+                dataset, grid_points, canonical_variables, forecast_hours,
+            )
+            inserted = bulk_insert_weather_point_cache(run_id, records)
+
+            finalize_weather_run_record(
+                run_id=run_id,
+                storage_path="",
+                status="completed",
+                run_time=selected_run_time,
+                extra_metadata={
+                    "file_format": "point_cache",
+                    "point_cache_rows": inserted,
+                    "grid_points": len(grid_points),
+                    "variables": canonical_variables,
+                    "forecast_hours": list(forecast_hours),
+                },
+            )
+            return inserted
+
+    try:
+        inserted = _attempt(run_time)
+        LOGGER.info(
+            "Weather point ingest completed: run_id=%d, rows=%d, grid_points=%d",
+            run_id,
+            inserted,
+            len(grid_points),
+        )
+        return run_id
+
+    except Exception as primary_exc:
+        # Fallback to previous GFS cycle.
+        prev_run_time = run_time - timedelta(hours=6)
+        fallback_age = (now - prev_run_time).total_seconds() / 3600
+
+        if fallback_age > max_fallback_age_hours:
+            LOGGER.error(
+                "Primary cycle %s failed and fallback %s is %.1fh old (max %dh). Giving up.",
+                run_time, prev_run_time, fallback_age, max_fallback_age_hours,
+            )
+            finalize_weather_run_record(
+                run_id=run_id, storage_path="", status="failed",
+                extra_metadata={"error": str(primary_exc), "fallback_skipped": True},
+            )
+            raise
+
+        LOGGER.warning(
+            "Primary cycle %s failed; falling back to %s",
+            run_time, prev_run_time,
+        )
+        try:
+            inserted = _attempt(prev_run_time)
+            LOGGER.info(
+                "Weather point ingest completed via fallback: run_id=%d, rows=%d",
+                run_id, inserted,
+            )
+            return run_id
+        except Exception as fallback_exc:
+            LOGGER.exception("Weather point ingest failed after fallback")
+            finalize_weather_run_record(
+                run_id=run_id, storage_path="", status="failed",
+                extra_metadata={
+                    "error": str(fallback_exc),
+                    "primary_error": str(primary_exc),
+                },
+            )
+            raise
+
+
+def main() -> None:
+    """CLI entry point."""
+    try:
+        run_id = ingest_weather_points()
+        LOGGER.info("Done. weather_runs.id = %d", run_id)
+    except Exception:
+        LOGGER.exception("Weather point ingest failed")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ingest/weather_repository.py
+++ b/ingest/weather_repository.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Mapping, Sequence
 
 from sqlalchemy import JSON, bindparam, text
 
 from ingest.repository import get_engine
+
+LOGGER = logging.getLogger(__name__)
 
 
 def create_weather_run_record(
@@ -110,4 +113,98 @@ def finalize_weather_run_record(
                 "extra_metadata": extra_metadata,
             },
         )
+
+
+# ---------------------------------------------------------------------------
+# Point-cache helpers
+# ---------------------------------------------------------------------------
+
+#: GFS native resolution in degrees.
+GFS_GRID_DEG = 0.25
+
+
+def snap_to_gfs_grid(lat: float, lon: float) -> tuple[float, float]:
+    """Snap a lat/lon pair to the nearest GFS 0.25° grid point."""
+    return (
+        round(round(lat / GFS_GRID_DEG) * GFS_GRID_DEG, 4),
+        round(round(lon / GFS_GRID_DEG) * GFS_GRID_DEG, 4),
+    )
+
+
+def query_fire_detection_grid_points(
+    lookback_hours: float = 48.0,
+) -> list[tuple[float, float]]:
+    """Return deduplicated GFS-snapped grid points near recent fire detections.
+
+    Queries ``fire_detections`` for the last *lookback_hours*, snaps each
+    detection to the nearest GFS 0.25° grid point, and returns unique pairs.
+    """
+    stmt = text(
+        """
+        SELECT DISTINCT
+            round((lat  / :grid)::numeric) * :grid AS lat_grid,
+            round((lon  / :grid)::numeric) * :grid AS lon_grid
+        FROM fire_detections
+        WHERE acq_time >= NOW() - INTERVAL '1 hour' * :lookback
+        """
+    )
+    with get_engine().connect() as conn:
+        rows = conn.execute(
+            stmt, {"grid": GFS_GRID_DEG, "lookback": lookback_hours}
+        ).fetchall()
+
+    return [(float(r[0]), float(r[1])) for r in rows]
+
+
+def bulk_insert_weather_point_cache(
+    run_id: int,
+    records: Sequence[dict[str, Any]],
+    *,
+    batch_size: int = 5000,
+) -> int:
+    """Bulk-insert rows into ``weather_point_cache``.
+
+    Each record must contain keys: ``forecast_hour``, ``lat_grid``,
+    ``lon_grid``, and optionally ``u10``, ``v10``, ``t2m``, ``rh2m``, ``tp``.
+
+    Returns the total number of rows inserted.
+    """
+    if not records:
+        return 0
+
+    stmt = text(
+        """
+        INSERT INTO weather_point_cache
+            (run_id, forecast_hour, lat_grid, lon_grid, u10, v10, t2m, rh2m, tp)
+        VALUES
+            (:run_id, :forecast_hour, :lat_grid, :lon_grid,
+             :u10, :v10, :t2m, :rh2m, :tp)
+        """
+    )
+
+    total = 0
+    with get_engine().begin() as conn:
+        for i in range(0, len(records), batch_size):
+            batch = records[i : i + batch_size]
+            params = [
+                {
+                    "run_id": run_id,
+                    "forecast_hour": r["forecast_hour"],
+                    "lat_grid": r["lat_grid"],
+                    "lon_grid": r["lon_grid"],
+                    "u10": r.get("u10"),
+                    "v10": r.get("v10"),
+                    "t2m": r.get("t2m"),
+                    "rh2m": r.get("rh2m"),
+                    "tp": r.get("tp"),
+                }
+                for r in batch
+            ]
+            conn.execute(stmt, params)
+            total += len(batch)
+
+    LOGGER.info(
+        "Inserted %d weather_point_cache rows for run_id=%d", total, run_id
+    )
+    return total
 

--- a/ml/spread_features.py
+++ b/ml/spread_features.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Sequence
 
 import numpy as np
+import pandas as pd
 import sqlalchemy as sa
 import xarray as xr
 
@@ -205,6 +206,156 @@ def _get_latest_weather_run(
     return dict(row) if row else None
 
 
+from ingest.weather_repository import GFS_GRID_DEG as _GFS_GRID_DEG
+
+
+def _load_weather_cube_from_cache(
+    ref_time: datetime,
+    window: GridWindow,
+    horizons_hours: Sequence[int],
+    bbox: tuple[float, float, float, float],
+    *,
+    weather_bias_corrector_path: Path | None = None,
+) -> xr.Dataset | None:
+    """Build a weather cube from the ``weather_point_cache`` DB table.
+
+    Queries GFS 0.25° grid points covering *bbox* (with a 1-cell margin for
+    bilinear interpolation), builds a tiny xarray Dataset, then interpolates
+    to the *window*'s 0.01° grid.  Returns ``None`` when no cached data
+    covers the requested region and time.
+    """
+    min_lon, min_lat, max_lon, max_lat = bbox
+    margin = _GFS_GRID_DEG * 2  # 2-cell margin for clean interp at edges
+
+    lat_lo = round(np.floor((min_lat - margin) / _GFS_GRID_DEG) * _GFS_GRID_DEG, 4)
+    lat_hi = round(np.ceil((max_lat + margin) / _GFS_GRID_DEG) * _GFS_GRID_DEG, 4)
+    lon_lo = round(np.floor((min_lon - margin) / _GFS_GRID_DEG) * _GFS_GRID_DEG, 4)
+    lon_hi = round(np.ceil((max_lon + margin) / _GFS_GRID_DEG) * _GFS_GRID_DEG, 4)
+
+    forecast_hours_list = sorted(set(horizons_hours))
+
+    # Use a subquery to find the latest run covering the bbox, then fetch
+    # only that run's rows.  This avoids fetching rows from older runs that
+    # would be discarded in Python.
+    stmt = sa.text("""
+        WITH latest_run AS (
+            SELECT wr.id AS run_id, wr.run_time
+            FROM weather_runs wr
+            WHERE wr.status = 'completed'
+              AND wr.run_time <= :ref_time
+            ORDER BY wr.run_time DESC
+            LIMIT 1
+        )
+        SELECT wpc.forecast_hour, wpc.lat_grid, wpc.lon_grid,
+               wpc.u10, wpc.v10, wpc.t2m, wpc.rh2m, wpc.tp,
+               lr.run_time
+        FROM weather_point_cache wpc
+        JOIN latest_run lr ON lr.run_id = wpc.run_id
+        WHERE wpc.lat_grid BETWEEN :lat_lo AND :lat_hi
+          AND wpc.lon_grid BETWEEN :lon_lo AND :lon_hi
+          AND wpc.forecast_hour = ANY(:fhs)
+    """)
+
+    with get_engine().connect() as conn:
+        rows = conn.execute(
+            stmt,
+            {
+                "ref_time": ref_time,
+                "lat_lo": lat_lo,
+                "lat_hi": lat_hi,
+                "lon_lo": lon_lo,
+                "lon_hi": lon_hi,
+                "fhs": forecast_hours_list,
+            },
+        ).mappings().all()
+
+    if not rows:
+        LOGGER.debug("No weather_point_cache rows for bbox=%s ref_time=%s", bbox, ref_time)
+        return None
+
+    best_run_time = rows[0]["run_time"]
+
+    df = pd.DataFrame(rows)
+    lats_unique = np.sort(df["lat_grid"].unique())
+    lons_unique = np.sort(df["lon_grid"].unique())
+
+    if len(lats_unique) < 2 or len(lons_unique) < 2:
+        LOGGER.debug("Not enough GFS grid points for interpolation (%d lat, %d lon)", len(lats_unique), len(lons_unique))
+        return None
+
+    variables = ["u10", "v10", "t2m", "rh2m"]
+    if "tp" in df.columns and df["tp"].notna().any():
+        variables.append("tp")
+
+    # Build per-forecast-hour datasets and concat along time.
+    datasets = []
+    ref_time_utc = ref_time.astimezone(timezone.utc) if ref_time.tzinfo else ref_time.replace(tzinfo=timezone.utc)
+
+    for fh in forecast_hours_list:
+        df_fh = df[df["forecast_hour"] == fh]
+        if df_fh.empty:
+            continue
+
+        target_time = ref_time_utc + timedelta(hours=int(fh))
+        target_time_64 = np.datetime64(target_time.replace(tzinfo=None), "ns")
+
+        # Vectorized grid fill: compute row/col indices once, then assign
+        # per-variable in a single numpy operation (avoids slow iterrows).
+        i_idx = np.searchsorted(lats_unique, df_fh["lat_grid"].values)
+        j_idx = np.searchsorted(lons_unique, df_fh["lon_grid"].values)
+        valid_mask = (i_idx < len(lats_unique)) & (j_idx < len(lons_unique))
+
+        data_vars = {}
+        for var in variables:
+            grid = np.full((len(lats_unique), len(lons_unique)), np.nan, dtype=np.float32)
+            vals = df_fh[var].values
+            var_valid = valid_mask & pd.notna(vals)
+            grid[i_idx[var_valid], j_idx[var_valid]] = vals[var_valid].astype(np.float32)
+            data_vars[var] = (("lat", "lon"), grid)
+
+        ds_fh = xr.Dataset(
+            data_vars=data_vars,
+            coords={"lat": lats_unique, "lon": lons_unique, "time": target_time_64},
+        )
+        datasets.append(ds_fh)
+
+    if not datasets:
+        return None
+
+    ds = xr.concat(datasets, dim="time")
+    ds = ds.assign_coords(lead_time_hours=("time", list(forecast_hours_list[:len(datasets)])))
+
+    # Interpolate from GFS 0.25° to the window's 0.01° grid.
+    try:
+        ds_interp = ds.interp(lat=window.lat, lon=window.lon)
+    except Exception:
+        LOGGER.warning("Interpolation from cache grid to window failed; returning None.")
+        return None
+
+    # Rename tp → precip_24h to match spread contract.
+    if "tp" in ds_interp.data_vars and "precip_24h" not in ds_interp.data_vars:
+        ds_interp = ds_interp.rename({"tp": "precip_24h"})
+
+    ds_interp = ds_interp.load()
+
+    # Apply bias correction and derive moisture fields.
+    ds_interp = _maybe_apply_weather_bias_correction(
+        ds_interp, weather_bias_corrector_path=weather_bias_corrector_path
+    )
+    ds_interp = _add_dfmc_to_weather(ds_interp)
+    ds_interp, _ = _add_lfmc_to_weather(ds_interp, window, ref_time, bbox)
+
+    ds_interp.attrs["weather_fallback_used"] = False
+    ds_interp.attrs["weather_source"] = "point_cache"
+    run_time = best_run_time
+    try:
+        ds_interp.attrs["weather_run_time"] = run_time.isoformat()
+    except Exception:
+        ds_interp.attrs["weather_run_time"] = str(run_time)
+
+    return ds_interp
+
+
 def _load_weather_cube(
     ref_time: datetime,
     window: GridWindow,
@@ -213,12 +364,29 @@ def _load_weather_cube(
     *,
     weather_bias_corrector_path: Path | None = None,
 ) -> xr.Dataset:
-    """Load and align weather data for the requested window and horizons."""
+    """Load and align weather data for the requested window and horizons.
+
+    Tries the DB point cache first (fast, no file I/O).  Falls back to opening
+    a NetCDF file from weather_runs, then to calm-conditions fallback.
+    """
+    # ── 1. Try DB point cache (primary path) ─────────────────────────────
+    try:
+        cached_cube = _load_weather_cube_from_cache(
+            ref_time, window, horizons_hours, bbox,
+            weather_bias_corrector_path=weather_bias_corrector_path,
+        )
+        if cached_cube is not None:
+            LOGGER.info("Weather cube built from point cache for bbox=%s", bbox)
+            return cached_cube
+    except Exception:
+        LOGGER.debug("Point-cache weather cube failed; trying file path.", exc_info=True)
+
+    # ── 2. Try file-based weather run ────────────────────────────────────
     run = _get_latest_weather_run(ref_time, bbox)
 
     if not run:
         LOGGER.warning(
-            "No completed weather run found for ref_time=%s and bbox=%s; using calm fallback.",
+            "No weather data (cache or file) for ref_time=%s and bbox=%s; using calm fallback.",
             ref_time, bbox
         )
         ds = _create_fallback_weather(window, ref_time, horizons_hours)
@@ -286,13 +454,18 @@ def _load_weather_cube(
 
         # 1) Align to AOI window coords.
         #
-        # Weather ingest writes NetCDFs already interpolated onto the shared analysis grid.
-        # Prefer exact label-based selection; fall back to nearest for robustness.
+        # Weather files are stored at native GFS 0.25° resolution (no pre-regrid).
+        # Try exact label-based selection first (works if a file already happens to
+        # be at 0.01°); fall back to bilinear interpolation so the output coords are
+        # exactly window.lat/lon and pass the strict np.allclose check downstream.
+        # interp is also scientifically preferable to nearest for sub-25 km queries.
         try:
             ds_aligned = ds.sel(lat=window.lat, lon=window.lon)
         except Exception:
-            LOGGER.info("Exact lat/lon selection failed for %s; falling back to nearest.", path)
-            ds_aligned = ds.sel(lat=window.lat, lon=window.lon, method="nearest")
+            LOGGER.info(
+                "Exact lat/lon selection failed for %s; interpolating to window grid.", path
+            )
+            ds_aligned = ds.interp(lat=window.lat, lon=window.lon)
 
         # 2) Select requested time horizons (absolute times).
         target_times = [ref_time + timedelta(hours=int(h)) for h in horizons_hours]

--- a/ml/spread_features.py
+++ b/ml/spread_features.py
@@ -24,6 +24,7 @@ from ml.weather_bias_correction import (
     resolve_weather_bias_corrector_path,
     WeatherBiasCorrector,
  )
+from ingest.weather_repository import GFS_GRID_DEG as _GFS_GRID_DEG
 
 LOGGER = logging.getLogger(__name__)
 
@@ -204,9 +205,6 @@ def _get_latest_weather_run(
             },
         ).mappings().first()
     return dict(row) if row else None
-
-
-from ingest.weather_repository import GFS_GRID_DEG as _GFS_GRID_DEG
 
 
 def _load_weather_cube_from_cache(

--- a/scripts/db_cleanup.py
+++ b/scripts/db_cleanup.py
@@ -46,7 +46,11 @@ TABLE_CONFIG: list[tuple[str, str, int]] = [
     ("fire_fronts",            "created_at",              DEFAULT_RETENTION_DAYS),
     # ---- ML drift metrics --------------------------------------------------
     ("denoiser_drift_metrics", "created_at",              DEFAULT_RETENTION_DAYS),
-    # ---- weather / forecast (existing) -------------------------------------
+    # ---- weather / forecast -------------------------------------------------
+    # weather_point_cache rows CASCADE-delete when their parent weather_runs
+    # row is removed, but an explicit entry here provides secondary cleanup
+    # and ensures the table is VACUUMed after large deletions.
+    ("weather_point_cache",    "created_at",              DEFAULT_RETENTION_DAYS),
     ("weather_runs",           "run_time",                DEFAULT_RETENTION_DAYS),
     ("spread_forecast_runs",   "forecast_reference_time", DEFAULT_RETENTION_DAYS),
     # ---- operational tables with extended retention ------------------------
@@ -206,6 +210,73 @@ def purge_orphan_forecast_files(repo_root: Path, *, dry_run: bool) -> int:
     return len(orphans)
 
 
+def _query_known_weather_storage_paths() -> set[str]:
+    """Return the set of storage_path values currently in weather_runs."""
+    stmt = text("SELECT storage_path FROM weather_runs WHERE storage_path != ''")
+    with get_engine().connect() as conn:
+        rows = conn.execute(stmt).fetchall()
+    return {row[0] for row in rows}
+
+
+def purge_orphan_weather_files(repo_root: Path, *, dry_run: bool) -> int:
+    """Delete NetCDF files under data/weather/ with no corresponding weather_runs row.
+
+    After the time-based cleanup deletes old weather_runs rows, their NetCDF files
+    are left on disk.  This function scans data/weather/ and removes any .nc file
+    whose absolute path (or repo-relative equivalent) is not referenced by any
+    remaining row, preventing unbounded disk growth.
+
+    Also removes empty date/hour directories left behind after file deletion.
+
+    Returns:
+        Number of orphaned files found (and deleted when not dry_run).
+    """
+    weather_dir = repo_root / "data" / "weather"
+    if not weather_dir.exists():
+        logger.info("data/weather/ does not exist — nothing to clean.")
+        return 0
+
+    known_raw = _query_known_weather_storage_paths()
+
+    # Normalise known paths: resolve both absolute and repo-relative forms so that
+    # storage_path values written by different working directories are all matched.
+    known_abs: set[str] = set()
+    for raw in known_raw:
+        p = Path(raw)
+        if p.is_absolute():
+            known_abs.add(str(p))
+        else:
+            known_abs.add(str((repo_root / p).resolve()))
+
+    orphans: list[Path] = []
+    for nc in weather_dir.rglob("*.nc"):
+        if str(nc.resolve()) not in known_abs:
+            orphans.append(nc)
+
+    if not orphans:
+        logger.info("No orphaned weather NetCDF files found.")
+        return 0
+
+    action = "Would remove" if dry_run else "Removing"
+    for path in orphans:
+        logger.info("%s orphaned weather file: %s", action, path)
+        if not dry_run:
+            path.unlink(missing_ok=True)
+
+    if not dry_run:
+        # Remove empty leaf directories (year/month/day/hour structure).
+        for d in sorted(weather_dir.rglob("*"), reverse=True):
+            if d.is_dir():
+                try:
+                    d.rmdir()
+                    logger.info("Removed empty weather directory: %s", d)
+                except OSError:
+                    pass  # Not empty — leave it
+
+    logger.info("%s %d orphaned weather NetCDF file(s).", action, len(orphans))
+    return len(orphans)
+
+
 def _cleanup_fire_detections(
     session,
     now: datetime,
@@ -299,10 +370,12 @@ def cleanup(dry_run: bool = False) -> None:
             if deleted > 0:
                 vacuumed_tables.append(table)
 
-    # Clean up orphaned raster files on disk (CASCADE already handled DB child rows).
-    # Runs in both live and dry-run modes — purge_orphan_forecast_files respects dry_run.
+    # Clean up orphaned files on disk — runs in both live and dry-run modes.
     logger.info("%sPurging orphaned spread forecast raster files …", prefix)
     purge_orphan_forecast_files(REPO_ROOT, dry_run=dry_run)
+
+    logger.info("%sPurging orphaned weather NetCDF files …", prefix)
+    purge_orphan_weather_files(REPO_ROOT, dry_run=dry_run)
 
     if dry_run:
         logger.info(f"{prefix}Dry-run complete — no rows were mutated.")


### PR DESCRIPTION
## Overview
Fixes broken weather ingestion by replacing global NetCDF files with a database-backed point cache. The system now:

1. **Downloads GFS data to a point cache** (`ingest/weather_point_ingest.py`): Queries fire detections, snaps to GFS 0.25° grid points, and bulk-inserts weather variables into `weather_point_cache` table
2. **Queries the cache directly** (`api/core/weather.py`): Fire detail API and spread model both query the DB table first, falling back to NetCDF files only for JIT-produced per-AOI files
3. **Stores efficiently**: No persistent files for point-cache runs, only temporary GRIBs during processing

## Key Changes

### New Files
- `ingest/weather_point_ingest.py`: Background job that extracts weather at GFS grid points near recent fire detections
- `api/migrations/versions/20260401_add_weather_point_cache.py`: DB migration adding `weather_point_cache` table with indexes

### Modified Files
- **`api/core/weather.py`**: Added `_query_point_cache()` for DB lookups; restructured `get_weather_data_for_point()` and `get_weather_context_for_point()` to try cache first, fall back to file-based path
- **`ingest/weather_repository.py`**: Added `snap_to_gfs_grid()`, `query_fire_detection_grid_points()`, and `bulk_insert_weather_point_cache()` helpers
- **`ml/spread_features.py`**: Added `_load_weather_cube_from_cache()` to build weather cubes directly from cached rows with on-load interpolation to 0.01° grid
- **`api/forecast/worker.py`**: Removed JIT weather ingestion logic (weather now sourced from background cache)
- **`ingest/orchestrator.py`**: Switched `_run_weather()` to call `ingest_weather_points()` instead of legacy `run_weather_ingest()`
- **`ingest/weather_ingest.py`**: Removed regridding/metadata attachment for bbox-scoped files (now stored at native 0.25° resolution)
- **`docker-compose.yml`**: Added `weather` job to orchestrator command
- **`scripts/db_cleanup.py`**: Updated to handle point-cache cascade deletes

## Benefits
- **No global files**: Eliminates 50GB+ NetCDF files; point cache is DB-backed
- **Faster API**: Direct DB queries for fire detail (~25 km resolution native)
- **Spread model improvements**: On-load interpolation in Python is more flexible and handles missing data gracefully
- **Backward compatible**: NetCDF fallback still works for legacy per-AOI files
