### PR TITLE
fix: reset WatchConfigDialog state when dialog opens (closes #243)

### DIFF
--- a/ui/src/components/WatchlistDashboard.tsx
+++ b/ui/src/components/WatchlistDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Alert,
   Box,
@@ -85,6 +85,13 @@ function WatchConfigDialog({ item, open, onClose }: WatchConfigDialogProps) {
   const [intervalMin, setIntervalMin] = useState<number>(item.watch_interval_minutes ?? 30);
   const [threshold, setThreshold] = useState<number>(item.watch_alert_threshold ?? 0.5);
   const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (open) {
+      setIntervalMin(item.watch_interval_minutes ?? 30);
+      setThreshold(item.watch_alert_threshold ?? 0.5);
+    }
+  }, [open, item.watch_interval_minutes, item.watch_alert_threshold]);
 
   const enable = useMutation({
     mutationFn: () =>


### PR DESCRIPTION
## Summary
Fixes #243

**Root cause:** `WatchConfigDialog` initialises `intervalMin` and `threshold` with `useState`, which only runs on the first mount. The component is always mounted inside `WatchlistRow` (MUI `open` prop, not conditional render), so changes to `item.watch_interval_minutes` / `item.watch_alert_threshold` from the 60-second auto-refresh were silently ignored — the dialog kept showing the values from the very first render. If a user opened the dialog and clicked "Enable Watch" without editing, the mutation would fire with the stale values, silently overwriting the current server config.

**Fix:** Added a `useEffect` that resets both state variables from the latest `item` prop whenever `open` transitions to `true`. This is the exact pattern suggested in the issue: minimal, non-disruptive, and correct.

## Test plan
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] ESLint passes with no errors (`npm run lint`)
- [x] All 96 UI tests pass (`npm run test:run`)
- [ ] Manual: open watch config dialog, wait for auto-refresh to update item, reopen dialog — fields should reflect updated values