### PR TITLE
fix: run synchronous DB call in thread pool to avoid blocking event loop (closes #226)

### DIFF
--- a/api/routes/forecast.py
+++ b/api/routes/forecast.py
@@ -7,6 +7,7 @@ import json
 import os
 from datetime import datetime, timezone
 import re
+from functools import partial
 from typing import Any, AsyncGenerator
 from urllib.parse import quote_plus
 from uuid import UUID
@@ -537,9 +538,10 @@ async def _job_status_event_stream(
             if elapsed > max_duration:
                 yield f"event: timeout\ndata: {json.dumps({'message': 'Stream timeout - check status endpoint'})}\n\n"
                 break
-            
-            # Get current job status
-            job = repo.get_jit_job(job_id)
+
+            # Get current job status (run in thread pool to avoid blocking event loop)
+            loop = asyncio.get_running_loop()
+            job = await loop.run_in_executor(None, partial(repo.get_jit_job, job_id))
             
             if not job:
                 yield f"event: error\ndata: {json.dumps({'message': 'Job not found'})}\n\n"


### PR DESCRIPTION
## Summary
Fixes issue #226 by wrapping the synchronous DB call in the async SSE generator with an executor.

## Root Cause
The `_job_status_event_stream` async generator was calling `repo.get_jit_job(job_id)` — a synchronous SQLAlchemy function — directly. This blocked the asyncio event loop for the full duration of the database query, preventing other async handlers from executing.

## Fix
The call is now executed in a thread pool using `asyncio.get_running_loop().run_in_executor()` so the event loop can continue processing other requests while waiting for the DB query.

## Changes
- Added `from functools import partial` import
- Wrapped `repo.get_jit_job(job_id)` call with `await loop.run_in_executor(None, partial(repo.get_jit_job, job_id))`

## Test Plan
- [x] Syntax check passes
- [x] Code review: minimal, targeted fix
- Manual verification: Multiple concurrent SSE streams should not starve other async endpoints