### PR TITLE
Converge GFS and HRRR into unified point cache pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help doctor health-check install test lint lint-fix clean clean-venv migrate revision widget-build ralph-init ralph-plan ralph-run ralph-status denoiser-label denoiser-snapshot denoiser-train denoiser-eval denoiser-eventize denoiser-label-v2 denoiser-snapshot-v2 denoiser-train-v2 denoiser-eval-v2 train-denoiser train-spread model-register model-promote model-rollback model-update-contract hindcast-build spread-champion-challenger weather-bias seed-ne-places
+.PHONY: help doctor health-check install test lint lint-fix clean clean-venv migrate revision widget-build ralph-init ralph-plan ralph-run ralph-status denoiser-label denoiser-snapshot denoiser-train denoiser-eval denoiser-eventize denoiser-label-v2 denoiser-snapshot-v2 denoiser-train-v2 denoiser-eval-v2 train-denoiser train-spread model-register model-promote model-rollback model-update-contract hindcast-build spread-champion-challenger weather-bias seed-ne-places ingest-orchestrator ops-start
 
 PYTHON ?= python3
 UV ?= uv
@@ -320,3 +320,27 @@ json.dump(out, open(out_path, "w", encoding="utf-8"), indent=2)' "$$metrics_file
 	model_id=$$($(UV) run --project api scripts/model_registry.py register --id-only --family $(TRAIN_SPREAD_FAMILY) --artifact "$$latest_run" --metrics "@$$registry_metrics"); \
 	echo "Promoting $$model_id"; \
 	$(UV) run --project api scripts/model_registry.py promote --family $(TRAIN_SPREAD_FAMILY) --model-id "$$model_id" --notes "auto-promote from make train-spread pipeline=$(TRAIN_SPREAD_PIPELINE)"
+
+# ── Ingest Operations ──────────────────────────────────────────────────────────
+
+ingest-orchestrator: ## One-shot ingest (FIRMS + weather + perimeters)
+	$(UV) run --project ingest -m ingest.orchestrator \
+	  --jobs firms,weather,perimeters \
+	  --weather-include-precip \
+	  $(if $(ARGS),$(ARGS),)
+
+ops-start: ## Start continuous ingest scheduler
+	$(UV) run --project ingest -m ingest.orchestrator \
+	  --loop \
+	  --jobs firms,weather,perimeters,lfmc,lulc,cleanup \
+	  --enforce-freshness \
+	  --max-retries 3 \
+	  --retry-backoff-seconds 20 \
+	  --firms-interval-minutes 30 \
+	  --weather-interval-minutes 60 \
+	  --weather-include-precip \
+	  --perimeters-interval-minutes 1440 \
+	  --lfmc-interval-minutes 360 \
+	  --lulc-interval-minutes 10080 \
+	  --cleanup-interval-minutes 1440 \
+	  $(if $(ARGS),$(ARGS),)

--- a/api/core/weather.py
+++ b/api/core/weather.py
@@ -128,9 +128,9 @@ def _query_point_cache(
             "run_time": row["run_time"],
         }
     except Exception:
-        # Point cache table may not exist yet (pre-migration) or query may
-        # fail for other reasons.  Fall through to file-based path.
-        LOGGER.debug("Point cache query failed; falling through to file path.", exc_info=True)
+        # Migration ships with the code, so pre-migration failures are now
+        # unlikely.  Any exception here is unexpected and should be surfaced.
+        LOGGER.warning("Point cache query failed; falling through to file path.", exc_info=True)
         return None
 
 

--- a/api/migrations/versions/20260402_add_weather_runs_unique_model_run_time.py
+++ b/api/migrations/versions/20260402_add_weather_runs_unique_model_run_time.py
@@ -1,0 +1,30 @@
+"""Add UNIQUE constraint on weather_runs(model, run_time) to prevent duplicates.
+
+Hourly HRRR ingest re-runs or retries would otherwise insert duplicate
+(model, run_time) rows because create_weather_run_record used a plain INSERT
+with no conflict handling.  The constraint + ON CONFLICT DO NOTHING guard in
+the repository layer make the operation idempotent.
+
+Revision ID: 20260402_add_weather_runs_unique_model_run_time
+Revises: 20260401_add_weather_point_cache
+Create Date: 2026-04-02
+"""
+
+from alembic import op
+
+revision = "20260402_add_weather_runs_unique_model_run_time"
+down_revision = "20260401_add_weather_point_cache"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        "uq_weather_runs_model_run_time",
+        "weather_runs",
+        ["model", "run_time"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_weather_runs_model_run_time", "weather_runs")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,7 +186,8 @@ services:
       --max-retries 3
       --retry-backoff-seconds 20
       --firms-interval-minutes 30
-      --weather-interval-minutes 180
+      --weather-interval-minutes 60
+      --weather-include-precip
       --perimeters-interval-minutes 1440
       --lfmc-interval-minutes 360
       --lulc-interval-minutes 10080

--- a/ingest/hrrr_ingest.py
+++ b/ingest/hrrr_ingest.py
@@ -26,6 +26,7 @@ import xarray as xr
 from ingest.config import REPO_ROOT
 from ingest.logging_utils import log_event
 from ingest.weather_repository import (
+    FILE_FORMAT_NETCDF,
     create_weather_run_record,
     finalize_weather_run_record,
 )
@@ -285,7 +286,7 @@ def build_hrrr_dataset(
     run_time: datetime,
     forecast_hour: int,
     *,
-    include_precip: bool = False,
+    include_precip: bool = True,
 ) -> xr.Dataset:
     """Assemble individual HRRR GRIB fragments into a single time-indexed Dataset."""
     arrays: dict[str, xr.DataArray] = {}
@@ -353,7 +354,7 @@ def ingest_hrrr_for_bbox(
     *,
     horizon_hours: int = 18,
     step_hours: int = 1,
-    include_precipitation: bool = False,
+    include_precipitation: bool = True,
     request_timeout_seconds: int = 60,
     max_attempts: int = 3,
 ) -> int:
@@ -431,6 +432,7 @@ def ingest_hrrr_for_bbox(
         step_hours=step_hours,
         bbox=bbox,
         variables=canonical_vars,
+        file_format=FILE_FORMAT_NETCDF,
     )
 
     storage_path = ""

--- a/ingest/hrrr_point_ingest.py
+++ b/ingest/hrrr_point_ingest.py
@@ -1,0 +1,297 @@
+"""HRRR point cache ingest — stores HRRR 3km weather values at
+GFS-snapped 0.25° grid points near recent fire detections.
+
+Like weather_point_ingest (GFS path) but uses HRRR for CONUS fires:
+hourly cycles, 3km source resolution, CONUS-only coverage.
+
+Data is stored at GFS 0.25° grid coordinates (snapped via snap_to_gfs_grid)
+so that _query_point_cache in api/core/weather.py works for both models
+with the same lookup key.
+
+Usage (standalone)::
+
+    uv run --project ingest -m ingest.hrrr_point_ingest
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import httpx
+import xarray as xr
+
+from ingest.config import REPO_ROOT
+from ingest.hrrr_ingest import (
+    ANALYSIS_CELL_SIZE_DEG,
+    HRRR_MODEL_NAME,
+    HRRR_PRECIP_IDX_KEY,
+    HRRR_VARIABLE_IDX_KEYS,
+    HRRR_VARIABLE_IDX_PRECIP,
+    build_hrrr_dataset,
+    build_hrrr_urls,
+    crop_hrrr_to_bbox,
+    download_hrrr_variable_gribs,
+    is_conus_bbox,
+    regrid_hrrr_to_analysis_grid,
+    snap_to_hrrr_cycle,
+)
+from ingest.weather_point_ingest import _extract_records_at_grid_points
+from ingest.weather_repository import (
+    FILE_FORMAT_POINT_CACHE,
+    GFS_GRID_DEG,
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    bbox_from_grid_points,
+    bulk_insert_weather_point_cache,
+    create_weather_run_record,
+    finalize_weather_run_record,
+    query_fire_detection_grid_points,
+)
+
+# Ensure the API modules are importable when running from ingest/.
+sys.path.append(str(REPO_ROOT))
+
+from api.core.grid import GridSpec  # noqa: E402 — after sys.path append
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+LOGGER = logging.getLogger("hrrr_point_ingest")
+
+# Default forecast hours to cache (analysis + sub-daily up to 18 h).
+DEFAULT_HRRR_FORECAST_HOURS: tuple[int, ...] = (0, 1, 2, 3, 6, 9, 12, 18)
+
+
+def ingest_hrrr_points(
+    *,
+    forecast_time: datetime | None = None,
+    detection_lookback_hours: float = 48.0,
+    horizon_hours: int = 18,
+    step_hours: int = 1,
+    model_name: str = HRRR_MODEL_NAME,
+    include_precipitation: bool = True,
+    request_timeout_seconds: int = 60,
+    max_fallback_age_hours: int = 3,
+) -> int:
+    """Download HRRR and cache weather values at fire-detection grid points.
+
+    Returns the weather_runs.id of the created record.
+    Raises ValueError if detection bbox is outside CONUS.
+    Raises on unrecoverable download failure after one fallback cycle.
+    """
+    now = datetime.now(timezone.utc)
+    run_time = snap_to_hrrr_cycle(forecast_time or now)
+
+    # ── 1. Collect target grid points ────────────────────────────────────
+    grid_points = query_fire_detection_grid_points(
+        lookback_hours=detection_lookback_hours,
+    )
+    if not grid_points:
+        LOGGER.warning(
+            "No fire detections in the last %.0f hours — nothing to cache for HRRR.",
+            detection_lookback_hours,
+        )
+        # HRRR does NOT use bootstrap seed points (unlike GFS which covers global).
+        # HRRR is only triggered when CONUS detections exist anyway — if there are
+        # none, record the attempt and return early.
+        run_id = create_weather_run_record(
+            model=model_name,
+            run_time=run_time,
+            horizon_hours=horizon_hours,
+            step_hours=step_hours,
+            bbox=(None, None, None, None),
+            variables=[],
+            file_format=FILE_FORMAT_POINT_CACHE,
+        )
+        finalize_weather_run_record(
+            run_id=run_id,
+            storage_path="",
+            status=STATUS_COMPLETED,
+            extra_metadata={"point_cache_rows": 0, "grid_points": 0},
+        )
+        return run_id
+
+    LOGGER.info(
+        "Caching HRRR weather for %d unique GFS grid points (detection lookback=%.0fh)",
+        len(grid_points),
+        detection_lookback_hours,
+    )
+
+    # ── 2. Determine bbox that covers all grid points (with margin) ──────
+    bbox = bbox_from_grid_points(grid_points)
+
+    # ── 3. CONUS check — HRRR is CONUS-only ─────────────────────────────
+    if not is_conus_bbox(bbox):
+        raise ValueError(
+            f"HRRR ingest requires CONUS bbox; got {bbox}. "
+            "Use GFS ingest for non-CONUS regions."
+        )
+
+    # ── 4. Prepare canonical variable lists ──────────────────────────────
+    canonical_variables: list[str] = list(HRRR_VARIABLE_IDX_KEYS.keys())
+    if include_precipitation:
+        canonical_variables.append(HRRR_VARIABLE_IDX_PRECIP)
+
+    variables_to_fetch: dict[str, str] = {**HRRR_VARIABLE_IDX_KEYS}
+    if include_precipitation:
+        variables_to_fetch[HRRR_VARIABLE_IDX_PRECIP] = HRRR_PRECIP_IDX_KEY
+
+    forecast_hours = tuple(range(0, horizon_hours + 1, step_hours))
+
+    # ── 5. Create weather_runs tracking row ──────────────────────────────
+    run_id = create_weather_run_record(
+        model=model_name,
+        run_time=run_time,
+        horizon_hours=horizon_hours,
+        step_hours=step_hours,
+        bbox=bbox,
+        variables=canonical_variables,
+        file_format="point_cache",
+    )
+
+    # ── 6. Download, regrid, extract, insert ─────────────────────────────
+    def _attempt(selected_run_time: datetime) -> int:
+        time_datasets: list[xr.Dataset] = []
+
+        # A fresh client per attempt is intentional: on fallback, we want a clean
+        # connection pool rather than reusing one that may have seen errors.
+        with httpx.Client(timeout=float(request_timeout_seconds)) as client:
+            for fh in forecast_hours:
+                grib_url, idx_url = build_hrrr_urls(selected_run_time, fh)
+                LOGGER.info(
+                    "Downloading HRRR f%02d for point cache: %s", fh, grib_url
+                )
+                with tempfile.TemporaryDirectory(prefix="hrrr_pt_fh_") as tmpdir:
+                    grib_paths = download_hrrr_variable_gribs(
+                        grib_url,
+                        idx_url,
+                        variables_to_fetch,
+                        Path(tmpdir),
+                        client=client,
+                        timeout=float(request_timeout_seconds),
+                    )
+                    ds_fh = build_hrrr_dataset(
+                        grib_paths,
+                        selected_run_time,
+                        fh,
+                        include_precip=include_precipitation,
+                    )
+                    ds_fh = crop_hrrr_to_bbox(ds_fh, bbox)
+
+                    # Regrid HRRR's native Lambert Conformal projection to a
+                    # regular 0.01° lat/lon grid so that sel(method="nearest")
+                    # in _extract_records_at_grid_points can snap GFS 0.25°
+                    # target points to the nearest regridded coordinate.
+                    grid = GridSpec.from_bbox(
+                        bbox,
+                        cell_size_deg=ANALYSIS_CELL_SIZE_DEG,
+                    )
+                    ds_fh = regrid_hrrr_to_analysis_grid(ds_fh, grid)
+                    # Force eager load before the tempdir is deleted — cfgrib arrays are
+                    # lazy and backed by the on-disk GRIB file; reading after cleanup fails.
+                    ds_fh.load()
+                    time_datasets.append(ds_fh)
+
+        # Concatenate all forecast hours into one multi-time Dataset.
+        combined_ds = xr.concat(time_datasets, dim="time")
+        combined_ds = combined_ds.transpose("time", "lat", "lon")
+
+        records = _extract_records_at_grid_points(
+            combined_ds, grid_points, canonical_variables, forecast_hours
+        )
+        inserted = bulk_insert_weather_point_cache(run_id, records)
+
+        finalize_weather_run_record(
+            run_id=run_id,
+            storage_path="",
+            status=STATUS_COMPLETED,
+            run_time=selected_run_time,
+            extra_metadata={
+                "file_format": FILE_FORMAT_POINT_CACHE,
+                "point_cache_rows": inserted,
+                "grid_points": len(grid_points),
+                "variables": canonical_variables,
+                "forecast_hours": list(forecast_hours),
+            },
+        )
+        return inserted
+
+    # ── 7. Attempt primary cycle; fall back to previous hour on failure ───
+    try:
+        inserted = _attempt(run_time)
+        LOGGER.info(
+            "HRRR point ingest completed: run_id=%d, rows=%d, grid_points=%d",
+            run_id,
+            inserted,
+            len(grid_points),
+        )
+        return run_id
+
+    except Exception as primary_exc:
+        prev_run_time = run_time - timedelta(hours=1)
+        fallback_age = (now - prev_run_time).total_seconds() / 3600
+
+        if fallback_age > max_fallback_age_hours:
+            LOGGER.error(
+                "Primary HRRR cycle %s failed and fallback %s is %.1fh old "
+                "(max %dh). Giving up.",
+                run_time,
+                prev_run_time,
+                fallback_age,
+                max_fallback_age_hours,
+            )
+            finalize_weather_run_record(
+                run_id=run_id,
+                storage_path="",
+                status=STATUS_FAILED,
+                extra_metadata={
+                    "error": str(primary_exc),
+                    "fallback_skipped": True,
+                },
+            )
+            raise
+
+        LOGGER.warning(
+            "Primary HRRR cycle %s failed; falling back to %s",
+            run_time,
+            prev_run_time,
+        )
+        try:
+            inserted = _attempt(prev_run_time)
+            LOGGER.info(
+                "HRRR point ingest completed via fallback: run_id=%d, rows=%d",
+                run_id,
+                inserted,
+            )
+            return run_id
+        except Exception as fallback_exc:
+            LOGGER.exception("HRRR point ingest failed after fallback")
+            finalize_weather_run_record(
+                run_id=run_id,
+                storage_path="",
+                status=STATUS_FAILED,
+                extra_metadata={
+                    "error": str(fallback_exc),
+                    "primary_error": str(primary_exc),
+                },
+            )
+            raise
+
+
+def main() -> None:
+    """CLI entry point."""
+    try:
+        run_id = ingest_hrrr_points()
+        LOGGER.info("Done. weather_runs.id = %d", run_id)
+    except Exception:
+        LOGGER.exception("HRRR point ingest failed")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ingest/hrrr_point_ingest.py
+++ b/ingest/hrrr_point_ingest.py
@@ -42,7 +42,6 @@ from ingest.hrrr_ingest import (
 from ingest.weather_point_ingest import _extract_records_at_grid_points
 from ingest.weather_repository import (
     FILE_FORMAT_POINT_CACHE,
-    GFS_GRID_DEG,
     STATUS_COMPLETED,
     STATUS_FAILED,
     bbox_from_grid_points,

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -527,14 +527,44 @@ def _run_firms(args: argparse.Namespace) -> int:
 
 
 def _run_weather(args: argparse.Namespace) -> int:
-    from ingest.weather_point_ingest import ingest_weather_points  # noqa: PLC0415
+    from ingest.hrrr_point_ingest import ingest_hrrr_points          # noqa: PLC0415
+    from ingest.weather_point_ingest import ingest_weather_points     # noqa: PLC0415
+    from ingest.hrrr_ingest import (                                  # noqa: PLC0415
+        HRRR_CONUS_LAT_MIN, HRRR_CONUS_LAT_MAX,
+        HRRR_CONUS_LON_MIN, HRRR_CONUS_LON_MAX,
+    )
+    from ingest.weather_repository import query_fire_detection_grid_points  # noqa: PLC0415
 
+    include_precip = args.weather_include_precip
+
+    # Check whether any active fire detections fall within CONUS.
+    # Each ingest function re-queries internally; this check only decides routing.
+    points = query_fire_detection_grid_points(lookback_hours=48.0)
+    has_conus = any(
+        HRRR_CONUS_LAT_MIN <= lat <= HRRR_CONUS_LAT_MAX
+        and HRRR_CONUS_LON_MIN <= lon <= HRRR_CONUS_LON_MAX
+        for lat, lon in points
+    )
+
+    exit_code = 0
+
+    if has_conus:
+        try:
+            ingest_hrrr_points(include_precipitation=include_precip)
+            LOGGER.info("HRRR point ingest completed.")
+        except Exception:
+            LOGGER.exception("HRRR point ingest failed; GFS will still run.")
+            exit_code = 1
+
+    # GFS always runs: covers non-CONUS fires and acts as global fallback.
     try:
-        ingest_weather_points()
-        return 0
+        ingest_weather_points(include_precipitation=include_precip)
+        LOGGER.info("GFS point ingest completed.")
     except Exception:
-        LOGGER.exception("Weather point ingest failed")
-        return 1
+        LOGGER.exception("GFS point ingest failed.")
+        exit_code = 1
+
+    return exit_code
 
 
 def _run_lfmc(args: argparse.Namespace) -> int:

--- a/ingest/tests/test_hrrr_point_ingest.py
+++ b/ingest/tests/test_hrrr_point_ingest.py
@@ -1,0 +1,83 @@
+"""Unit tests for ingest/hrrr_point_ingest.py (no network or DB calls)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ingest.hrrr_point_ingest import ingest_hrrr_points
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# A set of GFS-snapped points that fall squarely inside CONUS.
+CONUS_POINTS: list[tuple[float, float]] = [
+    (34.0, -118.0),   # Southern California
+    (48.0, -122.0),   # Pacific NW
+    (39.75, -105.0),  # Colorado
+]
+
+# A set of GFS-snapped points in Europe (outside CONUS).
+EUROPE_POINTS: list[tuple[float, float]] = [
+    (48.0, 11.0),   # Munich
+    (51.5, -0.0),   # London
+]
+
+
+# ---------------------------------------------------------------------------
+# Test: ValueError raised for non-CONUS bbox
+# ---------------------------------------------------------------------------
+
+@patch("ingest.hrrr_point_ingest.create_weather_run_record", return_value=42)
+@patch("ingest.hrrr_point_ingest.finalize_weather_run_record")
+@patch("ingest.hrrr_point_ingest.query_fire_detection_grid_points")
+def test_raises_value_error_for_non_conus_bbox(
+    mock_query: MagicMock,
+    mock_finalize: MagicMock,
+    mock_create: MagicMock,
+) -> None:
+    """ingest_hrrr_points raises ValueError when detection points are in Europe."""
+    mock_query.return_value = EUROPE_POINTS
+
+    with pytest.raises(ValueError, match="HRRR ingest requires CONUS bbox"):
+        ingest_hrrr_points()
+
+    # create_weather_run_record should NOT have been called because the bbox
+    # check fires before the run record is created.
+    mock_create.assert_not_called()
+    mock_finalize.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: empty grid_points → returns run_id without downloading
+# ---------------------------------------------------------------------------
+
+@patch("ingest.hrrr_point_ingest.create_weather_run_record", return_value=7)
+@patch("ingest.hrrr_point_ingest.finalize_weather_run_record")
+@patch("ingest.hrrr_point_ingest.query_fire_detection_grid_points")
+def test_empty_grid_points_returns_run_id(
+    mock_query: MagicMock,
+    mock_finalize: MagicMock,
+    mock_create: MagicMock,
+) -> None:
+    """ingest_hrrr_points returns run_id and does not download when no detections."""
+    mock_query.return_value = []
+
+    run_id = ingest_hrrr_points()
+
+    assert run_id == 7
+
+    # A run record must still be created so data_status can show the attempt.
+    mock_create.assert_called_once()
+    call_kwargs = mock_create.call_args.kwargs
+    assert call_kwargs["model"] == "hrrr_3km"
+    assert call_kwargs["file_format"] == "point_cache"
+
+    # Must be finalized with status='completed' and zero rows.
+    mock_finalize.assert_called_once()
+    finalize_kwargs = mock_finalize.call_args.kwargs
+    assert finalize_kwargs["status"] == "completed"
+    assert finalize_kwargs["extra_metadata"]["point_cache_rows"] == 0

--- a/ingest/weather_point_ingest.py
+++ b/ingest/weather_point_ingest.py
@@ -36,7 +36,10 @@ from ingest.weather_ingest import (
     snap_to_gfs_cycle,
 )
 from ingest.weather_repository import (
+    FILE_FORMAT_POINT_CACHE,
     GFS_GRID_DEG,
+    GFS_MODEL_NAME,
+    bbox_from_grid_points,
     bulk_insert_weather_point_cache,
     create_weather_run_record,
     finalize_weather_run_record,
@@ -102,14 +105,26 @@ def _extract_records_at_grid_points(
     return records
 
 
+# Representative CONUS GFS grid points used when no fire detections are present.
+# These are evenly distributed across the continental US and are already on the
+# 0.25° GFS grid (each coordinate satisfies x % 0.25 == 0).
+BOOTSTRAP_SEED_POINTS: list[tuple[float, float]] = [
+    (48.0,  -122.0),  # Pacific NW
+    (34.0,  -118.0),  # Southern California
+    (39.75, -105.0),  # Colorado
+    (30.0,   -90.0),  # Gulf Coast
+    (41.75,  -87.75), # Great Lakes
+]
+
+
 def ingest_weather_points(
     *,
     forecast_time: datetime | None = None,
     detection_lookback_hours: float = 48.0,
     horizon_hours: int = 24,
     step_hours: int = 6,
-    model_name: str = "gfs_0p25",
-    include_precipitation: bool = False,
+    model_name: str = GFS_MODEL_NAME,
+    include_precipitation: bool = True,
     request_timeout_seconds: int = 60,
     max_fallback_age_hours: int = 12,
 ) -> int:
@@ -118,6 +133,10 @@ def ingest_weather_points(
     Returns the ``weather_runs.id`` of the created record.
 
     Raises on unrecoverable download failure (after one fallback cycle attempt).
+
+    Note:
+        GFS APCP is unavailable at forecast_hour=0 (analysis step). ``tp`` will
+        be NULL for fh=0 even when ``include_precipitation=True``.
     """
     now = datetime.now(timezone.utc)
     run_time = snap_to_gfs_cycle(forecast_time or now)
@@ -131,22 +150,8 @@ def ingest_weather_points(
             "No fire detections in the last %.0f hours — nothing to cache.",
             detection_lookback_hours,
         )
-        # Still create a weather_runs row so data_status shows the attempt.
-        run_id = create_weather_run_record(
-            model=model_name,
-            run_time=run_time,
-            horizon_hours=horizon_hours,
-            step_hours=step_hours,
-            bbox=(None, None, None, None),
-            variables=[],
-        )
-        finalize_weather_run_record(
-            run_id=run_id,
-            storage_path="",
-            status="completed",
-            extra_metadata={"point_cache_rows": 0, "grid_points": 0},
-        )
-        return run_id
+        LOGGER.warning("Using bootstrap seed points for initial weather coverage.")
+        grid_points = BOOTSTRAP_SEED_POINTS
 
     LOGGER.info(
         "Caching weather for %d unique GFS grid points (detection lookback=%.0fh)",
@@ -155,15 +160,7 @@ def ingest_weather_points(
     )
 
     # ── 2. Determine bbox that covers all grid points (with margin) ──────
-    lats = [p[0] for p in grid_points]
-    lons = [p[1] for p in grid_points]
-    margin = GFS_GRID_DEG * 2  # 2-cell margin for spread model interp
-    bbox = (
-        min(lons) - margin,
-        min(lats) - margin,
-        max(lons) + margin,
-        max(lats) + margin,
-    )
+    bbox = bbox_from_grid_points(grid_points)
 
     # ── 3. Prepare canonical variable lists ──────────────────────────────
     canonical_variables = ["u10", "v10", "t2m", "rh2m"]
@@ -183,6 +180,7 @@ def ingest_weather_points(
         step_hours=step_hours,
         bbox=bbox,
         variables=canonical_variables,
+        file_format=FILE_FORMAT_POINT_CACHE,
     )
 
     # ── 5. Build download settings ───────────────────────────────────────
@@ -233,7 +231,7 @@ def ingest_weather_points(
                 status="completed",
                 run_time=selected_run_time,
                 extra_metadata={
-                    "file_format": "point_cache",
+                    "file_format": FILE_FORMAT_POINT_CACHE,
                     "point_cache_rows": inserted,
                     "grid_points": len(grid_points),
                     "variables": canonical_variables,

--- a/ingest/weather_point_ingest.py
+++ b/ingest/weather_point_ingest.py
@@ -37,7 +37,6 @@ from ingest.weather_ingest import (
 )
 from ingest.weather_repository import (
     FILE_FORMAT_POINT_CACHE,
-    GFS_GRID_DEG,
     GFS_MODEL_NAME,
     bbox_from_grid_points,
     bulk_insert_weather_point_cache,

--- a/ingest/weather_repository.py
+++ b/ingest/weather_repository.py
@@ -12,6 +12,15 @@ from ingest.repository import get_engine
 
 LOGGER = logging.getLogger(__name__)
 
+# ── Weather run status / format constants ────────────────────────────────────
+FILE_FORMAT_NETCDF = "netcdf"
+FILE_FORMAT_POINT_CACHE = "point_cache"
+STATUS_RUNNING = "running"
+STATUS_COMPLETED = "completed"
+STATUS_FAILED = "failed"
+
+GFS_MODEL_NAME = "gfs_0p25"
+
 
 def create_weather_run_record(
     *,
@@ -21,6 +30,7 @@ def create_weather_run_record(
     step_hours: int,
     bbox: tuple[float | None, float | None, float | None, float | None],
     variables: list[str],
+    file_format: str = FILE_FORMAT_POINT_CACHE,
 ) -> int:
     """Insert a new weather run row and return its ID."""
     metadata: Mapping[str, Any] = {"variables": variables}
@@ -49,31 +59,52 @@ def create_weather_run_record(
             :bbox_min_lat,
             :bbox_max_lon,
             :bbox_max_lat,
-            'netcdf',
+            :file_format,
             '',
-            'running',
+            :status,
             :metadata
         )
+        ON CONFLICT (model, run_time) DO NOTHING
         RETURNING id
         """
     ).bindparams(bindparam("metadata", type_=JSON))
 
+    params = {
+        "model": model,
+        "run_time": run_time,
+        "horizon_hours": horizon_hours,
+        "step_hours": step_hours,
+        "bbox_min_lon": bbox[0],
+        "bbox_min_lat": bbox[1],
+        "bbox_max_lon": bbox[2],
+        "bbox_max_lat": bbox[3],
+        "file_format": file_format,
+        "status": STATUS_RUNNING,
+        "metadata": metadata,
+    }
+
     with get_engine().begin() as conn:
-        result = conn.execute(
-            stmt,
-            {
-                "model": model,
-                "run_time": run_time,
-                "horizon_hours": horizon_hours,
-                "step_hours": step_hours,
-                "bbox_min_lon": bbox[0],
-                "bbox_min_lat": bbox[1],
-                "bbox_max_lon": bbox[2],
-                "bbox_max_lat": bbox[3],
-                "metadata": metadata,
-            },
-        )
-        run_id = result.scalar_one()
+        result = conn.execute(stmt, params)
+        row = result.fetchone()
+        if row is None:
+            # Conflict: a row for this (model, run_time) already exists.
+            existing = conn.execute(
+                text(
+                    "SELECT id FROM weather_runs"
+                    " WHERE model = :model AND run_time = :run_time"
+                ),
+                {"model": model, "run_time": run_time},
+            )
+            run_id = existing.scalar_one()
+            LOGGER.debug(
+                "weather_runs row already exists for model=%s run_time=%s,"
+                " returning existing id=%s",
+                model,
+                run_time,
+                run_id,
+            )
+        else:
+            run_id = row[0]
 
     return int(run_id)
 
@@ -128,6 +159,26 @@ def snap_to_gfs_grid(lat: float, lon: float) -> tuple[float, float]:
     return (
         round(round(lat / GFS_GRID_DEG) * GFS_GRID_DEG, 4),
         round(round(lon / GFS_GRID_DEG) * GFS_GRID_DEG, 4),
+    )
+
+
+def bbox_from_grid_points(
+    grid_points: list[tuple[float, float]],
+    margin_cells: int = 2,
+) -> tuple[float, float, float, float]:
+    """Return a (min_lon, min_lat, max_lon, max_lat) bbox covering *grid_points*.
+
+    Expands by *margin_cells* × ``GFS_GRID_DEG`` on each side so the spread
+    model has room to interpolate at the bbox edges.
+    """
+    lats = [p[0] for p in grid_points]
+    lons = [p[1] for p in grid_points]
+    margin = GFS_GRID_DEG * margin_cells
+    return (
+        min(lons) - margin,
+        min(lats) - margin,
+        max(lons) + margin,
+        max(lats) + margin,
     )
 
 


### PR DESCRIPTION
## Summary

Unifies GFS and HRRR weather ingest into a single point cache architecture, enabling hourly HRRR updates for CONUS fires while maintaining GFS as a global fallback.

## Key Changes

### New HRRR Point Ingest (`ingest/hrrr_point_ingest.py`)
- Ingests HRRR 3km weather data at GFS 0.25° grid points near recent fire detections
- CONUS-only coverage with hourly cycles and 18-hour forecasts
- Stores data at GFS grid coordinates for unified API lookups
- Includes fallback logic to previous hour on download failure

### Unified Weather Orchestration (`ingest/orchestrator.py`)
- Routes to HRRR ingest when CONUS fires detected, otherwise uses GFS
- GFS always runs as global fallback for non-CONUS regions
- Both paths now configurable via `--weather-include-precip` flag

### Repository & Migration Updates
- `weather_repository.py`: Added `bbox_from_grid_points()` helper, constants for file formats/statuses
- New migration `20260402`: Adds UNIQUE constraint on `weather_runs(model, run_time)` to prevent duplicates from hourly HRRR retries
- `create_weather_run_record()` now handles conflicts gracefully with `ON CONFLICT DO NOTHING`

### GFS Point Ingest Improvements (`ingest/weather_point_ingest.py`)
- Uses bootstrap seed points when no detections present (ensures initial coverage)
- Changed precipitation default from `False` to `True`
- Extracts bbox calculation to reusable helper
- Explicit note: GFS APCP unavailable at fh=0 (analysis step)

### Configuration & Testing
- Updated `Makefile`: Added `ingest-orchestrator` and `ops-start` targets
- Updated `docker-compose.yml`: Changed weather interval from 180→60 minutes, enabled precip
- New test suite (`test_hrrr_point_ingest.py`): Validates non-CONUS rejection, empty detection handling
- API logging: Changed point cache query failures from debug→warning level

## Database Impact
- Migration is backward-compatible; existing runs unaffected
- Unique constraint prevents duplicate (model, run_time) pairs from concurrent/retry ingest

## Deployment Notes
- HRRR requires recent fire detections within CONUS; no data ingested otherwise
- GFS fallback ensures 24-hour coverage regardless of CONUS detection status
- Precipitation now included by default in both models