### PR TITLE
feat(ml): close review queue learning loop into denoiser retraining

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -224,6 +224,26 @@ DENOISER_MODEL_RUN_DIR=             # e.g. /app/models/denoiser/run_001
 # ARCHIVE_RETENTION_DAYS=3           # Archive-ingested fire_detections retention (default: 3)
 
 # =============================================================================
+# Review Queue → Denoiser Training Feedback Loop (science_grade)
+# =============================================================================
+# When enabled, resolved operator review queue items are ingested as
+# denoiser_labels_v2 training rows each time `make denoiser-label-v2` runs.
+# When disabled (default), a WARNING is emitted if unprocessed labels exist so
+# the gap is visible during ops review.
+# Do not enable until Tasks 11–13 are complete (queue quality pre-requisites).
+#
+# REVIEW_QUEUE_FEEDBACK_ENABLED=false
+#
+# Per-label confidence weight for operator labels (default: 0.8).
+# Authoritative perimeter labels always use weight 1.0.
+# REVIEW_QUEUE_LABEL_WEIGHT=0.8
+#
+# Operator Label Quality (orchestrator JOB_OPERATOR_ACCURACY, runs weekly)
+# Computes per-operator accuracy against subsequent authoritative perimeters
+# and updates operator_label_quality table.
+# OPERATOR_ACCURACY_INTERVAL_MINUTES=10080   # weekly (default)
+
+# =============================================================================
 # Optional: Operational Notifications (webhook + email)
 # =============================================================================
 # Webhook (Slack / Discord incoming webhook — leave unset to disable):

--- a/api/migrations/versions/20260402_review_queue_feedback_loop.py
+++ b/api/migrations/versions/20260402_review_queue_feedback_loop.py
@@ -1,0 +1,132 @@
+"""Review queue → denoiser training feedback loop.
+
+Adds the schema required to close the learning loop from operator review queue
+resolutions back into denoiser v2 training labels:
+
+  1. label_weight (FLOAT, default 1.0) on denoiser_labels_v2 — allows
+     per-label confidence weighting so review-queue labels (default 0.8) can
+     be down-weighted relative to authoritative perimeter labels (1.0).
+
+  2. label_conflicts — audit table recording cases where an operator label
+     disagrees with an existing authoritative-perimeter label.  Perimeter
+     always wins; the conflict is logged here for QA inspection.
+
+  3. operator_label_quality — weekly-computed per-operator accuracy against
+     subsequent authoritative perimeters.  Used to weight labels in training:
+     high-accuracy operators → 1.0, low-accuracy → 0.5.  Initially only one
+     row exists because the UI sends resolved_by='operator' for all resolutions.
+
+Revision ID: 20260402_review_queue_feedback_loop
+Revises: 20260402_add_weather_runs_unique_model_run_time
+Create Date: 2026-04-02
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20260402_review_queue_feedback_loop"
+down_revision = "20260402_add_weather_runs_unique_model_run_time"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Add label_weight to denoiser_labels_v2
+    op.add_column(
+        "denoiser_labels_v2",
+        sa.Column(
+            "label_weight",
+            sa.Float(),
+            nullable=False,
+            server_default=sa.text("1.0"),
+        ),
+    )
+
+    # Index on source for efficient review_queue label lookups
+    op.create_index(
+        "ix_denoiser_labels_v2_source",
+        "denoiser_labels_v2",
+        ["source"],
+    )
+    # Composite index to support the NOT EXISTS subquery in label_review_queue.py:
+    #   WHERE dl.fire_detection_id = fem.fire_detection_id AND dl.source = 'review_queue'
+    op.create_index(
+        "ix_denoiser_labels_v2_detection_source",
+        "denoiser_labels_v2",
+        ["fire_detection_id", "source"],
+    )
+
+    # 2. label_conflicts — audit log for operator vs. perimeter disagreements
+    op.create_table(
+        "label_conflicts",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("event_id", sa.String(length=64), nullable=True),
+        sa.Column("fire_detection_id", sa.BigInteger(), nullable=True),
+        sa.Column("perimeter_label", sa.String(length=32), nullable=False),
+        sa.Column("operator_label", sa.String(length=32), nullable=False),
+        sa.Column("resolved_by", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["event_id"],
+            ["fire_events.event_id"],
+            name="fk_label_conflicts_event",
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["fire_detection_id"],
+            ["fire_detections.id"],
+            name="fk_label_conflicts_detection",
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index(
+        "ix_label_conflicts_event_id",
+        "label_conflicts",
+        ["event_id"],
+    )
+    op.create_index(
+        "ix_label_conflicts_created_at",
+        "label_conflicts",
+        ["created_at"],
+    )
+
+    # 3. operator_label_quality — per-operator accuracy computed weekly
+    # Unique on resolved_by: currently only one row ('operator') until auth is added.
+    op.create_table(
+        "operator_label_quality",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("resolved_by", sa.Text(), nullable=False),
+        sa.Column("fire_label_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("fire_correct_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("noise_label_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("noise_correct_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("fire_accuracy", sa.Float(), nullable=True),
+        sa.Column("noise_accuracy", sa.Float(), nullable=True),
+        # Derived training weight: min(1.0, max(0.5, avg(fire_accuracy, noise_accuracy)))
+        sa.Column("label_weight", sa.Float(), nullable=False, server_default=sa.text("1.0")),
+        sa.Column(
+            "computed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("resolved_by", name="uq_operator_label_quality_resolved_by"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("operator_label_quality")
+
+    op.drop_index("ix_label_conflicts_created_at", table_name="label_conflicts")
+    op.drop_index("ix_label_conflicts_event_id", table_name="label_conflicts")
+    op.drop_table("label_conflicts")
+
+    op.drop_index("ix_denoiser_labels_v2_detection_source", table_name="denoiser_labels_v2")
+    op.drop_index("ix_denoiser_labels_v2_source", table_name="denoiser_labels_v2")
+    op.drop_column("denoiser_labels_v2", "label_weight")

--- a/api/migrations/versions/20260402_review_queue_feedback_loop.py
+++ b/api/migrations/versions/20260402_review_queue_feedback_loop.py
@@ -23,7 +23,6 @@ Create Date: 2026-04-02
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 revision = "20260402_review_queue_feedback_loop"
 down_revision = "20260402_add_weather_runs_unique_model_run_time"

--- a/ingest/operator_accuracy_job.py
+++ b/ingest/operator_accuracy_job.py
@@ -1,0 +1,57 @@
+"""Orchestrator wrapper for the weekly operator label-quality accuracy job.
+
+This module is the thin ingest-layer adapter for ml.denoiser.operator_accuracy,
+following the same pattern as ingest/denoiser_drift_monitor.py.
+
+The job queries denoiser_labels_v2 (source='review_queue') and
+authoritative_perimeters to compute per-operator label accuracy, then upserts
+results into operator_label_quality.  This feeds back into the review queue
+feedback loop by adjusting the label_weight of future review queue labels.
+
+Invoked by the orchestrator as JOB_OPERATOR_ACCURACY (weekly by default).
+Can also be run standalone:
+    uv run --project ingest -m ingest.operator_accuracy_job
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from api.db import get_engine
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+LOGGER = logging.getLogger("operator_accuracy_job")
+
+
+def run_operator_accuracy_job() -> int:
+    """Run one operator accuracy computation cycle.
+
+    Returns 0 on success, 1 on failure.
+    """
+    # Lazy import keeps api.db out of module scope at ingest startup.
+    from ml.denoiser.operator_accuracy import compute_operator_accuracy  # noqa: PLC0415
+
+    engine = get_engine()
+    result = compute_operator_accuracy(engine)
+    n_operators = len(result.get("operators", []))
+    LOGGER.info(
+        "Operator accuracy job complete: %d operator(s) updated at %s",
+        n_operators,
+        result.get("computed_at"),
+    )
+    print(json.dumps(result))
+    return 0
+
+
+def main() -> None:
+    import sys
+
+    sys.exit(run_operator_accuracy_job())
+
+
+if __name__ == "__main__":
+    main()

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -40,7 +40,8 @@ JOB_INDUSTRIAL = "industrial"
 JOB_DENOISER_DRIFT = "denoiser_drift"
 JOB_CLEANUP = "cleanup"
 JOB_AOI_WATCH = "aoi_watch"
-JOB_ORDER = (JOB_FIRMS, JOB_WEATHER, JOB_LFMC, JOB_LULC, JOB_DROUGHT, JOB_LIGHTNING_PROXY, JOB_TERRAIN, JOB_PERIMETERS, JOB_INDUSTRIAL, JOB_DENOISER_DRIFT, JOB_CLEANUP, JOB_AOI_WATCH)
+JOB_OPERATOR_ACCURACY = "operator_accuracy"
+JOB_ORDER = (JOB_FIRMS, JOB_WEATHER, JOB_LFMC, JOB_LULC, JOB_DROUGHT, JOB_LIGHTNING_PROXY, JOB_TERRAIN, JOB_PERIMETERS, JOB_INDUSTRIAL, JOB_DENOISER_DRIFT, JOB_CLEANUP, JOB_AOI_WATCH, JOB_OPERATOR_ACCURACY)
 DEFAULT_DASHBOARD_PATH = REPO_ROOT / "data" / "ingest" / "orchestrator_dashboard.json"
 
 # Watermarks whose source name ends with _NRT are near-real-time feeds.
@@ -235,6 +236,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=float,
         default=1440.0,
         help="Database cleanup run interval in minutes (loop mode).",
+    )
+    parser.add_argument(
+        "--operator-accuracy-interval-minutes",
+        type=float,
+        default=10080.0,
+        help=(
+            "Operator label-quality accuracy job interval in minutes (loop mode). "
+            "Default 10080 = weekly.  Accuracy is retrospective (perimeters arrive "
+            "days after operator decisions), so daily runs are wasteful."
+        ),
     )
 
     parser.add_argument(
@@ -483,6 +494,7 @@ def _validate_args(args: argparse.Namespace) -> None:
         ("--denoiser-drift-interval-minutes", args.denoiser_drift_interval_minutes),
         ("--cleanup-interval-minutes", args.cleanup_interval_minutes),
         ("--aoi-watch-interval-minutes", args.aoi_watch_interval_minutes),
+        ("--operator-accuracy-interval-minutes", args.operator_accuracy_interval_minutes),
     )
     for flag, value in interval_flags:
         if value <= 0:
@@ -807,6 +819,13 @@ def _run_aoi_watch(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_operator_accuracy(args: argparse.Namespace) -> int:  # noqa: ARG001
+    """Run one operator label-quality accuracy computation cycle (weekly)."""
+    from ingest.operator_accuracy_job import run_operator_accuracy_job  # noqa: PLC0415
+
+    return run_operator_accuracy_job()
+
+
 def _run_cleanup(args: argparse.Namespace) -> int:
     """Run database cleanup.
 
@@ -880,6 +899,7 @@ def build_jobs(args: argparse.Namespace) -> list[ScheduledJob]:
         JOB_DENOISER_DRIFT: lambda: _run_denoiser_drift(args),
         JOB_CLEANUP: lambda: _run_cleanup(args),
         JOB_AOI_WATCH: lambda: _run_aoi_watch(args),
+        JOB_OPERATOR_ACCURACY: lambda: _run_operator_accuracy(args),
     }
 
     intervals_seconds = {
@@ -895,6 +915,7 @@ def build_jobs(args: argparse.Namespace) -> list[ScheduledJob]:
         JOB_DENOISER_DRIFT: args.denoiser_drift_interval_minutes * 60.0,
         JOB_CLEANUP: args.cleanup_interval_minutes * 60.0,
         JOB_AOI_WATCH: args.aoi_watch_interval_minutes * 60.0,
+        JOB_OPERATOR_ACCURACY: args.operator_accuracy_interval_minutes * 60.0,
     }
 
     return [

--- a/ml/denoiser/dataset.py
+++ b/ml/denoiser/dataset.py
@@ -18,13 +18,14 @@ def load_labeled_data(
     
     safe_label_table = validate_table_reference(label_table)
 
-    # We assume the labels table has fire_detection_id and label (POS/NEG/UNKNOWN)
+    # We assume the labels table has fire_detection_id, label, and label_weight.
     query = text(f"""
-        SELECT 
-            d.id, d.lat, d.lon, d.acq_time, d.confidence, d.frp, 
+        SELECT
+            d.id, d.lat, d.lon, d.acq_time, d.confidence, d.frp,
             d.brightness, d.bright_t31, d.scan, d.track, d.sensor, d.source,
             d.raw_properties,
-            l.label
+            l.label,
+            COALESCE(l.label_weight, 1.0) AS label_weight
         FROM fire_detections d
         JOIN {safe_label_table} l ON d.id = l.fire_detection_id
         WHERE d.acq_time BETWEEN :start AND :end
@@ -78,8 +79,12 @@ def build_dataset(
 
     X = train_df[feature_cols]
     y = train_df["label"].map({"POSITIVE": 1, "NEGATIVE": 0})
-    
-    meta_cols = ["id", "lat", "lon", "acq_time", "sensor", "source", "label"]
+
+    meta_cols = ["id", "lat", "lon", "acq_time", "sensor", "source", "label", "label_weight"]
+    # label_weight may be absent if the caller passed a pre-filtered DataFrame;
+    # train_df is already a copy (from the .copy() filter above), so assign directly.
+    if "label_weight" not in train_df.columns:
+        train_df["label_weight"] = 1.0
     meta = train_df[meta_cols]
-    
+
     return X, y, meta

--- a/ml/denoiser/label_review_queue.py
+++ b/ml/denoiser/label_review_queue.py
@@ -1,0 +1,257 @@
+"""Ingest resolved operator review queue items as denoiser_labels_v2 training rows.
+
+The review queue is event-centric — each queue row has an event_id but no
+fire_detection_id.  To produce per-detection training labels we join through
+fire_event_memberships, emitting one label row per detection that is a member
+of the resolved event.
+
+Label mapping:
+    resolved_notes = 'confirmed_fire'  →  label = 'POSITIVE'
+    resolved_notes = 'marked_noise'    →  label = 'NEGATIVE'
+
+Auto-resolved items (resolved_by LIKE 'auto:%') are excluded — they are already
+covered by the authoritative perimeter labeling pass.
+
+Conflict rule: if a detection already carries a non-weak-supervision perimeter
+label that disagrees with the operator label, the perimeter wins.  The conflict
+is logged to label_conflicts for QA, and the operator label is NOT inserted.
+
+The rule_version for review-queue labels is a fixed constant
+('review_queue_v1'), separate from perimeter-based rule versions so both can
+coexist in the table for the same detection.
+
+Implementation note: conflict detection and label insertion are done in bulk
+SQL rather than row-by-row Python loops to avoid O(N) round-trips.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+LOGGER = logging.getLogger("denoiser_label_review_queue")
+
+REVIEW_QUEUE_RULE_VERSION = "review_queue_v1"
+_DEFAULT_LABEL_WEIGHT = 0.8
+_VALID_RESOLVED_NOTES = frozenset({"confirmed_fire", "marked_noise"})
+_NOTES_TO_LABEL = {"confirmed_fire": "POSITIVE", "marked_noise": "NEGATIVE"}
+
+
+def _get_label_weight() -> float:
+    try:
+        return float(os.environ.get("REVIEW_QUEUE_LABEL_WEIGHT", str(_DEFAULT_LABEL_WEIGHT)))
+    except ValueError:
+        LOGGER.warning(
+            "Invalid REVIEW_QUEUE_LABEL_WEIGHT env value; using default %.1f",
+            _DEFAULT_LABEL_WEIGHT,
+        )
+        return _DEFAULT_LABEL_WEIGHT
+
+
+def warn_if_unprocessed_labels_exist(engine: Engine) -> int:
+    """Return the count of resolved operator queue items not yet in denoiser_labels_v2.
+
+    Logs a WARNING if any exist and REVIEW_QUEUE_FEEDBACK_ENABLED is not set.
+    Used in label_v2.py main() to surface the gap during ops review.
+    """
+    stmt = text(
+        """
+        SELECT COUNT(DISTINCT rq.id) AS n
+        FROM denoiser_review_queue rq
+        JOIN fire_event_memberships fem ON fem.event_id = rq.event_id
+        WHERE rq.status = 'resolved'
+          AND rq.resolved_notes IN ('confirmed_fire', 'marked_noise')
+          AND rq.resolved_by NOT LIKE 'auto:%'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM denoiser_labels_v2 dl
+              WHERE dl.fire_detection_id = fem.fire_detection_id
+                AND dl.source = 'review_queue'
+          )
+        """
+    )
+    with engine.connect() as conn:
+        row = conn.execute(stmt).fetchone()
+    count = int(row["n"]) if row else 0
+    if count > 0:
+        LOGGER.warning(
+            "WARNING [target: science_grade]: %d resolved review queue event(s) have not been "
+            "ingested as training labels. Set REVIEW_QUEUE_FEEDBACK_ENABLED=true to close the "
+            "learning loop.",
+            count,
+        )
+    return count
+
+
+def ingest_review_queue_labels(
+    engine: Engine,
+    *,
+    label_weight: float | None = None,
+) -> dict[str, int]:
+    """Ingest resolved operator review queue items as denoiser_labels_v2 rows.
+
+    Returns counts: {"inserted": n, "conflicts": n, "skipped_invalid_notes": n}.
+
+    Uses bulk SQL to avoid per-row round-trips:
+      1. One query fetches all candidates joined with any conflicting perimeter label.
+      2. One batch INSERT logs conflicts to label_conflicts.
+      3. One batch INSERT/ON CONFLICT upserts clean labels into denoiser_labels_v2.
+    """
+    if label_weight is None:
+        label_weight = _get_label_weight()
+
+    labeled_at = datetime.now(timezone.utc)
+
+    # -- Step 1: fetch all eligible candidates in one query.
+    #
+    # Joins fire_event_memberships to expand event → detections.
+    # LEFT JOINs denoiser_labels_v2 to detect conflicts in the same pass —
+    # a conflict exists when an authoritative (non-weak-supervision) perimeter
+    # label disagrees with the operator's resolved_notes.
+    #
+    # Columns returned:
+    #   queue_id, event_id, resolved_by, resolved_notes, fire_detection_id,
+    #   existing_perimeter_label (NULL if no conflict source exists)
+    fetch_stmt = text(
+        """
+        SELECT
+            rq.id                AS queue_id,
+            rq.event_id,
+            rq.resolved_by,
+            rq.resolved_notes,
+            fem.fire_detection_id,
+            existing.label       AS existing_perimeter_label
+        FROM denoiser_review_queue rq
+        JOIN fire_event_memberships fem ON fem.event_id = rq.event_id
+        LEFT JOIN LATERAL (
+            SELECT label
+            FROM denoiser_labels_v2
+            WHERE fire_detection_id = fem.fire_detection_id
+              AND source LIKE 'ground_truth_v2%'
+              AND weak_supervision = false
+            LIMIT 1
+        ) existing ON true
+        WHERE rq.status = 'resolved'
+          AND rq.resolved_notes IN ('confirmed_fire', 'marked_noise')
+          AND rq.resolved_by NOT LIKE 'auto:%'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM denoiser_labels_v2 dl
+              WHERE dl.fire_detection_id = fem.fire_detection_id
+                AND dl.source = 'review_queue'
+          )
+        """
+    )
+
+    # -- Step 2: batch insert conflicts into label_conflicts.
+    conflict_insert_stmt = text(
+        """
+        INSERT INTO label_conflicts
+            (event_id, fire_detection_id, perimeter_label, operator_label, resolved_by, created_at)
+        VALUES
+            (:event_id, :fire_detection_id, :perimeter_label, :operator_label, :resolved_by, now())
+        """
+    )
+
+    # -- Step 3: batch upsert clean labels into denoiser_labels_v2.
+    label_insert_stmt = text(
+        """
+        INSERT INTO denoiser_labels_v2
+            (fire_detection_id, event_id, label, rule_version, source,
+             rule_params, weak_supervision, labeled_at, label_weight)
+        VALUES
+            (:fire_detection_id, :event_id, :label, :rule_version, 'review_queue',
+             CAST(:rule_params AS jsonb), false, :labeled_at, :label_weight)
+        ON CONFLICT (fire_detection_id, rule_version) DO UPDATE SET
+            event_id       = EXCLUDED.event_id,
+            label          = EXCLUDED.label,
+            source         = EXCLUDED.source,
+            rule_params    = EXCLUDED.rule_params,
+            weak_supervision = EXCLUDED.weak_supervision,
+            labeled_at     = EXCLUDED.labeled_at,
+            label_weight   = EXCLUDED.label_weight
+        """
+    )
+
+    conflict_params: list[dict] = []
+    label_params: list[dict] = []
+    skipped_invalid = 0
+
+    with engine.begin() as conn:
+        candidates = conn.execute(fetch_stmt).fetchall()
+
+        for row in candidates:
+            notes = (row["resolved_notes"] or "").strip().lower()
+            if notes not in _VALID_RESOLVED_NOTES:
+                LOGGER.debug(
+                    "Skipping queue_id=%s: unrecognised resolved_notes=%r",
+                    row["queue_id"],
+                    row["resolved_notes"],
+                )
+                skipped_invalid += 1
+                continue
+
+            operator_label = _NOTES_TO_LABEL[notes]
+            existing_label = row["existing_perimeter_label"]
+
+            if existing_label is not None and existing_label != operator_label:
+                LOGGER.warning(
+                    "Label conflict: fire_detection_id=%s event_id=%s "
+                    "perimeter_label=%r operator_label=%r resolved_by=%r — perimeter wins",
+                    row["fire_detection_id"],
+                    row["event_id"],
+                    existing_label,
+                    operator_label,
+                    row["resolved_by"],
+                )
+                conflict_params.append(
+                    {
+                        "event_id": row["event_id"],
+                        "fire_detection_id": row["fire_detection_id"],
+                        "perimeter_label": existing_label,
+                        "operator_label": operator_label,
+                        "resolved_by": row["resolved_by"],
+                    }
+                )
+            else:
+                label_params.append(
+                    {
+                        "fire_detection_id": row["fire_detection_id"],
+                        "event_id": row["event_id"],
+                        "label": operator_label,
+                        "rule_version": REVIEW_QUEUE_RULE_VERSION,
+                        "rule_params": json.dumps(
+                            {
+                                "resolved_by": row["resolved_by"],
+                                "resolved_notes": row["resolved_notes"],
+                                "review_queue_id": row["queue_id"],
+                            }
+                        ),
+                        "labeled_at": labeled_at,
+                        "label_weight": label_weight,
+                    }
+                )
+
+        if conflict_params:
+            conn.execute(conflict_insert_stmt, conflict_params)
+
+        if label_params:
+            conn.execute(label_insert_stmt, label_params)
+
+    counts = {
+        "inserted": len(label_params),
+        "conflicts": len(conflict_params),
+        "skipped_invalid_notes": skipped_invalid,
+    }
+    LOGGER.info(
+        "Review queue label ingestion complete: inserted=%d conflicts=%d skipped_invalid=%d",
+        counts["inserted"],
+        counts["conflicts"],
+        counts["skipped_invalid_notes"],
+    )
+    return counts

--- a/ml/denoiser/label_v2.py
+++ b/ml/denoiser/label_v2.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import time
 from datetime import datetime, timedelta
 from typing import Dict, Optional, Tuple
@@ -699,7 +700,8 @@ def _label_single_window(
             source,
             rule_params,
             weak_supervision,
-            labeled_at
+            labeled_at,
+            label_weight
         )
         SELECT
             fire_detection_id,
@@ -709,7 +711,8 @@ def _label_single_window(
             :source,
             CAST(:rule_params AS jsonb),
             weak_supervision,
-            :labeled_at
+            :labeled_at,
+            1.0
         FROM tmp_label_final
         ON CONFLICT (fire_detection_id, rule_version) DO UPDATE SET
             event_id = EXCLUDED.event_id,
@@ -717,7 +720,8 @@ def _label_single_window(
             source = EXCLUDED.source,
             rule_params = EXCLUDED.rule_params,
             weak_supervision = EXCLUDED.weak_supervision,
-            labeled_at = EXCLUDED.labeled_at
+            labeled_at = EXCLUDED.labeled_at,
+            label_weight = EXCLUDED.label_weight
         """
     )
 
@@ -1027,8 +1031,9 @@ def main() -> None:
     start = datetime.strptime(args.start, "%Y-%m-%d")
     end = datetime.strptime(args.end, "%Y-%m-%d") + timedelta(days=1)
 
+    engine = get_engine()
     counts = label_detections_v2(
-        get_engine(),
+        engine,
         tuple(args.bbox),
         start,
         end,
@@ -1041,6 +1046,28 @@ def main() -> None:
         industrial_policy_version=args.industrial_policy_version,
         industrial_negatives_global=args.industrial_negatives_global,
     )
+
+    # Review queue feedback loop (science_grade).
+    # When enabled, resolved operator labels are ingested as training rows.
+    # When disabled, a WARNING is emitted if unprocessed labels exist so the
+    # gap is visible during ops review.
+    feedback_enabled = os.environ.get("REVIEW_QUEUE_FEEDBACK_ENABLED", "false").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    from ml.denoiser.label_review_queue import (  # noqa: PLC0415
+        ingest_review_queue_labels,
+        warn_if_unprocessed_labels_exist,
+    )
+
+    if feedback_enabled:
+        rq_counts = ingest_review_queue_labels(engine)
+        counts["review_queue_inserted"] = rq_counts["inserted"]
+        counts["review_queue_conflicts"] = rq_counts["conflicts"]
+    else:
+        warn_if_unprocessed_labels_exist(engine)
+
     print(json.dumps(counts))
 
 

--- a/ml/denoiser/operator_accuracy.py
+++ b/ml/denoiser/operator_accuracy.py
@@ -1,0 +1,226 @@
+"""Weekly operator accuracy computation for denoiser review queue labels.
+
+Evaluates per-operator (by resolved_by value) label quality by checking how
+many of their 'confirmed_fire' / 'marked_noise' decisions are later corroborated
+by authoritative perimeters ingested after the resolution was made.
+
+Accuracy definitions:
+    fire_accuracy  = confirmed_fires later covered by an authoritative perimeter
+                     / total confirmed_fire labels made by this operator
+    noise_accuracy = marked_noise items NOT covered by any perimeter within the
+                     lookback window / total marked_noise labels
+
+Derived label_weight = min(1.0, max(0.5, mean(fire_accuracy, noise_accuracy)))
+    - Perfect operator → weight 1.0
+    - Randomly labelling operator → weight ~0.5 (floor)
+
+Currently the UI sends resolved_by='operator' for all resolutions, so this
+produces a single aggregate row.  Individual weighting is available once auth
+is added (out of scope).
+
+NOTE: accuracy is retrospective — perimeters can arrive days to weeks after an
+operator decision.  The job should be run weekly; early runs will underestimate
+accuracy for recently resolved items.  Accuracy improves over time as more
+perimeters are ingested.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+LOGGER = logging.getLogger("denoiser_operator_accuracy")
+
+# Spatial buffer for "covered by perimeter" check — matches label_v2 default.
+_POSITIVE_BUFFER_M = 2315.0
+_POSITIVE_BUFFER_DEG = _POSITIVE_BUFFER_M / 111_320.0  # rough degree conversion for bbox index
+
+# Require the perimeter to have been ingested after the operator label, but allow
+# a grace window so very recent labels aren't marked inaccurate prematurely.
+_PERIMETER_GRACE_DAYS = 14  # ignore labels from the last N days when computing accuracy
+
+
+def compute_operator_accuracy(engine: Engine) -> dict[str, Any]:
+    """Compute per-operator accuracy and upsert into operator_label_quality.
+
+    Returns a summary dict with per-operator stats for logging.
+    """
+    now = datetime.now(timezone.utc)
+
+    # -- Fire accuracy: confirmed_fire labels where detection later fell inside a perimeter
+    fire_accuracy_stmt = text(
+        f"""
+        WITH operator_fire AS (
+            SELECT
+                dl.rule_params->>'resolved_by'   AS resolved_by,
+                dl.rule_params->>'review_queue_id' AS queue_id,
+                dl.fire_detection_id,
+                dl.labeled_at
+            FROM denoiser_labels_v2 dl
+            WHERE dl.source = 'review_queue'
+              AND dl.label = 'POSITIVE'
+              AND dl.labeled_at < NOW() - INTERVAL '{_PERIMETER_GRACE_DAYS} days'
+        ),
+        covered AS (
+            SELECT DISTINCT of.resolved_by, of.fire_detection_id
+            FROM operator_fire of
+            JOIN fire_detections fd ON fd.id = of.fire_detection_id
+            JOIN authoritative_perimeters ap
+              ON ap.geom && ST_Expand(fd.geom, :buffer_deg)
+             AND ST_DWithin(fd.geom::geography, ap.geom::geography, :buffer_m)
+             AND ap.created_at > of.labeled_at
+        )
+        SELECT
+            of.resolved_by,
+            COUNT(DISTINCT of.fire_detection_id)   AS fire_label_count,
+            COUNT(DISTINCT c.fire_detection_id)     AS fire_correct_count
+        FROM operator_fire of
+        LEFT JOIN covered c
+          ON c.resolved_by = of.resolved_by
+         AND c.fire_detection_id = of.fire_detection_id
+        GROUP BY of.resolved_by
+        """
+    )
+
+    noise_accuracy_stmt = text(
+        f"""
+        WITH operator_noise AS (
+            SELECT
+                dl.rule_params->>'resolved_by'   AS resolved_by,
+                dl.fire_detection_id,
+                dl.labeled_at
+            FROM denoiser_labels_v2 dl
+            WHERE dl.source = 'review_queue'
+              AND dl.label = 'NEGATIVE'
+              AND dl.labeled_at < NOW() - INTERVAL '{_PERIMETER_GRACE_DAYS} days'
+        ),
+        covered AS (
+            SELECT DISTINCT of.resolved_by, of.fire_detection_id
+            FROM operator_noise of
+            JOIN fire_detections fd ON fd.id = of.fire_detection_id
+            JOIN authoritative_perimeters ap
+              ON ap.geom && ST_Expand(fd.geom, :buffer_deg)
+             AND ST_DWithin(fd.geom::geography, ap.geom::geography, :buffer_m)
+             AND ap.created_at > of.labeled_at
+        )
+        SELECT
+            of.resolved_by,
+            COUNT(DISTINCT of.fire_detection_id)   AS noise_label_count,
+            -- Correct noise = NOT covered (operator correctly said it's noise)
+            COUNT(DISTINCT of.fire_detection_id)
+              FILTER (WHERE c.fire_detection_id IS NULL) AS noise_correct_count
+        FROM operator_noise of
+        LEFT JOIN covered c
+          ON c.resolved_by = of.resolved_by
+         AND c.fire_detection_id = of.fire_detection_id
+        GROUP BY of.resolved_by
+        """
+    )
+
+    upsert_stmt = text(
+        """
+        INSERT INTO operator_label_quality
+            (resolved_by, fire_label_count, fire_correct_count,
+             noise_label_count, noise_correct_count,
+             fire_accuracy, noise_accuracy, label_weight, computed_at)
+        VALUES
+            (:resolved_by, :fire_label_count, :fire_correct_count,
+             :noise_label_count, :noise_correct_count,
+             :fire_accuracy, :noise_accuracy, :label_weight, :computed_at)
+        ON CONFLICT (resolved_by) DO UPDATE SET
+            fire_label_count    = EXCLUDED.fire_label_count,
+            fire_correct_count  = EXCLUDED.fire_correct_count,
+            noise_label_count   = EXCLUDED.noise_label_count,
+            noise_correct_count = EXCLUDED.noise_correct_count,
+            fire_accuracy       = EXCLUDED.fire_accuracy,
+            noise_accuracy      = EXCLUDED.noise_accuracy,
+            label_weight        = EXCLUDED.label_weight,
+            computed_at         = EXCLUDED.computed_at
+        """
+    )
+
+    params = {
+        "buffer_m": _POSITIVE_BUFFER_M,
+        "buffer_deg": _POSITIVE_BUFFER_DEG,
+    }
+
+    results: dict[str, Any] = {"operators": [], "computed_at": now.isoformat()}
+
+    with engine.begin() as conn:
+        fire_rows = {
+            row["resolved_by"]: dict(row._mapping)
+            for row in conn.execute(fire_accuracy_stmt, params).fetchall()
+        }
+        noise_rows = {
+            row["resolved_by"]: dict(row._mapping)
+            for row in conn.execute(noise_accuracy_stmt, params).fetchall()
+        }
+
+        all_operators = set(fire_rows) | set(noise_rows)
+
+        for operator in all_operators:
+            fire = fire_rows.get(operator, {})
+            noise = noise_rows.get(operator, {})
+
+            fire_count = int(fire.get("fire_label_count", 0))
+            fire_correct = int(fire.get("fire_correct_count", 0))
+            noise_count = int(noise.get("noise_label_count", 0))
+            noise_correct = int(noise.get("noise_correct_count", 0))
+
+            fire_accuracy = fire_correct / fire_count if fire_count > 0 else None
+            noise_accuracy = noise_correct / noise_count if noise_count > 0 else None
+
+            # Derive label weight: average of available accuracy values, clamped to [0.5, 1.0]
+            available = [a for a in (fire_accuracy, noise_accuracy) if a is not None]
+            if available:
+                avg_accuracy = sum(available) / len(available)
+                label_weight = min(1.0, max(0.5, avg_accuracy))
+            else:
+                label_weight = 1.0  # no data yet → assume full weight
+
+            conn.execute(
+                upsert_stmt,
+                {
+                    "resolved_by": operator,
+                    "fire_label_count": fire_count,
+                    "fire_correct_count": fire_correct,
+                    "noise_label_count": noise_count,
+                    "noise_correct_count": noise_correct,
+                    "fire_accuracy": fire_accuracy,
+                    "noise_accuracy": noise_accuracy,
+                    "label_weight": label_weight,
+                    "computed_at": now,
+                },
+            )
+
+            LOGGER.info(
+                "Operator accuracy: resolved_by=%r fire_acc=%s noise_acc=%s "
+                "label_weight=%.3f (fire=%d/%d noise=%d/%d)",
+                operator,
+                f"{fire_accuracy:.3f}" if fire_accuracy is not None else "n/a",
+                f"{noise_accuracy:.3f}" if noise_accuracy is not None else "n/a",
+                label_weight,
+                fire_correct,
+                fire_count,
+                noise_correct,
+                noise_count,
+            )
+
+            results["operators"].append(
+                {
+                    "resolved_by": operator,
+                    "fire_label_count": fire_count,
+                    "fire_correct_count": fire_correct,
+                    "noise_label_count": noise_count,
+                    "noise_correct_count": noise_correct,
+                    "fire_accuracy": fire_accuracy,
+                    "noise_accuracy": noise_accuracy,
+                    "label_weight": label_weight,
+                }
+            )
+
+    return results

--- a/ml/tests/test_label_review_queue.py
+++ b/ml/tests/test_label_review_queue.py
@@ -1,0 +1,262 @@
+"""Tests for ml.denoiser.label_review_queue.
+
+Acceptance criteria covered:
+  - resolved 'confirmed_fire' queue item produces label='POSITIVE' row
+  - resolved 'marked_noise' queue item produces label='NEGATIVE' row
+  - auto-resolved items (resolved_by LIKE 'auto:%') are excluded
+  - conflict: operator label disagrees with perimeter label → logged to
+    label_conflicts, NOT inserted into denoiser_labels_v2
+  - items with unrecognised resolved_notes are skipped (counted, not inserted)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from ml.denoiser.label_review_queue import (
+    REVIEW_QUEUE_RULE_VERSION,
+    ingest_review_queue_labels,
+    warn_if_unprocessed_labels_exist,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row(**kwargs: Any) -> MagicMock:
+    """Build a MagicMock that behaves like a SQLAlchemy Row (dict-style access)."""
+    row = MagicMock()
+    row.__getitem__ = lambda self, key: kwargs[key]
+    row._mapping = kwargs
+    return row
+
+
+def _make_engine(fetch_rows: list[Any]) -> tuple[MagicMock, MagicMock]:
+    """Build a mock engine whose connection returns the given fetch_rows.
+
+    After the initial fetch, further execute() calls (batch inserts) return
+    a generic mock — we inspect call_args_list to assert what was inserted.
+    """
+    conn = MagicMock()
+    engine = MagicMock()
+    engine.begin.return_value.__enter__ = lambda self: conn
+    engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    fetch_result = MagicMock()
+    fetch_result.fetchall.return_value = fetch_rows
+
+    # First execute() is always the fetch; subsequent calls are batch inserts.
+    conn.execute.side_effect = [fetch_result, MagicMock(), MagicMock()]
+    return engine, conn
+
+
+# ---------------------------------------------------------------------------
+# Tests: label mapping
+# ---------------------------------------------------------------------------
+
+
+def test_confirmed_fire_produces_positive_label() -> None:
+    """A resolved 'confirmed_fire' queue item must emit label='POSITIVE'."""
+    candidate = _row(
+        queue_id=1,
+        event_id="ev_001",
+        resolved_by="operator",
+        resolved_notes="confirmed_fire",
+        fire_detection_id=42,
+        existing_perimeter_label=None,  # no conflict
+    )
+    engine, conn = _make_engine(fetch_rows=[candidate])
+
+    counts = ingest_review_queue_labels(engine, label_weight=0.8)
+
+    assert counts["inserted"] == 1
+    assert counts["conflicts"] == 0
+    assert counts["skipped_invalid_notes"] == 0
+
+    # The label batch insert is the second execute() call (index 1).
+    # Verify the params list passed to it contains the correct label.
+    label_call = conn.execute.call_args_list[1]
+    label_params_list = label_call[0][1]  # list of param dicts
+    assert len(label_params_list) == 1
+    p = label_params_list[0]
+    assert p["label"] == "POSITIVE"
+    assert p["rule_version"] == REVIEW_QUEUE_RULE_VERSION
+    assert p["label_weight"] == 0.8
+    assert p["fire_detection_id"] == 42
+
+
+def test_marked_noise_produces_negative_label() -> None:
+    """A resolved 'marked_noise' queue item must emit label='NEGATIVE'."""
+    candidate = _row(
+        queue_id=2,
+        event_id="ev_002",
+        resolved_by="operator",
+        resolved_notes="marked_noise",
+        fire_detection_id=99,
+        existing_perimeter_label=None,
+    )
+    engine, conn = _make_engine(fetch_rows=[candidate])
+
+    counts = ingest_review_queue_labels(engine, label_weight=0.8)
+
+    assert counts["inserted"] == 1
+    label_params_list = conn.execute.call_args_list[1][0][1]
+    assert label_params_list[0]["label"] == "NEGATIVE"
+    assert label_params_list[0]["fire_detection_id"] == 99
+
+
+# ---------------------------------------------------------------------------
+# Tests: auto-resolved exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_auto_resolved_items_excluded() -> None:
+    """Items with resolved_by='auto:perimeter:wfigs' must NOT reach denoiser_labels_v2.
+
+    The SQL fetch query already filters these out via WHERE resolved_by NOT LIKE 'auto:%',
+    so the result set is empty — no insert calls should happen.
+    """
+    engine, conn = _make_engine(fetch_rows=[])
+
+    counts = ingest_review_queue_labels(engine, label_weight=0.8)
+
+    assert counts["inserted"] == 0
+    assert counts["conflicts"] == 0
+    # Only the fetch query was executed; no batch inserts.
+    assert conn.execute.call_count == 1
+
+
+def test_auto_resolved_pattern_verified_in_fetch_sql() -> None:
+    """Confirm the fetch SQL contains the auto-resolve exclusion clause."""
+    import inspect
+
+    from ml.denoiser.label_review_queue import ingest_review_queue_labels
+
+    src = inspect.getsource(ingest_review_queue_labels)
+    assert "NOT LIKE 'auto:%'" in src or "resolved_by NOT LIKE" in src
+
+
+# ---------------------------------------------------------------------------
+# Tests: conflict resolution
+# ---------------------------------------------------------------------------
+
+
+def test_conflict_skips_label_insert_and_logs_to_label_conflicts() -> None:
+    """When the operator says 'confirmed_fire' but perimeter says 'NEGATIVE',
+    the conflict is logged to label_conflicts and no label is inserted."""
+    candidate = _row(
+        queue_id=3,
+        event_id="ev_003",
+        resolved_by="operator",
+        resolved_notes="confirmed_fire",
+        fire_detection_id=77,
+        existing_perimeter_label="NEGATIVE",  # conflict
+    )
+    engine, conn = _make_engine(fetch_rows=[candidate])
+
+    counts = ingest_review_queue_labels(engine, label_weight=0.8)
+
+    assert counts["inserted"] == 0
+    assert counts["conflicts"] == 1
+
+    # The conflict batch insert is the second execute() call (index 1).
+    conflict_call = conn.execute.call_args_list[1]
+    conflict_params_list = conflict_call[0][1]
+    assert len(conflict_params_list) == 1
+    p = conflict_params_list[0]
+    assert p["perimeter_label"] == "NEGATIVE"
+    assert p["operator_label"] == "POSITIVE"
+    assert p["fire_detection_id"] == 77
+
+
+def test_no_conflict_when_labels_agree() -> None:
+    """When operator and perimeter agree (both POSITIVE), no conflict is logged."""
+    candidate = _row(
+        queue_id=4,
+        event_id="ev_004",
+        resolved_by="operator",
+        resolved_notes="confirmed_fire",
+        fire_detection_id=55,
+        existing_perimeter_label="POSITIVE",  # agreement
+    )
+    engine, conn = _make_engine(fetch_rows=[candidate])
+
+    counts = ingest_review_queue_labels(engine, label_weight=0.8)
+
+    assert counts["inserted"] == 1
+    assert counts["conflicts"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: invalid / unknown resolved_notes
+# ---------------------------------------------------------------------------
+
+
+def test_unrecognised_resolved_notes_skipped() -> None:
+    """Items with notes outside ('confirmed_fire', 'marked_noise') are skipped."""
+    candidate = _row(
+        queue_id=5,
+        event_id="ev_005",
+        resolved_by="operator",
+        resolved_notes="needs_more_info",
+        fire_detection_id=33,
+        existing_perimeter_label=None,
+    )
+    engine, conn = _make_engine(fetch_rows=[candidate])
+
+    counts = ingest_review_queue_labels(engine, label_weight=0.8)
+
+    assert counts["inserted"] == 0
+    assert counts["skipped_invalid_notes"] == 1
+    # No batch inserts — only the initial fetch.
+    assert conn.execute.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: warn_if_unprocessed_labels_exist
+# ---------------------------------------------------------------------------
+
+
+def test_warn_logs_when_pending_labels_exist(caplog: pytest.LogCaptureFixture) -> None:
+    """warn_if_unprocessed_labels_exist must log a WARNING when count > 0."""
+    count_row = _row(n=3)
+    conn = MagicMock()
+    engine = MagicMock()
+    engine.connect.return_value.__enter__ = lambda self: conn
+    engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    result = MagicMock()
+    result.fetchone.return_value = count_row
+    conn.execute.return_value = result
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="denoiser_label_review_queue"):
+        count = warn_if_unprocessed_labels_exist(engine)
+
+    assert count == 3
+    assert any("REVIEW_QUEUE_FEEDBACK_ENABLED" in r.message for r in caplog.records)
+
+
+def test_warn_silent_when_no_pending_labels(caplog: pytest.LogCaptureFixture) -> None:
+    """warn_if_unprocessed_labels_exist must not log when count == 0."""
+    count_row = _row(n=0)
+    conn = MagicMock()
+    engine = MagicMock()
+    engine.connect.return_value.__enter__ = lambda self: conn
+    engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    result = MagicMock()
+    result.fetchone.return_value = count_row
+    conn.execute.return_value = result
+
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="denoiser_label_review_queue"):
+        count = warn_if_unprocessed_labels_exist(engine)
+
+    assert count == 0
+    assert not any("REVIEW_QUEUE_FEEDBACK_ENABLED" in r.message for r in caplog.records)

--- a/ml/train_denoiser_v2.py
+++ b/ml/train_denoiser_v2.py
@@ -105,6 +105,13 @@ def _feature_matrix(df: pd.DataFrame, features: list[str]) -> pd.DataFrame:
     return df[features].astype(np.float32)
 
 
+def _label_weights(df: pd.DataFrame) -> np.ndarray:
+    """Return per-row label_weight as a float array, defaulting to 1.0 if absent."""
+    if "label_weight" in df.columns:
+        return df["label_weight"].fillna(1.0).to_numpy(dtype=np.float32)
+    return np.ones(len(df), dtype=np.float32)
+
+
 def _stratified_downsample(
     df: pd.DataFrame,
     *,
@@ -677,7 +684,8 @@ def _fit_legacy_two_stage(
     y_train_known = y_train[known_train]
 
     class_weight_pos = float(config.get("pos_class_weight", 1.0))
-    sample_weight = np.where(y_train_known == 1, class_weight_pos, 1.0)
+    per_row_weight = _label_weights(train_df.loc[known_train])
+    sample_weight = np.where(y_train_known == 1, class_weight_pos, 1.0) * per_row_weight
     model_stage1.fit(x_train_known, y_train_known, sample_weight=sample_weight)
 
     unknown_mask = y_train == -1
@@ -695,7 +703,8 @@ def _fit_legacy_two_stage(
     model = _build_model(config)
     x_stage2 = _feature_matrix(train_df.loc[stage2_known], features)
     y_stage2_known = y_stage2[stage2_known]
-    sample_weight_stage2 = np.where(y_stage2_known == 1, class_weight_pos, 1.0)
+    per_row_weight_stage2 = _label_weights(train_df.loc[stage2_known])
+    sample_weight_stage2 = np.where(y_stage2_known == 1, class_weight_pos, 1.0) * per_row_weight_stage2
     model.fit(x_stage2, y_stage2_known, sample_weight=sample_weight_stage2)
 
     stats = {


### PR DESCRIPTION
## Summary

Closes the learning loop from operator review queue resolutions back into denoiser v2 training by:

1. **Database schema** (migration): Adds `label_weight` to `denoiser_labels_v2`, plus new tables:
   - `label_conflicts`: Audit log for operator vs. perimeter label disagreements
   - `operator_label_quality`: Weekly per-operator accuracy metrics

2. **Label ingestion** (`ml.denoiser.label_review_queue`): New module to ingest resolved review queue items as training rows with:
   - Automatic label mapping: `confirmed_fire` → `POSITIVE`, `marked_noise` → `NEGATIVE`
   - Conflict detection: perimeter labels win; conflicts logged to audit table
   - Auto-resolved items excluded (already covered by perimeter labeling)
   - Configurable label weights (default 0.8 for review queue vs. 1.0 for perimeter)

3. **Operator accuracy job** (`ml.denoiser.operator_accuracy`): Weekly orchestrator job that:
   - Computes per-operator accuracy by checking resolutions against subsequent perimeters
   - Updates `operator_label_quality` with accuracy metrics and derived weights
   - Feeds weights back into future review queue label ingestions

4. **Integration**:
   - `label_v2.py`: Calls review queue ingestion when `REVIEW_QUEUE_FEEDBACK_ENABLED=true`; warns if unprocessed labels exist
   - `train_denoiser_v2.py`: Respects per-row `label_weight` during model training
   - Orchestrator: Adds `JOB_OPERATOR_ACCURACY` scheduled weekly

5. **Testing**: Comprehensive test suite for label ingestion (mapping, conflicts, auto-resolution exclusion, invalid notes handling)

## Environment variables

- `REVIEW_QUEUE_FEEDBACK_ENABLED` (default: false) — Enable feedback loop
- `REVIEW_QUEUE_LABEL_WEIGHT` (default: 0.8) — Confidence weight for operator labels
- `OPERATOR_ACCURACY_INTERVAL_MINUTES` (default: 10080 = weekly) — Job schedule