### PR TITLE
feat(notifications): operational fire intelligence alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -259,3 +259,9 @@ DENOISER_MODEL_RUN_DIR=             # e.g. /app/models/denoiser/run_001
 #
 # Rate limiting (default: 900 s = 15 min per event type):
 # NOTIFICATION_RATE_LIMIT_SECONDS=900
+#
+# Per-severity webhook routing (optional — fall back to NOTIFICATION_WEBHOOK_URL if not set):
+# NOTIFICATION_WEBHOOK_URL_CRITICAL=   # Paging/ops channel for critical events
+# NOTIFICATION_WEBHOOK_URL_WARNING=    # Ops channel for warnings
+# NOTIFICATION_WEBHOOK_URL_INFO=       # Logging/audit channel for info events
+# NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY=false  # If true, fallback URL only receives critical events

--- a/api/aoi_utils.py
+++ b/api/aoi_utils.py
@@ -1,0 +1,28 @@
+"""Shared AOI utility helpers.
+
+Kept in a standalone module so both api.routes.aois and ingest modules can
+import without circular dependencies.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _is_notifications_paused(aoi: dict[str, Any]) -> bool:
+    """Return True if AOI notifications are currently paused.
+
+    The column ``watch_notifications_paused_until`` is NULL when active, or set
+    to a future TIMESTAMPTZ when paused.  A past timestamp means the pause has
+    expired and notifications are treated as active.
+    """
+    paused_until = aoi.get("watch_notifications_paused_until")
+    if paused_until is None:
+        return False
+    if isinstance(paused_until, str):
+        paused_until = datetime.fromisoformat(paused_until)
+    # Normalise to UTC-aware for safe comparison.
+    if paused_until.tzinfo is None:
+        paused_until = paused_until.replace(tzinfo=timezone.utc)
+    return paused_until > datetime.now(timezone.utc)

--- a/api/aois/repo.py
+++ b/api/aois/repo.py
@@ -29,7 +29,8 @@ _AOI_SELECT = """
     watch_alert_threshold,
     watch_last_checked_at,
     watch_last_alerted_at,
-    watch_last_spread_prob
+    watch_last_spread_prob,
+    watch_notifications_paused_until
 """
 
 
@@ -322,6 +323,22 @@ def list_watched_aois_due(now: datetime) -> list[dict[str, Any]]:
         rows = conn.execute(stmt, {"now": now}).mappings().all()
 
     return [dict(r) for r in rows]
+
+
+def set_aoi_notifications_paused_until(
+    aoi_id: UUID,
+    paused_until: Optional[datetime],
+) -> None:
+    """Set or clear the notification pause timestamp for an AOI.
+
+    Pass ``paused_until=None`` to resume notifications immediately.
+    Pass a future UTC-aware datetime to pause until that time.
+    """
+    stmt = text(
+        "UPDATE aois SET watch_notifications_paused_until = :paused_until WHERE id = :aoi_id"
+    )
+    with get_engine().begin() as conn:
+        conn.execute(stmt, {"aoi_id": aoi_id, "paused_until": paused_until})
 
 
 def update_aoi_watch_status(

--- a/api/data_status.py
+++ b/api/data_status.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from typing import Any
 
@@ -9,6 +10,9 @@ from sqlalchemy import Engine, text
 
 from api.config import settings
 from api.db import get_engine
+from api.notifications import notify
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _utc_now() -> datetime:
@@ -583,3 +587,86 @@ def build_data_status_snapshot(
             "lulc": lulc["idempotency"],
         }
     return snapshot
+
+
+def notify_staleness_if_degraded(snapshot: dict[str, Any], aoi_id: str | None = None) -> None:
+    """Fire a user-facing notification when the situational picture is degraded or critical.
+
+    Inspects snapshot["overall_state"] and emits a notification when the state
+    is "critical" (severity="critical") or "degraded" (severity="warning").
+    No notification is emitted for "healthy".
+
+    Args:
+        snapshot:  Output of build_data_status_snapshot(include_internal=True).
+        aoi_id:    AOI that triggered the check, if applicable.
+    """
+    overall_state: str = str(snapshot.get("overall_state", "healthy")).lower()
+    if overall_state not in {"critical", "degraded"}:
+        LOGGER.info("data_status: situational picture is healthy — no staleness notification")
+        return
+
+    # Derive age from the oldest stale source's last_seen_at.
+    stale_sources: list[str] = snapshot.get("stale_sources", [])
+    sources: dict[str, Any] = snapshot.get("sources", {})
+    now = _utc_now()
+
+    oldest_last_seen: datetime | None = None
+    for source_name in stale_sources:
+        source_detail = sources.get(source_name, {})
+        raw_last_seen = source_detail.get("last_seen_at")
+        if raw_last_seen is None:
+            continue
+        # last_seen_at is an ISO string inside the snapshot sources dict.
+        if isinstance(raw_last_seen, str):
+            try:
+                last_seen_dt = datetime.fromisoformat(raw_last_seen)
+                if last_seen_dt.tzinfo is None:
+                    last_seen_dt = last_seen_dt.replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue
+        elif isinstance(raw_last_seen, datetime):
+            last_seen_dt = raw_last_seen
+            if last_seen_dt.tzinfo is None:
+                last_seen_dt = last_seen_dt.replace(tzinfo=timezone.utc)
+        else:
+            continue
+
+        if oldest_last_seen is None or last_seen_dt < oldest_last_seen:
+            oldest_last_seen = last_seen_dt
+
+    if oldest_last_seen is not None:
+        age_hours = round((now - oldest_last_seen).total_seconds() / 3600.0, 1)
+    else:
+        age_hours = 0.0
+
+    identifier = aoi_id if aoi_id else "global"
+
+    if overall_state == "critical":
+        severity = "critical"
+        title = "Situational picture degraded"
+        body = (
+            f"Ground truth data is {age_hours}h old — confidence in current fire positions is reduced."
+        )
+        LOGGER.warning(
+            "data_status: situational picture is CRITICAL — stale sources: %s",
+            stale_sources,
+        )
+    else:
+        severity = "warning"
+        title = "Situational picture may be outdated"
+        body = (
+            f"Ground truth data is {age_hours}h old — confidence in current fire positions is reduced."
+        )
+        LOGGER.warning(
+            "data_status: situational picture is DEGRADED — stale sources: %s",
+            stale_sources,
+        )
+
+    notify(
+        f"picture_stale:{identifier}",
+        title=title,
+        body=body,
+        severity=severity,  # type: ignore[arg-type]
+        stale_sources=stale_sources,
+        aoi_id=aoi_id,
+    )

--- a/api/data_status.py
+++ b/api/data_status.py
@@ -589,6 +589,111 @@ def build_data_status_snapshot(
     return snapshot
 
 
+_SOURCE_DISPLAY_NAMES: dict[str, str] = {
+    "firms": "Satellite detections (FIRMS)",
+    "weather": "Weather forecasts",
+    "perimeters": "Fire perimeters",
+    "terrain": "Terrain data",
+    "lfmc": "Fuel moisture",
+    "lulc": "Land cover",
+}
+
+_BATCH_IMPLICATION_SOURCES = {"terrain", "lfmc", "lulc"}
+
+
+def _format_staleness_body(snapshot: dict[str, Any], overall_state: str) -> str:
+    """Build a source-specific, operationally meaningful notification body.
+
+    Args:
+        snapshot:      Output of build_data_status_snapshot(include_internal=True).
+        overall_state: "critical" or "degraded".
+
+    Returns:
+        A multi-line string suitable for SMS/pager/webhook delivery.
+    """
+    sources: dict[str, Any] = snapshot.get("sources", {})
+    now = _utc_now()
+
+    stale_entries: list[dict[str, Any]] = []
+    fresh_display_names: list[str] = []
+
+    for key, detail in sources.items():
+        is_stale: bool = bool(detail.get("is_stale")) or str(detail.get("state", "")).lower() in {"stale", "missing"}
+        display_name = _SOURCE_DISPLAY_NAMES.get(key, key)
+        raw_last_seen = detail.get("last_seen_at")
+
+        if is_stale:
+            # Parse last_seen_at to compute age.
+            last_seen_dt: datetime | None = None
+            if isinstance(raw_last_seen, str):
+                try:
+                    last_seen_dt = datetime.fromisoformat(raw_last_seen)
+                    if last_seen_dt.tzinfo is None:
+                        last_seen_dt = last_seen_dt.replace(tzinfo=timezone.utc)
+                except ValueError:
+                    last_seen_dt = None
+            elif isinstance(raw_last_seen, datetime):
+                last_seen_dt = raw_last_seen
+                if last_seen_dt.tzinfo is None:
+                    last_seen_dt = last_seen_dt.replace(tzinfo=timezone.utc)
+
+            age_hours = round((now - last_seen_dt).total_seconds() / 3600.0, 1) if last_seen_dt is not None else None
+            last_seen_iso = last_seen_dt.strftime("%H:%M UTC") if last_seen_dt is not None else "unknown"
+            stale_entries.append({
+                "key": key,
+                "display_name": display_name,
+                "age_hours": age_hours,
+                "last_seen_at": last_seen_dt.isoformat() if last_seen_dt is not None else None,
+                "last_seen_hhmm": last_seen_iso,
+            })
+        else:
+            fresh_display_names.append(display_name)
+
+    if overall_state == "critical":
+        opening = "CRITICAL: Ground truth is degraded — fire positions may be significantly out of date."
+    else:
+        opening = "WARNING: Some data sources are outdated — picture may be incomplete."
+
+    lines: list[str] = [opening, "", "Stale data sources:"]
+
+    # Batch-implication sources (terrain/lfmc/lulc) share one implication clause
+    # if multiple are stale, to keep the body concise.
+    batch_stale: list[dict[str, Any]] = []
+    for entry in stale_entries:
+        key = entry["key"]
+        age_str = f"{entry['age_hours']}h old" if entry["age_hours"] is not None else "age unknown"
+
+        if key == "firms":
+            implication = f"new ignitions since {entry['last_seen_hhmm']} may not be visible"
+            lines.append(f"• {entry['display_name']}: {age_str} — {implication}")
+        elif key == "weather":
+            implication = "fire weather context may be outdated"
+            lines.append(f"• {entry['display_name']}: {age_str} — {implication}")
+        elif key == "perimeters":
+            implication = "official containment boundaries may be outdated"
+            lines.append(f"• {entry['display_name']}: {age_str} — {implication}")
+        elif key in _BATCH_IMPLICATION_SOURCES:
+            batch_stale.append(entry)
+        else:
+            # Unknown source — emit a generic line.
+            implication = "forecast accuracy may be reduced"
+            lines.append(f"• {entry['display_name']}: {age_str} — {implication}")
+
+    # Emit batched terrain/lfmc/lulc entries.
+    for entry in batch_stale:
+        age_str = f"{entry['age_hours']}h old" if entry["age_hours"] is not None else "age unknown"
+        lines.append(f"• {entry['display_name']}: {age_str} — forecast accuracy may be reduced")
+
+    if not stale_entries:
+        lines.append("  (none identified)")
+
+    if fresh_display_names:
+        lines.append("")
+        lines.append(f"Active sources: {', '.join(fresh_display_names)}")
+
+    return "\n".join(lines)
+
+
 def notify_staleness_if_degraded(snapshot: dict[str, Any], aoi_id: str | None = None) -> None:
     """Fire a user-facing notification when the situational picture is degraded or critical.
 
@@ -605,58 +710,49 @@ def notify_staleness_if_degraded(snapshot: dict[str, Any], aoi_id: str | None = 
         LOGGER.info("data_status: situational picture is healthy — no staleness notification")
         return
 
-    # Derive age from the oldest stale source's last_seen_at.
     stale_sources: list[str] = snapshot.get("stale_sources", [])
     sources: dict[str, Any] = snapshot.get("sources", {})
     now = _utc_now()
 
-    oldest_last_seen: datetime | None = None
+    # Build stale_source_details for programmatic consumers.
+    stale_source_details: list[dict[str, Any]] = []
     for source_name in stale_sources:
         source_detail = sources.get(source_name, {})
         raw_last_seen = source_detail.get("last_seen_at")
-        if raw_last_seen is None:
-            continue
-        # last_seen_at is an ISO string inside the snapshot sources dict.
+        last_seen_dt: datetime | None = None
         if isinstance(raw_last_seen, str):
             try:
                 last_seen_dt = datetime.fromisoformat(raw_last_seen)
                 if last_seen_dt.tzinfo is None:
                     last_seen_dt = last_seen_dt.replace(tzinfo=timezone.utc)
             except ValueError:
-                continue
+                last_seen_dt = None
         elif isinstance(raw_last_seen, datetime):
             last_seen_dt = raw_last_seen
             if last_seen_dt.tzinfo is None:
                 last_seen_dt = last_seen_dt.replace(tzinfo=timezone.utc)
-        else:
-            continue
 
-        if oldest_last_seen is None or last_seen_dt < oldest_last_seen:
-            oldest_last_seen = last_seen_dt
+        age_hours = round((now - last_seen_dt).total_seconds() / 3600.0, 1) if last_seen_dt is not None else None
+        stale_source_details.append({
+            "source": source_name,
+            "age_hours": age_hours,
+            "last_seen_at": last_seen_dt.isoformat() if last_seen_dt is not None else None,
+        })
 
-    if oldest_last_seen is not None:
-        age_hours = round((now - oldest_last_seen).total_seconds() / 3600.0, 1)
-    else:
-        age_hours = 0.0
-
+    n_stale = len(stale_sources)
     identifier = aoi_id if aoi_id else "global"
+    body = _format_staleness_body(snapshot, overall_state)
 
     if overall_state == "critical":
         severity = "critical"
-        title = "Situational picture degraded"
-        body = (
-            f"Ground truth data is {age_hours}h old — confidence in current fire positions is reduced."
-        )
+        title = f"Situational picture degraded ({n_stale} source{'s' if n_stale != 1 else ''} stale)"
         LOGGER.warning(
             "data_status: situational picture is CRITICAL — stale sources: %s",
             stale_sources,
         )
     else:
         severity = "warning"
-        title = "Situational picture may be outdated"
-        body = (
-            f"Ground truth data is {age_hours}h old — confidence in current fire positions is reduced."
-        )
+        title = f"Situational picture may be outdated ({n_stale} source{'s' if n_stale != 1 else ''} stale)"
         LOGGER.warning(
             "data_status: situational picture is DEGRADED — stale sources: %s",
             stale_sources,
@@ -668,5 +764,6 @@ def notify_staleness_if_degraded(snapshot: dict[str, Any], aoi_id: str | None = 
         body=body,
         severity=severity,  # type: ignore[arg-type]
         stale_sources=stale_sources,
+        stale_source_details=stale_source_details,
         aoi_id=aoi_id,
     )

--- a/api/migrations/versions/20260403_add_aoi_watch_notifications_paused_until.py
+++ b/api/migrations/versions/20260403_add_aoi_watch_notifications_paused_until.py
@@ -1,0 +1,40 @@
+"""add aoi watch_notifications_paused_until column
+
+Revision ID: 20260403_add_aoi_watch_notifications_paused_until
+Revises: d46889070598
+Create Date: 2026-04-03 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "20260403_add_aoi_watch_notifications_paused_until"
+down_revision: Union[str, Sequence[str], None] = "d46889070598"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add watch_notifications_paused_until column to aois table.
+
+    NULL means notifications are active.  A future timestamp means notifications
+    are paused until that time.  A past timestamp is treated as expired (active).
+    """
+    op.add_column(
+        "aois",
+        sa.Column(
+            "watch_notifications_paused_until",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            server_default=None,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove watch_notifications_paused_until column from aois table."""
+    op.drop_column("aois", "watch_notifications_paused_until")

--- a/api/notifications.py
+++ b/api/notifications.py
@@ -261,8 +261,14 @@ def notify(
     body: str,
     severity: Literal["info", "warning", "critical"] = "info",
     **context: Any,
-) -> None:
+) -> bool:
     """Fire-and-forget operational notification. Never blocks the caller.
+
+    Returns:
+        True if the notification was dispatched (scheduled for delivery).
+        False if it was suppressed by burst cap, rate limit, or missing channel config.
+        Callers that maintain transition-gate state (e.g. spread_trajectory_watch) MUST
+        check this return value and only advance gate state when True is returned.
 
     Args:
         event_type: Stable identifier used for rate limiting, e.g. ``"ingest_job_failed:firms"``.
@@ -280,16 +286,16 @@ def notify(
     smtp_host = os.getenv("NOTIFICATION_SMTP_HOST", "").strip()
 
     if not webhook_url and not (email_to and smtp_host):
-        return  # No channel configured — silent no-op
+        return False  # No channel configured — silent no-op
 
     aoi_id: str | None = context.get("aoi_id") or None
     if _check_burst(aoi_id, event_type):
         LOGGER.debug("burst cap suppressed event_type=%s for aoi_id=%s", event_type, aoi_id)
-        return
+        return False
 
     if _is_rate_limited(event_type):
         LOGGER.debug("Notification suppressed by rate limit: %s", event_type)
-        return
+        return False
 
     async def _run() -> None:
         await _dispatch(
@@ -306,3 +312,5 @@ def notify(
             asyncio.run(_run())
 
         threading.Thread(target=_thread, daemon=True).start()
+
+    return True

--- a/api/notifications.py
+++ b/api/notifications.py
@@ -6,7 +6,14 @@ Rate-limited to at most one notification per event_type per window (default 900 
 Silently no-ops when no channel is configured.
 
 Environment variables:
-    NOTIFICATION_WEBHOOK_URL            Slack/Discord-compatible incoming webhook URL.
+    NOTIFICATION_WEBHOOK_URL            Slack/Discord-compatible incoming webhook URL (fallback).
+    NOTIFICATION_WEBHOOK_URL_CRITICAL   Webhook URL for critical-severity events only.
+    NOTIFICATION_WEBHOOK_URL_WARNING    Webhook URL for warning-severity events only.
+    NOTIFICATION_WEBHOOK_URL_INFO       Webhook URL for info-severity events only.
+    NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY
+                                        If "true", the fallback NOTIFICATION_WEBHOOK_URL is only
+                                        used for critical events; info/warning events are dropped
+                                        when no severity-specific URL is configured.
     NOTIFICATION_EMAIL_TO               Recipient address for email alerts.
     NOTIFICATION_SMTP_HOST              SMTP server hostname (required for email).
     NOTIFICATION_SMTP_PORT              SMTP port (default: 587).
@@ -49,6 +56,36 @@ _BURST_EXEMPT_PREFIXES: tuple[str, ...] = (
     "denoiser_drift_hard",
     "burst_digest:",
 )
+
+
+# ROUTING ARCHITECTURE (mvp_operational → science_grade):
+# Current implementation supports severity-based channel routing via env vars.
+# Target: per-AOI channel configuration stored in the aois table, allowing
+# incident commanders to configure separate Slack channels per AOI or fire event.
+# See audit gap: "No routing architecture — all notifications go to one global webhook."
+
+
+def _resolve_webhook_url(severity: str) -> str | None:
+    """Return the webhook URL to use for a given severity level.
+
+    Checks severity-specific URL first, falls back to NOTIFICATION_WEBHOOK_URL.
+    Returns None if no webhook is configured for this severity.
+    """
+    specific = {
+        "critical": os.getenv("NOTIFICATION_WEBHOOK_URL_CRITICAL", "").strip(),
+        "warning": os.getenv("NOTIFICATION_WEBHOOK_URL_WARNING", "").strip(),
+        "info": os.getenv("NOTIFICATION_WEBHOOK_URL_INFO", "").strip(),
+    }.get(severity, "")
+
+    if specific:
+        return specific
+
+    critical_only = os.getenv("NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY", "").strip().lower() == "true"
+    if critical_only and severity != "critical":
+        return None  # suppress non-critical when in critical-only mode
+
+    fallback = os.getenv("NOTIFICATION_WEBHOOK_URL", "").strip()
+    return fallback if fallback else None
 
 
 def _rate_limit_seconds() -> int:
@@ -127,7 +164,7 @@ async def _dispatch(
     body: str,
     severity: Literal["info", "warning", "critical"],
     context: dict[str, Any],
-    webhook_url: str,
+    webhook_url: str | None,
     email_to: str,
     smtp_host: str,
 ) -> None:
@@ -238,7 +275,7 @@ def notify(
     Rate-limited: at most one notification per *event_type* per ``NOTIFICATION_RATE_LIMIT_SECONDS``
     (default 900 s / 15 min).
     """
-    webhook_url = os.getenv("NOTIFICATION_WEBHOOK_URL", "").strip()
+    webhook_url = _resolve_webhook_url(severity)
     email_to = os.getenv("NOTIFICATION_EMAIL_TO", "").strip()
     smtp_host = os.getenv("NOTIFICATION_SMTP_HOST", "").strip()
 

--- a/api/notifications.py
+++ b/api/notifications.py
@@ -6,14 +6,16 @@ Rate-limited to at most one notification per event_type per window (default 900 
 Silently no-ops when no channel is configured.
 
 Environment variables:
-    NOTIFICATION_WEBHOOK_URL          Slack/Discord-compatible incoming webhook URL.
-    NOTIFICATION_EMAIL_TO             Recipient address for email alerts.
-    NOTIFICATION_SMTP_HOST            SMTP server hostname (required for email).
-    NOTIFICATION_SMTP_PORT            SMTP port (default: 587).
-    NOTIFICATION_SMTP_USER            SMTP username (optional).
-    NOTIFICATION_SMTP_PASSWORD        SMTP password (optional).
-    NOTIFICATION_EMAIL_FROM           Sender address (default: wildfire-nowcast@localhost).
-    NOTIFICATION_RATE_LIMIT_SECONDS   Per-event rate-limit window in seconds (default: 900).
+    NOTIFICATION_WEBHOOK_URL            Slack/Discord-compatible incoming webhook URL.
+    NOTIFICATION_EMAIL_TO               Recipient address for email alerts.
+    NOTIFICATION_SMTP_HOST              SMTP server hostname (required for email).
+    NOTIFICATION_SMTP_PORT              SMTP port (default: 587).
+    NOTIFICATION_SMTP_USER              SMTP username (optional).
+    NOTIFICATION_SMTP_PASSWORD          SMTP password (optional).
+    NOTIFICATION_EMAIL_FROM             Sender address (default: wildfire-nowcast@localhost).
+    NOTIFICATION_RATE_LIMIT_SECONDS     Per-event rate-limit window in seconds (default: 900).
+    NOTIFICATION_BURST_CAP              Max distinct event_types per AOI per burst window (default: 3).
+    NOTIFICATION_BURST_WINDOW_SECONDS   Burst-tracking window in seconds (default: 60).
 """
 from __future__ import annotations
 
@@ -32,6 +34,21 @@ LOGGER = logging.getLogger(__name__)
 
 _rate_limit_lock = threading.Lock()
 _last_sent: dict[str, float] = {}
+
+_BURST_CAP: int = int(os.getenv("NOTIFICATION_BURST_CAP", "3"))
+_BURST_WINDOW_SECONDS: int = int(os.getenv("NOTIFICATION_BURST_WINDOW_SECONDS", "60"))
+
+# aoi_id → list of (sent_at_monotonic, event_type)
+_burst_tracker: dict[str, list[tuple[float, str]]] = {}
+_burst_tracker_lock = threading.Lock()
+
+# Infrastructure / digest event_type prefixes that are never burst-capped.
+_BURST_EXEMPT_PREFIXES: tuple[str, ...] = (
+    "ingest_job_failed",
+    "data_stale_critical",
+    "denoiser_drift_hard",
+    "burst_digest:",
+)
 
 
 def _rate_limit_seconds() -> int:
@@ -145,6 +162,62 @@ async def _dispatch(
             LOGGER.exception("Email notification failed (non-fatal): event_type=%s", event_type)
 
 
+def _schedule_digest(aoi_id: str, count: int) -> None:
+    """Fire-and-forget a single burst-digest notification for *aoi_id*."""
+    notify(
+        event_type=f"burst_digest:{aoi_id}",
+        title=f"Multiple alerts for AOI {aoi_id}",
+        body=f"{count} simultaneous events detected. Check dashboard for details.",
+        severity="warning",
+        aoi_id=aoi_id,
+        suppressed_count=count,
+    )
+
+
+def _check_burst(aoi_id: str | None, event_type: str) -> bool:
+    """Return True if this event should be suppressed due to the per-AOI burst cap.
+
+    Non-AOI events (aoi_id is None or empty) and infrastructure event types are
+    never burst-capped and always return False.
+    """
+    if not aoi_id:
+        return False
+
+    if any(event_type.startswith(prefix) for prefix in _BURST_EXEMPT_PREFIXES):
+        return False
+
+    now = time.monotonic()
+    with _burst_tracker_lock:
+        entries = _burst_tracker.get(aoi_id, [])
+        # Prune stale entries outside the window.
+        entries = [(t, et) for (t, et) in entries if now - t < _BURST_WINDOW_SECONDS]
+        _burst_tracker[aoi_id] = entries
+
+        distinct_types = {et for (_, et) in entries}
+        count = len(distinct_types)
+
+        if count < _BURST_CAP:
+            # Under cap — allow and record.
+            entries.append((now, event_type))
+            _burst_tracker[aoi_id] = entries
+            return False
+
+        if count == _BURST_CAP:
+            # Exactly at cap — this event tips us over; record it then digest.
+            entries.append((now, event_type))
+            _burst_tracker[aoi_id] = entries
+            total = len({et for (_, et) in entries})
+            # Schedule digest outside the lock to avoid re-entrant locking.
+            digest_count = total
+        else:
+            # Already over cap — suppress silently; digest already sent.
+            return True
+
+    # We reach here only when count == _BURST_CAP (first overflow).
+    _schedule_digest(aoi_id, digest_count)
+    return True
+
+
 def notify(
     event_type: str,
     title: str,
@@ -171,6 +244,11 @@ def notify(
 
     if not webhook_url and not (email_to and smtp_host):
         return  # No channel configured — silent no-op
+
+    aoi_id: str | None = context.get("aoi_id") or None
+    if _check_burst(aoi_id, event_type):
+        LOGGER.debug("burst cap suppressed event_type=%s for aoi_id=%s", event_type, aoi_id)
+        return
 
     if _is_rate_limited(event_type):
         LOGGER.debug("Notification suppressed by rate limit: %s", event_type)

--- a/api/routes/aois.py
+++ b/api/routes/aois.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 from uuid import UUID
 
@@ -37,6 +38,11 @@ class UpdateAOIRequest(BaseModel):
     geometry: Optional[dict[str, Any]] = None
     description: Optional[str] = None
     tags: Optional[dict[str, Any]] = None
+
+
+class PauseNotificationsRequest(BaseModel):
+    duration_hours: Annotated[float, Field(ge=0.5, le=168.0)]
+    reason: Optional[str] = None
 
 
 class WatchConfigRequest(BaseModel):
@@ -296,3 +302,39 @@ def delete_aoi(aoi_id: UUID):
     """Delete an AOI."""
     if not repo.delete_aoi(aoi_id):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="AOI not found")
+
+
+@aois_router.post("/{aoi_id}/pause-notifications", dependencies=[Depends(no_cache)])
+def pause_notifications(aoi_id: UUID, request: PauseNotificationsRequest):
+    """Pause watch notifications for an AOI for the given duration.
+
+    Notifications are suppressed until the pause expires; monitoring (forecasts,
+    watermarks) continues uninterrupted.
+    """
+    aoi = repo.get_aoi(aoi_id)
+    if not aoi:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="AOI not found")
+
+    paused_until = datetime.now(timezone.utc) + timedelta(hours=request.duration_hours)
+    repo.set_aoi_notifications_paused_until(aoi_id, paused_until)
+
+    return {
+        "aoi_id": str(aoi_id),
+        "paused_until": paused_until.isoformat(),
+        "reason": request.reason,
+    }
+
+
+@aois_router.post("/{aoi_id}/resume-notifications", dependencies=[Depends(no_cache)])
+def resume_notifications(aoi_id: UUID):
+    """Resume watch notifications for an AOI by clearing any active pause."""
+    aoi = repo.get_aoi(aoi_id)
+    if not aoi:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="AOI not found")
+
+    repo.set_aoi_notifications_paused_until(aoi_id, None)
+
+    return {
+        "aoi_id": str(aoi_id),
+        "resumed_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/api/tests/test_aoi_pause_routes.py
+++ b/api/tests/test_aoi_pause_routes.py
@@ -1,0 +1,188 @@
+"""Tests for per-AOI notification pause/resume endpoints and helper."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+import api.routes.aois as aois_routes
+from api.aoi_utils import _is_notifications_paused
+from api.main import app
+
+client = TestClient(app)
+
+_NOW_STR = "2026-04-03T12:00:00+00:00"
+
+_BASE_AOI = {
+    "id": None,  # overridden per test
+    "name": "Test AOI",
+    "description": None,
+    "tags": None,
+    "owner_id": None,
+    "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]},
+    "bbox": {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]},
+    "area_km2": 100.0,
+    "vertex_count": 5,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z",
+    "watch_enabled": True,
+    "watch_interval_minutes": 30,
+    "watch_alert_threshold": 0.5,
+    "watch_last_checked_at": None,
+    "watch_last_alerted_at": None,
+    "watch_last_spread_prob": None,
+    "watch_notifications_paused_until": None,
+}
+
+
+def _make_aoi(**overrides):
+    aoi = dict(_BASE_AOI)
+    aoi["id"] = uuid4()
+    aoi.update(overrides)
+    return aoi
+
+
+# ── POST /aois/{aoi_id}/pause-notifications ───────────────────────────────────
+
+def test_pause_sets_paused_until(monkeypatch):
+    """POST pause with 4h → response contains paused_until ~4h from now."""
+    aoi = _make_aoi()
+    monkeypatch.setattr(aois_routes.repo, "get_aoi", MagicMock(return_value=aoi))
+    mock_set = MagicMock()
+    monkeypatch.setattr(aois_routes.repo, "set_aoi_notifications_paused_until", mock_set)
+
+    response = client.post(
+        f"/aois/{aoi['id']}/pause-notifications",
+        json={"duration_hours": 4.0, "reason": "Known prescribed burn"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["aoi_id"] == str(aoi["id"])
+    assert data["reason"] == "Known prescribed burn"
+
+    # paused_until should be ~4h from now (allow ±60s slop)
+    paused_until = datetime.fromisoformat(data["paused_until"])
+    expected = datetime.now(timezone.utc) + timedelta(hours=4)
+    assert abs((paused_until - expected).total_seconds()) < 60
+
+    # Repo function must have been called with a future timestamp
+    mock_set.assert_called_once()
+    call_args = mock_set.call_args[0]
+    assert call_args[1] > datetime.now(timezone.utc)
+
+
+def test_pause_rejects_duration_over_168h(monkeypatch):
+    """duration=200 exceeds the 168h maximum → 422 Unprocessable Entity."""
+    aoi = _make_aoi()
+    monkeypatch.setattr(aois_routes.repo, "get_aoi", MagicMock(return_value=aoi))
+
+    response = client.post(
+        f"/aois/{aoi['id']}/pause-notifications",
+        json={"duration_hours": 200.0},
+    )
+
+    assert response.status_code == 422
+
+
+def test_pause_rejects_duration_below_minimum(monkeypatch):
+    """duration=0.1 is below the 0.5h minimum → 422 Unprocessable Entity."""
+    aoi = _make_aoi()
+    monkeypatch.setattr(aois_routes.repo, "get_aoi", MagicMock(return_value=aoi))
+
+    response = client.post(
+        f"/aois/{aoi['id']}/pause-notifications",
+        json={"duration_hours": 0.1},
+    )
+
+    assert response.status_code == 422
+
+
+def test_pause_404_for_unknown_aoi(monkeypatch):
+    """Unknown aoi_id → 404."""
+    monkeypatch.setattr(aois_routes.repo, "get_aoi", MagicMock(return_value=None))
+
+    response = client.post(
+        f"/aois/{uuid4()}/pause-notifications",
+        json={"duration_hours": 2.0},
+    )
+
+    assert response.status_code == 404
+
+
+# ── POST /aois/{aoi_id}/resume-notifications ─────────────────────────────────
+
+def test_resume_clears_paused_until(monkeypatch):
+    """POST resume → repo is called with None to clear the pause."""
+    aoi = _make_aoi(
+        watch_notifications_paused_until=(
+            datetime.now(timezone.utc) + timedelta(hours=2)
+        ).isoformat()
+    )
+    monkeypatch.setattr(aois_routes.repo, "get_aoi", MagicMock(return_value=aoi))
+    mock_set = MagicMock()
+    monkeypatch.setattr(aois_routes.repo, "set_aoi_notifications_paused_until", mock_set)
+
+    response = client.post(f"/aois/{aoi['id']}/resume-notifications")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["aoi_id"] == str(aoi["id"])
+    assert "resumed_at" in data
+
+    # Repo must be called with None to clear the pause
+    mock_set.assert_called_once()
+    call_args = mock_set.call_args[0]
+    assert call_args[1] is None
+
+
+def test_resume_404_for_unknown_aoi(monkeypatch):
+    """Unknown aoi_id → 404."""
+    monkeypatch.setattr(aois_routes.repo, "get_aoi", MagicMock(return_value=None))
+
+    response = client.post(f"/aois/{uuid4()}/resume-notifications")
+
+    assert response.status_code == 404
+
+
+# ── _is_notifications_paused helper ──────────────────────────────────────────
+
+def test_is_notifications_paused_future():
+    """paused_until in the future → True."""
+    aoi = {"watch_notifications_paused_until": datetime.now(timezone.utc) + timedelta(hours=2)}
+    assert _is_notifications_paused(aoi) is True
+
+
+def test_is_notifications_paused_past():
+    """paused_until in the past → False (pause expired)."""
+    aoi = {"watch_notifications_paused_until": datetime.now(timezone.utc) - timedelta(hours=1)}
+    assert _is_notifications_paused(aoi) is False
+
+
+def test_is_notifications_paused_none():
+    """paused_until = None → False (notifications active)."""
+    aoi = {"watch_notifications_paused_until": None}
+    assert _is_notifications_paused(aoi) is False
+
+
+def test_is_notifications_paused_string_future():
+    """paused_until as ISO string in the future → True."""
+    future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    aoi = {"watch_notifications_paused_until": future}
+    assert _is_notifications_paused(aoi) is True
+
+
+def test_is_notifications_paused_string_past():
+    """paused_until as ISO string in the past → False."""
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    aoi = {"watch_notifications_paused_until": past}
+    assert _is_notifications_paused(aoi) is False
+
+
+def test_is_notifications_paused_missing_key():
+    """AOI with no paused_until key → False (treat as active)."""
+    aoi = {}
+    assert _is_notifications_paused(aoi) is False

--- a/api/tests/test_data_staleness_user.py
+++ b/api/tests/test_data_staleness_user.py
@@ -1,0 +1,223 @@
+"""Tests for notify_staleness_if_degraded in api.data_status."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+
+from api.data_status import notify_staleness_if_degraded
+
+_NOW = datetime(2026, 4, 3, 12, 0, 0, tzinfo=timezone.utc)
+_STALE_SINCE = (_NOW - timedelta(hours=4)).isoformat()
+
+
+def _make_snapshot(
+    overall_state: str = "healthy",
+    stale_sources: list[str] | None = None,
+    sources: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal snapshot dict suitable for notify_staleness_if_degraded."""
+    if stale_sources is None:
+        stale_sources = []
+    if sources is None:
+        sources = {
+            src: {"last_seen_at": _STALE_SINCE, "state": "stale", "is_stale": True}
+            for src in stale_sources
+        }
+    return {
+        "overall_state": overall_state,
+        "stale_sources": stale_sources,
+        "critical_stale_sources": stale_sources if overall_state == "critical" else [],
+        "sources": sources,
+        "as_of": _NOW.isoformat(),
+    }
+
+
+# ── critical state → notify with severity "critical" ──────────────────────────
+
+
+def test_critical_state_emits_critical_notification() -> None:
+    """overall_state='critical' fires notify() with severity='critical'."""
+    snapshot = _make_snapshot(
+        overall_state="critical",
+        stale_sources=["firms", "weather"],
+    )
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot, aoi_id=None)
+
+    mock_notify.assert_called_once()
+    call_args = mock_notify.call_args.args
+    call_kwargs = mock_notify.call_args.kwargs
+
+    # First positional arg is event_type.
+    event_type = call_args[0] if call_args else call_kwargs.get("event_type", "")
+    assert "picture_stale" in event_type
+
+    assert call_kwargs.get("severity") == "critical"
+
+
+def test_critical_state_event_type_uses_global_when_no_aoi() -> None:
+    """When aoi_id is None, event_type contains 'global'."""
+    snapshot = _make_snapshot(overall_state="critical", stale_sources=["firms"])
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot, aoi_id=None)
+
+    call_args = mock_notify.call_args.args
+    event_type = call_args[0]
+    assert event_type == "picture_stale:global"
+
+
+def test_critical_state_event_type_uses_aoi_id_when_provided() -> None:
+    """When aoi_id is set, event_type contains the aoi_id."""
+    snapshot = _make_snapshot(overall_state="critical", stale_sources=["firms"])
+    aoi_id = "aoi-42"
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot, aoi_id=aoi_id)
+
+    call_args = mock_notify.call_args.args
+    event_type = call_args[0]
+    assert event_type == f"picture_stale:{aoi_id}"
+
+
+# ── degraded state → notify with severity "warning" ───────────────────────────
+
+
+def test_degraded_state_emits_warning_notification() -> None:
+    """overall_state='degraded' fires notify() with severity='warning'."""
+    snapshot = _make_snapshot(
+        overall_state="degraded",
+        stale_sources=["lfmc"],
+    )
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot, aoi_id=None)
+
+    mock_notify.assert_called_once()
+    call_kwargs = mock_notify.call_args.kwargs
+    assert call_kwargs.get("severity") == "warning"
+
+
+def test_degraded_state_title_indicates_may_be_outdated() -> None:
+    """Degraded title mentions 'may be outdated'."""
+    snapshot = _make_snapshot(overall_state="degraded", stale_sources=["lfmc"])
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot)
+
+    call_kwargs = mock_notify.call_args.kwargs
+    title = call_kwargs.get("title", "")
+    assert "outdated" in title.lower() or "updated" in title.lower() or "may" in title.lower()
+
+
+# ── healthy state → notify not called ─────────────────────────────────────────
+
+
+def test_healthy_state_does_not_notify() -> None:
+    """overall_state='healthy' must not trigger any notification."""
+    snapshot = _make_snapshot(overall_state="healthy", stale_sources=[])
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot)
+
+    mock_notify.assert_not_called()
+
+
+def test_healthy_state_with_aoi_id_does_not_notify() -> None:
+    """Healthy state suppresses notification even when aoi_id is supplied."""
+    snapshot = _make_snapshot(overall_state="healthy")
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot, aoi_id="aoi-99")
+
+    mock_notify.assert_not_called()
+
+
+# ── stale_sources included in context ─────────────────────────────────────────
+
+
+def test_stale_sources_list_passed_in_context() -> None:
+    """stale_sources is forwarded as a context field to notify()."""
+    stale = ["firms", "weather", "perimeters"]
+    snapshot = _make_snapshot(overall_state="critical", stale_sources=stale)
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot)
+
+    call_kwargs = mock_notify.call_args.kwargs
+    assert call_kwargs.get("stale_sources") == stale
+
+
+def test_empty_stale_sources_passed_in_context() -> None:
+    """Empty stale_sources list is forwarded as-is (critical with no named sources)."""
+    snapshot = _make_snapshot(overall_state="critical", stale_sources=[])
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot)
+
+    mock_notify.assert_called_once()
+    call_kwargs = mock_notify.call_args.kwargs
+    assert call_kwargs.get("stale_sources") == []
+
+
+# ── aoi_id context field ───────────────────────────────────────────────────────
+
+
+def test_aoi_id_forwarded_in_context() -> None:
+    """aoi_id kwarg is passed through as a notify() context field."""
+    snapshot = _make_snapshot(overall_state="critical", stale_sources=["firms"])
+    aoi_id = "some-aoi-uuid"
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot, aoi_id=aoi_id)
+
+    call_kwargs = mock_notify.call_args.kwargs
+    assert call_kwargs.get("aoi_id") == aoi_id
+
+
+def test_aoi_id_none_forwarded_in_context() -> None:
+    """aoi_id=None is still passed as context so callers can rely on its presence."""
+    snapshot = _make_snapshot(overall_state="critical", stale_sources=["firms"])
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot, aoi_id=None)
+
+    call_kwargs = mock_notify.call_args.kwargs
+    assert "aoi_id" in call_kwargs
+    assert call_kwargs["aoi_id"] is None
+
+
+# ── age computation ────────────────────────────────────────────────────────────
+
+
+def test_age_appears_in_body() -> None:
+    """The notification body mentions the data age in hours."""
+    stale_since = (datetime.now(timezone.utc) - timedelta(hours=6)).isoformat()
+    snapshot = _make_snapshot(
+        overall_state="critical",
+        stale_sources=["firms"],
+        sources={"firms": {"last_seen_at": stale_since, "state": "stale", "is_stale": True}},
+    )
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot)
+
+    call_kwargs = mock_notify.call_args.kwargs
+    body = call_kwargs.get("body", "")
+    assert "h old" in body or "hour" in body

--- a/api/tests/test_data_staleness_user.py
+++ b/api/tests/test_data_staleness_user.py
@@ -221,3 +221,174 @@ def test_age_appears_in_body() -> None:
     call_kwargs = mock_notify.call_args.kwargs
     body = call_kwargs.get("body", "")
     assert "h old" in body or "hour" in body
+
+
+# ── source-specific body generation ───────────────────────────────────────────
+
+
+def _firms_stale_snapshot(overall_state: str = "critical") -> dict[str, Any]:
+    """Snapshot with only FIRMS stale, everything else fresh."""
+    firms_last_seen = datetime(2026, 4, 3, 9, 30, 0, tzinfo=timezone.utc).isoformat()
+    fresh_last_seen = datetime(2026, 4, 3, 11, 55, 0, tzinfo=timezone.utc).isoformat()
+    return {
+        "overall_state": overall_state,
+        "stale_sources": ["firms"],
+        "critical_stale_sources": ["firms"] if overall_state == "critical" else [],
+        "as_of": _NOW.isoformat(),
+        "sources": {
+            "firms": {"last_seen_at": firms_last_seen, "state": "stale", "is_stale": True},
+            "weather": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+            "perimeters": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+            "terrain": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+            "lfmc": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+            "lulc": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+        },
+    }
+
+
+def test_critical_body_names_stale_source() -> None:
+    """critical snapshot with FIRMS stale → body contains human name and UTC timestamp."""
+    snapshot = _firms_stale_snapshot(overall_state="critical")
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot)
+
+    body = mock_notify.call_args.kwargs.get("body", "")
+    assert "Satellite detections (FIRMS)" in body
+    assert "09:" in body  # UTC time reference for last_seen 09:30 UTC
+
+
+def test_degraded_body_lists_stale_and_fresh_sources() -> None:
+    """degraded snapshot with weather stale, firms fresh → body separates stale from active."""
+    fresh_last_seen = datetime(2026, 4, 3, 11, 55, 0, tzinfo=timezone.utc).isoformat()
+    weather_last_seen = datetime(2026, 4, 3, 9, 0, 0, tzinfo=timezone.utc).isoformat()
+    snapshot = {
+        "overall_state": "degraded",
+        "stale_sources": ["weather"],
+        "critical_stale_sources": [],
+        "as_of": _NOW.isoformat(),
+        "sources": {
+            "firms": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+            "weather": {"last_seen_at": weather_last_seen, "state": "stale", "is_stale": True},
+            "perimeters": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+            "terrain": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+            "lfmc": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+            "lulc": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+        },
+    }
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot)
+
+    body = mock_notify.call_args.kwargs.get("body", "")
+    assert "Weather forecasts" in body
+    # Weather must appear in the stale section (bullet point)
+    assert "•" in body and "Weather forecasts" in body
+    # Firms must appear in the active sources line
+    assert "Active sources" in body
+    assert "Satellite detections (FIRMS)" in body
+
+
+def test_critical_title_includes_source_count() -> None:
+    """critical with 2 stale sources → title contains '2'."""
+    stale_last_seen = datetime(2026, 4, 3, 8, 0, 0, tzinfo=timezone.utc).isoformat()
+    snapshot = {
+        "overall_state": "critical",
+        "stale_sources": ["firms", "weather"],
+        "critical_stale_sources": ["firms", "weather"],
+        "as_of": _NOW.isoformat(),
+        "sources": {
+            "firms": {"last_seen_at": stale_last_seen, "state": "stale", "is_stale": True},
+            "weather": {"last_seen_at": stale_last_seen, "state": "stale", "is_stale": True},
+        },
+    }
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot)
+
+    title = mock_notify.call_args.kwargs.get("title", "")
+    assert "2" in title
+
+
+def test_body_operational_implication_firms() -> None:
+    """FIRMS stale → body mentions 'new ignitions'."""
+    snapshot = _firms_stale_snapshot(overall_state="critical")
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot)
+
+    body = mock_notify.call_args.kwargs.get("body", "")
+    assert "new ignitions" in body
+
+
+def test_body_operational_implication_perimeters() -> None:
+    """Perimeters stale → body mentions 'containment boundaries'."""
+    fresh_last_seen = datetime(2026, 4, 3, 11, 55, 0, tzinfo=timezone.utc).isoformat()
+    perimeters_last_seen = datetime(2026, 4, 3, 8, 0, 0, tzinfo=timezone.utc).isoformat()
+    snapshot = {
+        "overall_state": "degraded",
+        "stale_sources": ["perimeters"],
+        "critical_stale_sources": [],
+        "as_of": _NOW.isoformat(),
+        "sources": {
+            "firms": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+            "weather": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+            "perimeters": {"last_seen_at": perimeters_last_seen, "state": "stale", "is_stale": True},
+            "terrain": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+            "lfmc": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+            "lulc": {"last_seen_at": fresh_last_seen, "state": "fresh", "is_stale": False},
+        },
+    }
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot)
+
+    body = mock_notify.call_args.kwargs.get("body", "")
+    assert "containment boundaries" in body
+
+
+def test_body_no_fresh_sources_section_when_all_stale() -> None:
+    """All sources stale → no 'Active sources' line in body."""
+    stale_last_seen = datetime(2026, 4, 3, 6, 0, 0, tzinfo=timezone.utc).isoformat()
+    sources = {
+        key: {"last_seen_at": stale_last_seen, "state": "stale", "is_stale": True}
+        for key in ("firms", "weather", "perimeters", "terrain", "lfmc", "lulc")
+    }
+    snapshot = {
+        "overall_state": "critical",
+        "stale_sources": list(sources.keys()),
+        "critical_stale_sources": list(sources.keys()),
+        "as_of": _NOW.isoformat(),
+        "sources": sources,
+    }
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot)
+
+    body = mock_notify.call_args.kwargs.get("body", "")
+    assert "Active sources" not in body
+
+
+def test_stale_source_details_in_kwargs() -> None:
+    """notify() receives stale_source_details as a list of dicts with required keys."""
+    snapshot = _firms_stale_snapshot(overall_state="critical")
+    mock_notify = MagicMock()
+
+    with patch("api.data_status.notify", mock_notify):
+        notify_staleness_if_degraded(snapshot)
+
+    call_kwargs = mock_notify.call_args.kwargs
+    assert "stale_source_details" in call_kwargs
+    details = call_kwargs["stale_source_details"]
+    assert isinstance(details, list)
+    assert len(details) == 1
+    detail = details[0]
+    assert detail["source"] == "firms"
+    assert isinstance(detail["age_hours"], float)
+    assert "last_seen_at" in detail

--- a/api/tests/test_notifications.py
+++ b/api/tests/test_notifications.py
@@ -10,6 +10,8 @@ from unittest.mock import AsyncMock, patch
 import api.notifications as notif
 from api.notifications import (
     _build_webhook_payload,
+    _burst_tracker,
+    _check_burst,
     _dispatch,
     _is_rate_limited,
     _last_sent,
@@ -189,3 +191,123 @@ class TestNotifyDispatch(unittest.TestCase):
             with patch("api.notifications._post_webhook", new_callable=AsyncMock):
                 notify("ev_sync", "Title", "Body")
                 time.sleep(0.05)  # give the daemon thread time to finish
+
+
+class TestBurstCap(unittest.TestCase):
+    """Per-AOI burst cap suppresses excess simultaneous alerts."""
+
+    def setUp(self):
+        _last_sent.clear()
+        _burst_tracker.clear()
+        # Use a cap of 3 and a large window so tests are deterministic.
+        notif._BURST_CAP = 3
+        notif._BURST_WINDOW_SECONDS = 60
+
+    def tearDown(self):
+        _burst_tracker.clear()
+        _last_sent.clear()
+        # Restore module defaults (env may not be set in tests).
+        notif._BURST_CAP = int(os.getenv("NOTIFICATION_BURST_CAP", "3"))
+        notif._BURST_WINDOW_SECONDS = int(os.getenv("NOTIFICATION_BURST_WINDOW_SECONDS", "60"))
+
+    # ------------------------------------------------------------------
+    # _check_burst unit tests (no I/O, no webhook)
+    # ------------------------------------------------------------------
+
+    def test_burst_cap_allows_first_n_alerts(self):
+        """First _BURST_CAP distinct event_types for the same aoi_id are allowed."""
+        aoi = "aoi-allows"
+        self.assertFalse(_check_burst(aoi, "new_ignition"))
+        self.assertFalse(_check_burst(aoi, "perimeter_breach"))
+        self.assertFalse(_check_burst(aoi, "perimeter_growth"))
+        # Exactly at cap after third — still not suppressed until the 4th.
+        # (The 4th is what triggers suppression.)
+
+    def test_burst_cap_suppresses_nth_plus_one(self):
+        """The (cap+1)th distinct event_type within the window is suppressed."""
+        aoi = "aoi-suppress"
+        _check_burst(aoi, "new_ignition")
+        _check_burst(aoi, "perimeter_breach")
+        _check_burst(aoi, "perimeter_growth")
+        # 4th event tips over the cap → suppressed
+        result = _check_burst(aoi, "spread_trajectory")
+        self.assertTrue(result)
+
+    def test_burst_cap_independent_per_aoi(self):
+        """Burst counts are tracked independently per aoi_id.
+
+        3 events on aoi-1 and 3 events on aoi-2 are each allowed (counts don't
+        bleed across AOIs).  A 4th event on aoi-1 is suppressed without affecting
+        aoi-3, which has only 1 event and must still be allowed.
+        """
+        for et in ("new_ignition", "perimeter_breach", "perimeter_growth"):
+            self.assertFalse(_check_burst("aoi-indep-1", et))
+            self.assertFalse(_check_burst("aoi-indep-2", et))
+        # aoi-indep-1 is at cap — 4th event is suppressed.
+        self.assertTrue(_check_burst("aoi-indep-1", "spread_trajectory"))
+        # aoi-indep-3 has had no events — must not be affected by aoi-indep-1's cap.
+        self.assertFalse(_check_burst("aoi-indep-3", "new_ignition"))
+
+    def test_burst_cap_resets_after_window(self):
+        """After the window expires, a fresh batch of alerts is allowed."""
+        aoi = "aoi-reset"
+        # Fill the window.
+        _check_burst(aoi, "new_ignition")
+        _check_burst(aoi, "perimeter_breach")
+        _check_burst(aoi, "perimeter_growth")
+        # Backdate all entries far into the past so they expire.
+        expired_time = time.monotonic() - 99999
+        notif._burst_tracker[aoi] = [
+            (expired_time, et) for (_, et) in notif._burst_tracker[aoi]
+        ]
+        # First three of a fresh batch must be allowed.
+        self.assertFalse(_check_burst(aoi, "new_ignition"))
+        self.assertFalse(_check_burst(aoi, "perimeter_breach"))
+        self.assertFalse(_check_burst(aoi, "perimeter_growth"))
+
+    def test_burst_cap_skipped_for_none_aoi_id(self):
+        """Events with no aoi_id are never burst-capped."""
+        for _ in range(10):
+            self.assertFalse(_check_burst(None, "new_ignition"))
+            self.assertFalse(_check_burst("", "new_ignition"))
+
+    def test_burst_cap_skipped_for_infrastructure_events(self):
+        """Infrastructure event types are never burst-capped even with an aoi_id."""
+        aoi = "aoi-infra"
+        for _ in range(10):
+            self.assertFalse(_check_burst(aoi, "ingest_job_failed"))
+            self.assertFalse(_check_burst(aoi, "data_stale_critical"))
+            self.assertFalse(_check_burst(aoi, "denoiser_drift_hard"))
+            self.assertFalse(_check_burst(aoi, "burst_digest:aoi-infra"))
+
+    # ------------------------------------------------------------------
+    # Integration test: notify() + webhook dispatch
+    # ------------------------------------------------------------------
+
+    def test_digest_sent_on_cap_exceeded(self):
+        """When cap is exceeded, a digest notification is dispatched with the correct event_type."""
+        aoi = "aoi-digest"
+        dispatched: list[str] = []
+
+        async def run():
+            _last_sent.clear()
+            _burst_tracker.clear()
+            with patch.dict(os.environ, {"NOTIFICATION_WEBHOOK_URL": "http://fake/hook"}):
+                with patch("api.notifications._post_webhook", new_callable=AsyncMock) as mock_post:
+                    mock_post.side_effect = lambda url, payload: dispatched.append(
+                        payload["attachments"][0]["title"]
+                    )
+                    # Send cap events — all should proceed.
+                    for et in ("new_ignition", "perimeter_breach", "perimeter_growth"):
+                        notify(et, "Title", "Body", aoi_id=aoi)
+                    await asyncio.sleep(0.1)
+                    # 4th event tips over the cap → suppressed; digest fires instead.
+                    notify("spread_trajectory", "Title", "Body", aoi_id=aoi)
+                    await asyncio.sleep(0.1)
+
+            # 3 real alerts + 1 digest (burst_digest:aoi-digest).
+            self.assertEqual(len(dispatched), 4)
+            digest_titles = [t for t in dispatched if "Multiple alerts" in t]
+            self.assertEqual(len(digest_titles), 1)
+
+        asyncio.run(run())

--- a/api/tests/test_notifications.py
+++ b/api/tests/test_notifications.py
@@ -15,6 +15,7 @@ from api.notifications import (
     _dispatch,
     _is_rate_limited,
     _last_sent,
+    _resolve_webhook_url,
     notify,
 )
 
@@ -309,5 +310,207 @@ class TestBurstCap(unittest.TestCase):
             self.assertEqual(len(dispatched), 4)
             digest_titles = [t for t in dispatched if "Multiple alerts" in t]
             self.assertEqual(len(digest_titles), 1)
+
+        asyncio.run(run())
+
+
+class TestResolveWebhookUrl(unittest.TestCase):
+    """Unit tests for _resolve_webhook_url severity-based channel routing."""
+
+    _ROUTING_VARS = (
+        "NOTIFICATION_WEBHOOK_URL",
+        "NOTIFICATION_WEBHOOK_URL_CRITICAL",
+        "NOTIFICATION_WEBHOOK_URL_WARNING",
+        "NOTIFICATION_WEBHOOK_URL_INFO",
+        "NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY",
+    )
+
+    def _clean_env(self):
+        """Remove all routing env vars to start from a known-blank state."""
+        for var in self._ROUTING_VARS:
+            os.environ.pop(var, None)
+
+    def setUp(self):
+        self._clean_env()
+
+    def tearDown(self):
+        self._clean_env()
+
+    def test_resolve_webhook_url_returns_none_when_nothing_configured(self):
+        """With no env vars set, _resolve_webhook_url returns None for all severities."""
+        for severity in ("critical", "warning", "info"):
+            self.assertIsNone(_resolve_webhook_url(severity))
+
+    def test_critical_uses_severity_specific_url(self):
+        """When NOTIFICATION_WEBHOOK_URL_CRITICAL is set, critical events use it."""
+        with patch.dict(
+            os.environ,
+            {
+                "NOTIFICATION_WEBHOOK_URL_CRITICAL": "http://critical-channel/hook",
+                "NOTIFICATION_WEBHOOK_URL": "http://fallback/hook",
+            },
+        ):
+            self.assertEqual(_resolve_webhook_url("critical"), "http://critical-channel/hook")
+
+    def test_severity_specific_takes_precedence_over_fallback(self):
+        """Severity-specific URL wins over the global fallback when both are set."""
+        with patch.dict(
+            os.environ,
+            {
+                "NOTIFICATION_WEBHOOK_URL_CRITICAL": "http://critical-specific/hook",
+                "NOTIFICATION_WEBHOOK_URL": "http://fallback/hook",
+            },
+        ):
+            result = _resolve_webhook_url("critical")
+            self.assertEqual(result, "http://critical-specific/hook")
+            self.assertNotEqual(result, "http://fallback/hook")
+
+    def test_warning_falls_back_to_global_when_no_specific(self):
+        """When only the global fallback is set, warning events use it."""
+        with patch.dict(os.environ, {"NOTIFICATION_WEBHOOK_URL": "http://fallback/hook"}):
+            self.assertEqual(_resolve_webhook_url("warning"), "http://fallback/hook")
+
+    def test_info_suppressed_in_critical_only_mode(self):
+        """In critical-only mode, info events return None (webhook suppressed)."""
+        with patch.dict(
+            os.environ,
+            {
+                "NOTIFICATION_WEBHOOK_URL": "http://fallback/hook",
+                "NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY": "true",
+            },
+        ):
+            self.assertIsNone(_resolve_webhook_url("info"))
+
+    def test_warning_suppressed_in_critical_only_mode(self):
+        """In critical-only mode, warning events return None (webhook suppressed)."""
+        with patch.dict(
+            os.environ,
+            {
+                "NOTIFICATION_WEBHOOK_URL": "http://fallback/hook",
+                "NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY": "true",
+            },
+        ):
+            self.assertIsNone(_resolve_webhook_url("warning"))
+
+    def test_critical_still_sends_in_critical_only_mode(self):
+        """In critical-only mode, critical events still use the fallback URL."""
+        with patch.dict(
+            os.environ,
+            {
+                "NOTIFICATION_WEBHOOK_URL": "http://fallback/hook",
+                "NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY": "true",
+            },
+        ):
+            self.assertEqual(_resolve_webhook_url("critical"), "http://fallback/hook")
+
+    def test_critical_only_false_does_not_suppress(self):
+        """NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY=false leaves normal fallback behaviour intact."""
+        with patch.dict(
+            os.environ,
+            {
+                "NOTIFICATION_WEBHOOK_URL": "http://fallback/hook",
+                "NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY": "false",
+            },
+        ):
+            self.assertEqual(_resolve_webhook_url("warning"), "http://fallback/hook")
+            self.assertEqual(_resolve_webhook_url("info"), "http://fallback/hook")
+
+
+class TestSeverityRoutingIntegration(unittest.TestCase):
+    """Integration tests: notify() + _post_webhook with severity-based routing."""
+
+    _ROUTING_VARS = (
+        "NOTIFICATION_WEBHOOK_URL",
+        "NOTIFICATION_WEBHOOK_URL_CRITICAL",
+        "NOTIFICATION_WEBHOOK_URL_WARNING",
+        "NOTIFICATION_WEBHOOK_URL_INFO",
+        "NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY",
+        "NOTIFICATION_EMAIL_TO",
+        "NOTIFICATION_SMTP_HOST",
+    )
+
+    def setUp(self):
+        _last_sent.clear()
+        for var in self._ROUTING_VARS:
+            os.environ.pop(var, None)
+
+    def tearDown(self):
+        _last_sent.clear()
+        for var in self._ROUTING_VARS:
+            os.environ.pop(var, None)
+
+    def test_critical_webhook_posted_to_severity_specific_url(self):
+        """notify() POSTs to NOTIFICATION_WEBHOOK_URL_CRITICAL when it is set."""
+        posted_urls: list[str] = []
+
+        async def run():
+            _last_sent.clear()
+            with patch.dict(
+                os.environ,
+                {
+                    "NOTIFICATION_WEBHOOK_URL_CRITICAL": "http://critical/hook",
+                    "NOTIFICATION_WEBHOOK_URL": "http://fallback/hook",
+                },
+            ):
+                with patch("api.notifications._post_webhook", new_callable=AsyncMock) as mock_post:
+                    mock_post.side_effect = lambda url, payload: posted_urls.append(url)
+                    notify("ev_crit_routing", "Title", "Body", severity="critical")
+                    await asyncio.sleep(0.05)
+
+            self.assertEqual(len(posted_urls), 1)
+            self.assertEqual(posted_urls[0], "http://critical/hook")
+
+        asyncio.run(run())
+
+    def test_info_suppressed_in_critical_only_mode_no_webhook_call(self):
+        """In critical-only mode, info-severity notify() never calls _post_webhook."""
+        async def run():
+            _last_sent.clear()
+            with patch.dict(
+                os.environ,
+                {
+                    "NOTIFICATION_WEBHOOK_URL": "http://fallback/hook",
+                    "NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY": "true",
+                    # No email configured either, so notify() exits before dispatch.
+                },
+            ):
+                with patch("api.notifications._post_webhook", new_callable=AsyncMock) as mock_post:
+                    notify("ev_info_suppressed", "Title", "Body", severity="info")
+                    await asyncio.sleep(0.05)
+                    self.assertEqual(mock_post.call_count, 0)
+
+        asyncio.run(run())
+
+    def test_email_always_sends_regardless_of_webhook_routing(self):
+        """Even when the webhook is suppressed (critical-only mode), email is still dispatched."""
+        email_calls: list[dict] = []
+
+        async def fake_email(**kwargs: object) -> None:
+            email_calls.append(dict(kwargs))
+
+        async def run():
+            _last_sent.clear()
+            with patch.dict(
+                os.environ,
+                {
+                    "NOTIFICATION_WEBHOOK_URL": "http://fallback/hook",
+                    "NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY": "true",
+                    "NOTIFICATION_EMAIL_TO": "ops@example.com",
+                    "NOTIFICATION_SMTP_HOST": "smtp.example.com",
+                },
+            ):
+                with patch("api.notifications._post_webhook", new_callable=AsyncMock) as mock_post:
+                    with patch(
+                        "api.notifications._send_email_blocking",
+                        side_effect=lambda **kw: email_calls.append(kw),
+                    ):
+                        notify("ev_email_always", "Title", "Body", severity="warning")
+                        await asyncio.sleep(0.1)
+
+                # Webhook must NOT have been called (suppressed).
+                self.assertEqual(mock_post.call_count, 0)
+
+            # Email must still have been dispatched.
+            self.assertEqual(len(email_calls), 1)
 
         asyncio.run(run())

--- a/ingest/aoi_watch.py
+++ b/ingest/aoi_watch.py
@@ -35,6 +35,7 @@ import httpx
 
 from sqlalchemy import text as sa_text
 
+from api.aoi_utils import _is_notifications_paused
 from api.aois.repo import list_watched_aois_due, update_aoi_watch_status
 from api.db import get_engine
 from api.notifications import notify
@@ -340,24 +341,32 @@ def check_new_ignition(
             if max_acq_time is not None and lag_minutes is not None
             else ""
         )
-        notify(
-            f"new_ignition:{aoi_id}",
-            title=f"New confirmed ignition in {aoi_name}",
-            body=(
-                f"{detection_count} confirmed detection(s) clustered within "
-                f"{_IGNITION_CLUSTER_RADIUS_M / 1000:.0f} km in AOI '{aoi_name}'. "
-                f"Max denoiser confidence: {max_score:.0%}."
-                + _data_suffix
-            ),
-            severity="critical",
-            aoi_id=str(aoi_id),
-            denoised_score=round(max_score, 4),
-            detection_count=detection_count,
-            lat=round(centroid_lat, 6),
-            lon=round(centroid_lon, 6),
-            data_as_of=max_acq_time.isoformat() if max_acq_time is not None else None,
-            data_lag_minutes=lag_minutes,
-        )
+
+        if _is_notifications_paused(aoi):
+            LOGGER.info(
+                "aoi_watch: notifications paused for AOI %s until %s — skipping alerts",
+                aoi_name,
+                aoi.get("watch_notifications_paused_until"),
+            )
+        else:
+            notify(
+                f"new_ignition:{aoi_id}",
+                title=f"New confirmed ignition in {aoi_name}",
+                body=(
+                    f"{detection_count} confirmed detection(s) clustered within "
+                    f"{_IGNITION_CLUSTER_RADIUS_M / 1000:.0f} km in AOI '{aoi_name}'. "
+                    f"Max denoiser confidence: {max_score:.0%}."
+                    + _data_suffix
+                ),
+                severity="critical",
+                aoi_id=str(aoi_id),
+                denoised_score=round(max_score, 4),
+                detection_count=detection_count,
+                lat=round(centroid_lat, 6),
+                lon=round(centroid_lon, 6),
+                data_as_of=max_acq_time.isoformat() if max_acq_time is not None else None,
+                data_lag_minutes=lag_minutes,
+            )
 
         return {
             "aoi_id": str(aoi_id),
@@ -437,25 +446,32 @@ def run_aoi_watch_cycle(api_base_url: str | None = None) -> int:
 
             if max_spread_prob is not None and _should_alert(aoi, max_spread_prob, check_time):
                 threshold = aoi["watch_alert_threshold"]
-                notify(
-                    event_type=f"aoi_watch_alert:{aoi_id}",
-                    title=f"Spread alert: {aoi_name}",
-                    body=(
-                        f"AOI '{aoi_name}' has reached spread probability "
-                        f"{max_spread_prob:.0%} (threshold: {threshold:.0%})."
-                    ),
-                    severity="warning",
-                    aoi_id=str(aoi_id),
-                    aoi_name=aoi_name,
-                    max_spread_prob=f"{max_spread_prob:.3f}",
-                    threshold=f"{threshold:.3f}",
-                    job_id=job_id,
-                )
-                alerted_at = check_time
-                LOGGER.info(
-                    "aoi_watch: alert fired for AOI %s max_spread_prob=%.3f threshold=%.3f",
-                    aoi_name, max_spread_prob, threshold,
-                )
+                if _is_notifications_paused(aoi):
+                    LOGGER.info(
+                        "aoi_watch: notifications paused for AOI %s until %s — skipping alerts",
+                        aoi_name,
+                        aoi.get("watch_notifications_paused_until"),
+                    )
+                else:
+                    notify(
+                        event_type=f"aoi_watch_alert:{aoi_id}",
+                        title=f"Spread alert: {aoi_name}",
+                        body=(
+                            f"AOI '{aoi_name}' has reached spread probability "
+                            f"{max_spread_prob:.0%} (threshold: {threshold:.0%})."
+                        ),
+                        severity="warning",
+                        aoi_id=str(aoi_id),
+                        aoi_name=aoi_name,
+                        max_spread_prob=f"{max_spread_prob:.3f}",
+                        threshold=f"{threshold:.3f}",
+                        job_id=job_id,
+                    )
+                    alerted_at = check_time
+                    LOGGER.info(
+                        "aoi_watch: alert fired for AOI %s max_spread_prob=%.3f threshold=%.3f",
+                        aoi_name, max_spread_prob, threshold,
+                    )
             elif max_spread_prob is not None:
                 LOGGER.info(
                     "aoi_watch: AOI %s max_spread_prob=%.3f below threshold=%.3f — no alert",

--- a/ingest/aoi_watch.py
+++ b/ingest/aoi_watch.py
@@ -22,16 +22,21 @@ Environment variables (optional):
 
 from __future__ import annotations
 
+import json
 import logging
+import math
 import os
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import UUID
 
 import httpx
 
+from sqlalchemy import text as sa_text
+
 from api.aois.repo import list_watched_aois_due, update_aoi_watch_status
+from api.db import get_engine
 from api.notifications import notify
 
 LOGGER = logging.getLogger(__name__)
@@ -137,6 +142,211 @@ def _should_alert(
     return True
 
 
+# Minimum denoised_score for a detection to qualify as confirmed.
+_IGNITION_MIN_SCORE: float = 0.7
+# Minimum cluster size (number of qualifying detections within proximity).
+_IGNITION_MIN_CLUSTER_SIZE: int = 2
+# Proximity radius for clustering (metres).
+_IGNITION_CLUSTER_RADIUS_M: float = 1000.0
+# Lookback window when watch_last_checked_at is NULL.
+_IGNITION_DEFAULT_LOOKBACK_HOURS: int = 2
+
+
+def check_new_ignition(
+    aoi: dict[str, Any],
+    engine=None,
+    _now: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Check for a new confirmed ignition cluster inside an AOI.
+
+    Queries fire_detections for qualifying detections (is_noise=false,
+    false_source_masked=false, denoised_score >= 0.7) within the AOI geometry
+    since watch_last_checked_at (or 2 h ago if null).  Groups detections into
+    proximity clusters (>= 2 within 1 km of each other) that are either
+    unassociated with a fire event or whose event started within the last 2 h
+    (i.e. a genuinely new ignition, not an existing tracked fire).
+
+    If a qualifying cluster is found, fires a "new_ignition:{aoi_id}"
+    notification and returns a dict with cluster details.
+
+    Returns None when no qualifying cluster is found or on any error.
+
+    Args:
+        aoi:    AOI record dict (from list_watched_aois_due).
+        engine: SQLAlchemy engine (defaults to get_engine()). Injectable for testing.
+        _now:   Override for current UTC time (testing only).
+    """
+    aoi_id: UUID = aoi["id"]
+    aoi_name: str = aoi["name"]
+
+    try:
+        now = _now if _now is not None else datetime.now(timezone.utc)
+        last_checked_at: datetime | None = aoi.get("watch_last_checked_at")
+        if last_checked_at is None:
+            since = now - timedelta(hours=_IGNITION_DEFAULT_LOOKBACK_HOURS)
+        else:
+            # Ensure timezone-aware.
+            if last_checked_at.tzinfo is None:
+                since = last_checked_at.replace(tzinfo=timezone.utc)
+            else:
+                since = last_checked_at
+
+        # Serialise AOI geometry to GeoJSON string for PostGIS.
+        geometry = aoi.get("geometry")
+        if not geometry:
+            LOGGER.warning(
+                "aoi_watch: AOI %s (%s) has no geometry — skipping ignition check",
+                aoi_name,
+                aoi_id,
+            )
+            return None
+        geojson_str = json.dumps(geometry)
+
+        db_engine = engine or get_engine()
+        with db_engine.begin() as conn:
+            # Fetch all qualifying detections within the AOI geometry that are
+            # new enough (acquired since the lookback window).
+            rows = conn.execute(
+                sa_text(
+                    """
+                    SELECT
+                        fd.id,
+                        fd.lat,
+                        fd.lon,
+                        fd.denoised_score,
+                        fd.event_id,
+                        fe.started_at AS event_started_at
+                    FROM fire_detections fd
+                    LEFT JOIN fire_events fe ON fe.id = fd.event_id
+                    WHERE fd.is_noise = false
+                      AND fd.false_source_masked = false
+                      AND fd.denoised_score >= :min_score
+                      AND fd.acq_time >= :since
+                      AND ST_Within(
+                            fd.geom,
+                            ST_SetSRID(ST_GeomFromGeoJSON(:geojson), 4326)
+                          )
+                    """
+                ),
+                {
+                    "min_score": _IGNITION_MIN_SCORE,
+                    "since": since,
+                    "geojson": geojson_str,
+                },
+            ).mappings().all()
+
+        detections = [dict(r) for r in rows]
+        LOGGER.info(
+            "aoi_watch: ignition check for AOI %s (%s): %d qualifying detection(s) since %s",
+            aoi_name,
+            aoi_id,
+            len(detections),
+            since.isoformat(),
+        )
+
+        if not detections:
+            return None
+
+        # Filter to detections that represent NEW ignitions: event_id is None, or
+        # the associated event started within the last 2 hours.
+        new_cutoff = now - timedelta(hours=2)
+        new_detections = [
+            d
+            for d in detections
+            if d["event_id"] is None
+            or (
+                d["event_started_at"] is not None
+                and (
+                    d["event_started_at"].replace(tzinfo=timezone.utc)
+                    if d["event_started_at"].tzinfo is None
+                    else d["event_started_at"]
+                )
+                >= new_cutoff
+            )
+        ]
+
+        if not new_detections:
+            LOGGER.info(
+                "aoi_watch: AOI %s — all qualifying detections belong to existing events (> 2 h old)",
+                aoi_name,
+            )
+            return None
+
+        # Cluster by proximity: find the largest cluster where at least two
+        # detections are within _IGNITION_CLUSTER_RADIUS_M of each other.
+        # Simple O(n²) sweep — detection counts per AOI check are small.
+        best_cluster: list[dict[str, Any]] = []
+        for anchor in new_detections:
+            cos_lat = math.cos(math.radians(float(anchor["lat"])))
+            cluster: list[dict[str, Any]] = []
+            for detection in new_detections:
+                dlat_m = (float(detection["lat"]) - float(anchor["lat"])) * 111_000
+                dlon_m = (float(detection["lon"]) - float(anchor["lon"])) * 111_000 * cos_lat
+                dist_m = math.sqrt(dlat_m**2 + dlon_m**2)
+                if dist_m <= _IGNITION_CLUSTER_RADIUS_M:
+                    cluster.append(detection)
+            if len(cluster) > len(best_cluster):
+                best_cluster = cluster
+
+        if len(best_cluster) < _IGNITION_MIN_CLUSTER_SIZE:
+            LOGGER.info(
+                "aoi_watch: AOI %s — largest proximity cluster has %d detection(s) (< %d required)",
+                aoi_name,
+                len(best_cluster),
+                _IGNITION_MIN_CLUSTER_SIZE,
+            )
+            return None
+
+        # Compute cluster centroid and max score.
+        centroid_lat = sum(float(d["lat"]) for d in best_cluster) / len(best_cluster)
+        centroid_lon = sum(float(d["lon"]) for d in best_cluster) / len(best_cluster)
+        max_score = max(float(d["denoised_score"]) for d in best_cluster)
+        detection_count = len(best_cluster)
+
+        LOGGER.warning(
+            "aoi_watch: NEW IGNITION detected in AOI %s — %d detection(s), max_score=%.3f, "
+            "centroid=(%.4f, %.4f)",
+            aoi_name,
+            detection_count,
+            max_score,
+            centroid_lat,
+            centroid_lon,
+        )
+
+        notify(
+            f"new_ignition:{aoi_id}",
+            title=f"New confirmed ignition in {aoi_name}",
+            body=(
+                f"{detection_count} confirmed detection(s) clustered within "
+                f"{_IGNITION_CLUSTER_RADIUS_M / 1000:.0f} km in AOI '{aoi_name}'. "
+                f"Max denoiser confidence: {max_score:.0%}."
+            ),
+            severity="critical",
+            aoi_id=str(aoi_id),
+            denoised_score=round(max_score, 4),
+            detection_count=detection_count,
+            lat=round(centroid_lat, 6),
+            lon=round(centroid_lon, 6),
+        )
+
+        return {
+            "aoi_id": str(aoi_id),
+            "aoi_name": aoi_name,
+            "detection_count": detection_count,
+            "max_denoised_score": max_score,
+            "centroid_lat": centroid_lat,
+            "centroid_lon": centroid_lon,
+        }
+
+    except Exception:
+        LOGGER.exception(
+            "aoi_watch: error during ignition check for AOI %s (%s) — returning None",
+            aoi_name,
+            aoi_id,
+        )
+        return None
+
+
 def run_aoi_watch_cycle(api_base_url: str | None = None) -> int:
     """Run one AOI watchlist check cycle.
 
@@ -219,6 +429,9 @@ def run_aoi_watch_cycle(api_base_url: str | None = None) -> int:
                     "aoi_watch: AOI %s max_spread_prob=%.3f below threshold=%.3f — no alert",
                     aoi_name, max_spread_prob, aoi.get("watch_alert_threshold"),
                 )
+
+            # Run new-ignition check on every cycle pass, independently of spread alerts.
+            check_new_ignition(aoi)
 
             update_aoi_watch_status(
                 aoi_id=aoi_id,

--- a/ingest/aoi_watch.py
+++ b/ingest/aoi_watch.py
@@ -490,4 +490,50 @@ def run_aoi_watch_cycle(api_base_url: str | None = None) -> int:
             processed += 1
 
     LOGGER.info("aoi_watch: cycle complete — processed %d AOI(s)", processed)
+
+    # ── Batch watch checks that require a DB session ──────────────────────────
+    # Run once per cycle (not per-AOI) to keep DB connection lifetime short.
+    if due_aois:
+        _run_batch_watch_checks(due_aois)
+
     return processed
+
+
+def _run_batch_watch_checks(aois: list[dict[str, Any]]) -> None:
+    """Run weather threshold, spread trajectory, and perimeter breach checks.
+
+    Opens a single DB connection shared across all three check functions.
+    Errors in any individual check are logged but do not abort others.
+    """
+    from ingest.weather_threshold_watch import run_weather_threshold_checks  # noqa: PLC0415
+    from ingest.spread_trajectory_watch import run_spread_trajectory_checks  # noqa: PLC0415
+    from ingest.perimeter_breach_watch import run_perimeter_breach_checks  # noqa: PLC0415
+
+    engine = get_engine()
+    try:
+        with engine.begin() as conn:
+            try:
+                results = run_weather_threshold_checks(aois, conn)
+                LOGGER.info(
+                    "aoi_watch: weather threshold checks — %d trigger(s)", len(results)
+                )
+            except Exception:
+                LOGGER.exception("aoi_watch: weather threshold checks failed")
+
+            try:
+                results = run_spread_trajectory_checks(aois, conn)
+                LOGGER.info(
+                    "aoi_watch: spread trajectory checks — %d trigger(s)", len(results)
+                )
+            except Exception:
+                LOGGER.exception("aoi_watch: spread trajectory checks failed")
+
+            try:
+                results = run_perimeter_breach_checks(conn)
+                LOGGER.info(
+                    "aoi_watch: perimeter breach checks — %d breach(es)", len(results)
+                )
+            except Exception:
+                LOGGER.exception("aoi_watch: perimeter breach checks failed")
+    except Exception:
+        LOGGER.exception("aoi_watch: could not open DB connection for batch watch checks")

--- a/ingest/aoi_watch.py
+++ b/ingest/aoi_watch.py
@@ -492,26 +492,27 @@ def run_aoi_watch_cycle(api_base_url: str | None = None) -> int:
     LOGGER.info("aoi_watch: cycle complete — processed %d AOI(s)", processed)
 
     # ── Batch watch checks that require a DB session ──────────────────────────
-    # Run once per cycle (not per-AOI) to keep DB connection lifetime short.
+    # AOI-specific checks only run when AOIs were due; perimeter breach checks
+    # query all active fire_perimeters globally and always run every cycle.
     if due_aois:
-        _run_batch_watch_checks(due_aois)
+        _run_aoi_batch_checks(due_aois)
+    _run_perimeter_checks()
 
     return processed
 
 
-def _run_batch_watch_checks(aois: list[dict[str, Any]]) -> None:
-    """Run weather threshold, spread trajectory, and perimeter breach checks.
+def _run_aoi_batch_checks(aois: list[dict[str, Any]]) -> None:
+    """Run weather threshold and spread trajectory checks for the given AOIs.
 
-    Opens a single DB connection shared across all three check functions.
+    Opens a single read-only DB connection shared across both check functions.
     Errors in any individual check are logged but do not abort others.
     """
     from ingest.weather_threshold_watch import run_weather_threshold_checks  # noqa: PLC0415
     from ingest.spread_trajectory_watch import run_spread_trajectory_checks  # noqa: PLC0415
-    from ingest.perimeter_breach_watch import run_perimeter_breach_checks  # noqa: PLC0415
 
     engine = get_engine()
     try:
-        with engine.begin() as conn:
+        with engine.connect() as conn:
             try:
                 results = run_weather_threshold_checks(aois, conn)
                 LOGGER.info(
@@ -527,13 +528,24 @@ def _run_batch_watch_checks(aois: list[dict[str, Any]]) -> None:
                 )
             except Exception:
                 LOGGER.exception("aoi_watch: spread trajectory checks failed")
-
-            try:
-                results = run_perimeter_breach_checks(conn)
-                LOGGER.info(
-                    "aoi_watch: perimeter breach checks — %d breach(es)", len(results)
-                )
-            except Exception:
-                LOGGER.exception("aoi_watch: perimeter breach checks failed")
     except Exception:
-        LOGGER.exception("aoi_watch: could not open DB connection for batch watch checks")
+        LOGGER.exception("aoi_watch: could not open DB connection for AOI batch checks")
+
+
+def _run_perimeter_checks() -> None:
+    """Run perimeter breach checks against all active fire perimeters.
+
+    Runs every watch cycle regardless of whether any AOIs were due — spot fire
+    detection is not AOI-specific and must not be gated on AOI scheduling.
+    """
+    from ingest.perimeter_breach_watch import run_perimeter_breach_checks  # noqa: PLC0415
+
+    engine = get_engine()
+    try:
+        with engine.connect() as conn:
+            results = run_perimeter_breach_checks(conn)
+            LOGGER.info(
+                "aoi_watch: perimeter breach checks — %d breach(es)", len(results)
+            )
+    except Exception:
+        LOGGER.exception("aoi_watch: perimeter breach checks failed")

--- a/ingest/aoi_watch.py
+++ b/ingest/aoi_watch.py
@@ -142,6 +142,9 @@ def _should_alert(
     return True
 
 
+# FIRMS near-real-time data latency floor (acquisition to DB availability)
+_FIRMS_LATENCY_FLOOR_MINUTES: int = 60
+
 # Minimum denoised_score for a detection to qualify as confirmed.
 _IGNITION_MIN_SCORE: float = 0.7
 # Minimum cluster size (number of qualifying detections within proximity).
@@ -213,6 +216,7 @@ def check_new_ignition(
                         fd.id,
                         fd.lat,
                         fd.lon,
+                        fd.acq_time,
                         fd.denoised_score,
                         fd.event_id,
                         fe.started_at AS event_started_at
@@ -236,6 +240,23 @@ def check_new_ignition(
             ).mappings().all()
 
         detections = [dict(r) for r in rows]
+
+        # Compute satellite acquisition timestamp and data-currency lag.
+        # _FIRMS_LATENCY_FLOOR_MINUTES documents the minimum expected lag.
+        max_acq_time: datetime | None = max(
+            (d["acq_time"] for d in detections if d.get("acq_time") is not None),
+            default=None,
+        )
+        lag_minutes: int | None = None
+        if max_acq_time is not None:
+            # Ensure timezone-aware before arithmetic.
+            acq_aware = (
+                max_acq_time.replace(tzinfo=timezone.utc)
+                if max_acq_time.tzinfo is None
+                else max_acq_time
+            )
+            lag_minutes = int((now - acq_aware).total_seconds() / 60)
+
         LOGGER.info(
             "aoi_watch: ignition check for AOI %s (%s): %d qualifying detection(s) since %s",
             aoi_name,
@@ -313,6 +334,12 @@ def check_new_ignition(
             centroid_lon,
         )
 
+        _data_suffix = (
+            f" Based on satellite data acquired at "
+            f"{max_acq_time.strftime('%H:%M UTC')} (~{lag_minutes}min ago)."
+            if max_acq_time is not None and lag_minutes is not None
+            else ""
+        )
         notify(
             f"new_ignition:{aoi_id}",
             title=f"New confirmed ignition in {aoi_name}",
@@ -320,6 +347,7 @@ def check_new_ignition(
                 f"{detection_count} confirmed detection(s) clustered within "
                 f"{_IGNITION_CLUSTER_RADIUS_M / 1000:.0f} km in AOI '{aoi_name}'. "
                 f"Max denoiser confidence: {max_score:.0%}."
+                + _data_suffix
             ),
             severity="critical",
             aoi_id=str(aoi_id),
@@ -327,6 +355,8 @@ def check_new_ignition(
             detection_count=detection_count,
             lat=round(centroid_lat, 6),
             lon=round(centroid_lon, 6),
+            data_as_of=max_acq_time.isoformat() if max_acq_time is not None else None,
+            data_lag_minutes=lag_minutes,
         )
 
         return {
@@ -336,6 +366,8 @@ def check_new_ignition(
             "max_denoised_score": max_score,
             "centroid_lat": centroid_lat,
             "centroid_lon": centroid_lon,
+            "data_as_of": max_acq_time,
+            "data_lag_minutes": lag_minutes,
         }
 
     except Exception:

--- a/ingest/nifc_pl_watch.py
+++ b/ingest/nifc_pl_watch.py
@@ -1,0 +1,172 @@
+"""NIFC National Preparedness Level (PL) fetcher.
+
+Provides the current national resource Preparedness Level (1-5) for inclusion
+in critical-severity notifications. Uses a two-tier env-var strategy since
+NIFC does not publish a stable machine-readable PL API.
+
+# STAGE-GAP WARNING (mvp_operational → science_grade): get_preparedness_level()
+# currently relies on operator-configured env vars (NIFC_PL_URL, NIFC_PL_OVERRIDE)
+# rather than a live authoritative feed. Mitigation: operators should set
+# NIFC_PL_OVERRIDE during high-PL events. Target stage: integrate with NIFC
+# official machine-readable PL feed when published.
+
+Environment variables:
+    NIFC_PL_URL              Optional URL that returns JSON with a
+                             ``preparedness_level`` or ``pl`` integer field.
+                             If set and reachable, this is the primary source.
+    NIFC_PL_OVERRIDE         Integer 1-5 set manually by operators during
+                             high-PL incidents when no API is available.
+    NIFC_PL_CACHE_TTL_SECONDS  Cache lifetime in seconds (default: 1800 / 30 min).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+
+LOGGER = logging.getLogger(__name__)
+
+_CACHE_TTL_SECONDS: int = int(os.getenv("NIFC_PL_CACHE_TTL_SECONDS", "1800"))
+
+# In-memory cache: (fetched_at, preparedness_level)
+_cache: tuple[datetime, int | None] | None = None
+
+_VALID_PL_RANGE = range(1, 6)  # 1-5 inclusive
+
+
+def _fetch_from_url(http_client: httpx.Client) -> int | None:
+    """Attempt to fetch PL from NIFC_PL_URL. Returns None on any failure."""
+    url = os.getenv("NIFC_PL_URL", "").strip()
+    if not url:
+        return None
+    try:
+        resp = http_client.get(url, timeout=10.0)
+        resp.raise_for_status()
+        data = resp.json()
+        raw = data.get("preparedness_level") or data.get("pl")
+        if raw is None:
+            LOGGER.warning(
+                "nifc_pl_watch: NIFC_PL_URL response missing 'preparedness_level'/'pl' field"
+            )
+            return None
+        pl = int(raw)
+        if pl not in _VALID_PL_RANGE:
+            LOGGER.warning(
+                "nifc_pl_watch: NIFC_PL_URL returned out-of-range PL=%d (expected 1-5)", pl
+            )
+            return None
+        return pl
+    except httpx.HTTPError as exc:
+        LOGGER.warning("nifc_pl_watch: NIFC_PL_URL fetch failed (%s) — falling back", exc)
+        return None
+    except Exception as exc:
+        LOGGER.warning("nifc_pl_watch: NIFC_PL_URL parse error (%s) — falling back", exc)
+        return None
+
+
+def _read_override() -> int | None:
+    """Read NIFC_PL_OVERRIDE env var. Returns None if unset or invalid."""
+    raw = os.getenv("NIFC_PL_OVERRIDE", "").strip()
+    if not raw:
+        return None
+    try:
+        pl = int(raw)
+    except ValueError:
+        LOGGER.warning(
+            "nifc_pl_watch: NIFC_PL_OVERRIDE=%r is not a valid integer — ignoring", raw
+        )
+        return None
+    if pl not in _VALID_PL_RANGE:
+        LOGGER.warning(
+            "nifc_pl_watch: NIFC_PL_OVERRIDE=%d is out of valid range 1-5 — ignoring", pl
+        )
+        return None
+    return pl
+
+
+def get_preparedness_level(http_client: httpx.Client | None = None) -> int | None:
+    """Fetch current NIFC National Preparedness Level (1-5), or None if unavailable.
+
+    Uses a 30-minute in-memory cache. Returns None on any network or parse failure
+    rather than raising — callers should treat None as "unknown, do not display."
+
+    PL meanings:
+        1 = Low activity
+        2 = Normal
+        3 = Above normal
+        4 = High — mutual aid limited
+        5 = Critical — all national resources committed
+
+    Resolution order:
+        Tier 1: NIFC_PL_URL (operator-configured JSON endpoint)
+        Tier 2: NIFC_PL_OVERRIDE (manually set integer, 1-5)
+        Tier 3: None (no source configured)
+    """
+    global _cache
+
+    now = datetime.now(timezone.utc)
+    ttl = timedelta(seconds=_CACHE_TTL_SECONDS)
+
+    if _cache is not None:
+        fetched_at, cached_pl = _cache
+        if now - fetched_at < ttl:
+            LOGGER.debug("nifc_pl_watch: returning cached PL=%s", cached_pl)
+            return cached_pl
+
+    pl: int | None = None
+
+    # Tier 1: URL source.
+    url = os.getenv("NIFC_PL_URL", "").strip()
+    if url:
+        if http_client is not None:
+            pl = _fetch_from_url(http_client)
+        else:
+            with httpx.Client() as client:
+                pl = _fetch_from_url(client)
+
+    # Tier 2: manual override.
+    if pl is None:
+        pl = _read_override()
+
+    # Tier 3: no source.
+    if pl is None and not url and not os.getenv("NIFC_PL_OVERRIDE", "").strip():
+        LOGGER.debug(
+            "nifc_pl_watch: no PL source configured — returning None. "
+            "Set NIFC_PL_URL or NIFC_PL_OVERRIDE."
+        )
+
+    _cache = (now, pl)
+    return pl
+
+
+def get_preparedness_level_context() -> dict[str, Any]:
+    """Return a dict suitable for spreading into a notify() call's **context.
+
+    Returns {} if PL is unavailable (callers can spread this safely).
+    Returns {"nifc_preparedness_level": N, "nifc_pl_resource_warning": str} if PL >= 4.
+    Returns {"nifc_preparedness_level": N} if PL < 4.
+    """
+    pl = get_preparedness_level()
+    if pl is None:
+        return {}
+    ctx: dict[str, Any] = {"nifc_preparedness_level": pl}
+    if pl >= 4:
+        ctx["nifc_pl_resource_warning"] = (
+            f"National Preparedness Level {pl} — "
+            + (
+                "mutual aid severely limited."
+                if pl == 4
+                else "all national resources committed."
+            )
+        )
+    return ctx
+
+
+def clear_cache() -> None:
+    """Clear the in-memory cache. Used in tests."""
+    global _cache
+    _cache = None

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -1167,6 +1167,21 @@ def _execute_job(
             overall_state="critical",
             stale_sources=", ".join(critical_sources),
         )
+        # Also fire the user-facing staleness notification (picture_stale:global).
+        try:
+            from api.data_status import notify_staleness_if_degraded  # noqa: PLC0415
+
+            notify_staleness_if_degraded(fresh_snapshot, aoi_id=None)
+        except Exception:
+            LOGGER.debug("notify_staleness_if_degraded skipped: snapshot unavailable")
+    elif fresh_snapshot and str(fresh_snapshot.get("overall_state", "")) == "degraded":
+        # Degraded state: user-facing notification only (no internal ops alert).
+        try:
+            from api.data_status import notify_staleness_if_degraded  # noqa: PLC0415
+
+            notify_staleness_if_degraded(fresh_snapshot, aoi_id=None)
+        except Exception:
+            LOGGER.debug("notify_staleness_if_degraded skipped: snapshot unavailable")
     return code
 
 

--- a/ingest/perimeter_breach_watch.py
+++ b/ingest/perimeter_breach_watch.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -32,6 +33,33 @@ _CLUSTER_RADIUS_DEG = 0.01        # ~1 km grouping radius
 _DENOISED_SCORE_MIN = 0.7
 _LOOKBACK_HOURS = 6
 _MIN_CLUSTER_SIZE = 3
+
+# Perimeter age guard — perimeters older than this are stale; skip breach check.
+# science_grade: consider per-source freshness SLAs.
+_MAX_PERIMETER_AGE_HOURS: int = int(os.environ.get("PERIMETER_MAX_AGE_HOURS", "48"))
+
+# Module-level breach state tracker.
+# best-effort; resets on restart — science_grade: persist to DB.
+_active_breaches: dict[str, dict] = {}
+# Key: source_id
+# Value: {"first_detected_at": datetime, "last_seen_at": datetime,
+#         "cluster_lat": float, "cluster_lon": float}
+
+
+def reset_breach_state(source_id: str) -> None:
+    """Remove a single source_id from the active breach tracker.
+
+    Intended for testing and manual operator resets.
+    """
+    _active_breaches.pop(source_id, None)
+
+
+def get_active_breaches() -> dict:
+    """Return a shallow copy of the current active breach state.
+
+    Intended for inspection/debugging.
+    """
+    return dict(_active_breaches)
 
 
 def _haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
@@ -99,7 +127,8 @@ def check_perimeter_breach(perimeter: dict[str, Any], session: Any) -> dict[str,
     fire_name: str = perimeter["fire_name"]
 
     try:
-        since = datetime.now(timezone.utc) - timedelta(hours=_LOOKBACK_HOURS)
+        now = datetime.now(timezone.utc)
+        since = now - timedelta(hours=_LOOKBACK_HOURS)
 
         # Accept WKT string or a GeoJSON dict for the perimeter geometry.
         geom_input = perimeter["geom"]
@@ -128,7 +157,8 @@ def check_perimeter_breach(perimeter: dict[str, Any], session: Any) -> dict[str,
                 ST_Y(fd.geom) AS lat,
                 ST_X(fd.geom) AS lon,
                 fd.denoised_score,
-                ST_Distance(fd.geom, {geom_sql}) AS dist_deg
+                ST_Distance(fd.geom, {geom_sql}) AS dist_deg,
+                MAX(fd.acq_time) OVER () AS max_acq_time
             FROM fire_detections fd
             WHERE
                 fd.acq_time >= :since
@@ -149,7 +179,19 @@ def check_perimeter_breach(perimeter: dict[str, Any], session: Any) -> dict[str,
                 "perimeter_breach_watch: no candidate detections outside perimeter source_id=%s",
                 source_id,
             )
+            # No qualifying cluster found — resolve any active breach for this source.
+            if source_id in _active_breaches:
+                _active_breaches.pop(source_id)
+                LOGGER.info(
+                    "perimeter_breach_watch: breach resolved for source_id=%s", source_id
+                )
             return None
+
+        # Pull max_acq_time from the first row (window function is identical across rows).
+        max_acq_time: datetime = rows[0].max_acq_time
+        if max_acq_time.tzinfo is None:
+            max_acq_time = max_acq_time.replace(tzinfo=timezone.utc)
+        lag_min = int((now - max_acq_time).total_seconds() / 60)
 
         detections = [
             {"lat": row.lat, "lon": row.lon, "denoised_score": row.denoised_score, "dist_deg": row.dist_deg}
@@ -172,20 +214,59 @@ def check_perimeter_breach(perimeter: dict[str, Any], session: Any) -> dict[str,
             dist_km = min_dist_deg * 111.0
             n_detections = len(cluster)
 
-            LOGGER.warning(
-                "perimeter_breach_watch: spot fire cluster detected outside %s "
-                "source_id=%s n=%d dist_km=%.1f max_score=%.3f",
-                fire_name, source_id, n_detections, dist_km, max_score,
+            # Data-freshness suffix for notification body.
+            data_freshness_suffix = (
+                f" (satellite data as of {max_acq_time.strftime('%H:%M UTC')},"
+                f" approx. {lag_min}min ago)"
             )
 
-            notify(
-                f"perimeter_breach:{source_id}",
-                title=f"Spot fire detected outside {fire_name} perimeter",
-                body=(
+            # Determine NEW vs ONGOING breach.
+            if source_id not in _active_breaches:
+                # First detection for this source.
+                _active_breaches[source_id] = {
+                    "first_detected_at": now,
+                    "last_seen_at": now,
+                    "cluster_lat": lat,
+                    "cluster_lon": lon,
+                }
+                title = f"NEW: Spot fire detected outside {fire_name} perimeter"
+                body = (
                     f"Cluster of {n_detections} confirmed detections found "
                     f"{dist_km:.1f}km outside perimeter boundary — "
                     f"possible spot fire or breakover."
-                ),
+                    f"{data_freshness_suffix}"
+                )
+                LOGGER.warning(
+                    "perimeter_breach_watch: NEW spot fire cluster outside %s "
+                    "source_id=%s n=%d dist_km=%.1f max_score=%.3f",
+                    fire_name, source_id, n_detections, dist_km, max_score,
+                )
+            else:
+                # Ongoing breach — update last_seen and report duration.
+                entry = _active_breaches[source_id]
+                first_detected_at: datetime = entry["first_detected_at"]
+                duration_hours = (now - first_detected_at).total_seconds() / 3600.0
+                entry["last_seen_at"] = now
+                entry["cluster_lat"] = lat
+                entry["cluster_lon"] = lon
+                title = f"ONGOING: Spot fire persists outside {fire_name} perimeter"
+                body = (
+                    f"Cluster of {n_detections} confirmed detections found "
+                    f"{dist_km:.1f}km outside perimeter boundary — "
+                    f"possible spot fire or breakover. "
+                    f"First detected {duration_hours:.1f}h ago, still active."
+                    f"{data_freshness_suffix}"
+                )
+                LOGGER.warning(
+                    "perimeter_breach_watch: ONGOING spot fire cluster outside %s "
+                    "source_id=%s n=%d dist_km=%.1f max_score=%.3f duration_h=%.1f",
+                    fire_name, source_id, n_detections, dist_km, max_score, duration_hours,
+                )
+
+            notify(
+                f"perimeter_breach:{source_id}",
+                title=title,
+                body=body,
                 severity="critical",
                 denoised_score=max_score,
                 aoi_id=None,
@@ -194,6 +275,8 @@ def check_perimeter_breach(perimeter: dict[str, Any], session: Any) -> dict[str,
                 cluster_lat=lat,
                 cluster_lon=lon,
                 distance_km=dist_km,
+                data_as_of=max_acq_time.isoformat(),
+                data_lag_minutes=lag_min,
             )
 
             return {
@@ -204,12 +287,19 @@ def check_perimeter_breach(perimeter: dict[str, Any], session: Any) -> dict[str,
                 "detection_count": n_detections,
                 "max_denoised_score": max_score,
                 "distance_km": dist_km,
+                "data_as_of": max_acq_time,
             }
 
+        # All clusters were below the threshold — treat as "no qualifying cluster".
         LOGGER.info(
             "perimeter_breach_watch: no qualifying cluster (all < %d) for source_id=%s",
             _MIN_CLUSTER_SIZE, source_id,
         )
+        if source_id in _active_breaches:
+            _active_breaches.pop(source_id)
+            LOGGER.info(
+                "perimeter_breach_watch: breach resolved for source_id=%s", source_id
+            )
         return None
 
     except Exception:
@@ -223,7 +313,9 @@ def run_perimeter_breach_checks(session: Any) -> list[dict[str, Any]]:
     """Check all active perimeters for spot fire clusters.
 
     Queries fire_perimeters where fire_end IS NULL or fire_end > now(), then
-    calls check_perimeter_breach on each.
+    calls check_perimeter_breach on fresh perimeters only.  Stale perimeters
+    (created_at older than PERIMETER_MAX_AGE_HOURS) emit a warning notification
+    instead.
 
     Returns:
         List of breach dicts for perimeters where a qualifying cluster was found.
@@ -239,7 +331,8 @@ def run_perimeter_breach_checks(session: Any) -> list[dict[str, Any]]:
                 fire_name,
                 ST_AsText(geom) AS geom,
                 source,
-                acres
+                acres,
+                created_at
             FROM fire_perimeters
             WHERE fire_end IS NULL OR fire_end > :now
         """
@@ -253,10 +346,38 @@ def run_perimeter_breach_checks(session: Any) -> list[dict[str, Any]]:
 
         results: list[dict[str, Any]] = []
         for row in rows:
+            source_id: str = row.source_id
+            fire_name: str = row.fire_name
+            created_at: datetime = row.created_at
+            if created_at.tzinfo is None:
+                created_at = created_at.replace(tzinfo=timezone.utc)
+
+            age_hours = (now - created_at).total_seconds() / 3600.0
+
+            if age_hours >= _MAX_PERIMETER_AGE_HOURS:
+                # Stale perimeter — emit warning, skip breach check.
+                LOGGER.warning(
+                    "perimeter_breach_watch: stale perimeter source_id=%s age=%.0fh — skipping breach check",
+                    source_id, age_hours,
+                )
+                notify(
+                    f"perimeter_stale:{source_id}",
+                    title=f"{fire_name} perimeter data is stale",
+                    body=(
+                        f"Perimeter last updated {age_hours:.0f}h ago — "
+                        f"spot fire checks suspended until data refreshes."
+                    ),
+                    severity="warning",
+                    aoi_id=None,
+                    fire_name=fire_name,
+                    perimeter_age_hours=age_hours,
+                )
+                continue
+
             perimeter = {
                 "id": row.id,
-                "source_id": row.source_id,
-                "fire_name": row.fire_name,
+                "source_id": source_id,
+                "fire_name": fire_name,
                 "geom": row.geom,  # WKT from ST_AsText
                 "source": row.source,
                 "acres": row.acres,

--- a/ingest/perimeter_breach_watch.py
+++ b/ingest/perimeter_breach_watch.py
@@ -1,0 +1,276 @@
+"""Perimeter breach (spot fire) watch.
+
+Detects clusters of confirmed fire detections that lie outside a known fire
+perimeter — a leading indicator of spot fires or breakovers.
+
+Rules (from NOTIFICATION_CONTRACTS.md):
+  - Lookback window : 6 hours
+  - Detection filter: is_noise=False, false_source_masked=False, denoised_score >= 0.7
+  - Candidate zone  : outside perimeter AND within ~50 km (0.5°) of boundary
+  - Edge filter     : >= 500 m (0.004°) from boundary (suppress fringe noise)
+  - Cluster         : detections within 1 km of each other
+  - Alert threshold : cluster size >= 3
+
+Severity is always "critical" (spot fires are high-priority events).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from api.notifications import notify
+
+LOGGER = logging.getLogger(__name__)
+
+# Spatial thresholds (degrees, WGS-84 approximate)
+_CANDIDATE_RADIUS_DEG = 0.5       # ~50 km
+_MIN_DIST_DEG = 0.004             # ~500 m minimum distance outside perimeter
+_CLUSTER_RADIUS_DEG = 0.01        # ~1 km grouping radius
+_DENOISED_SCORE_MIN = 0.7
+_LOOKBACK_HOURS = 6
+_MIN_CLUSTER_SIZE = 3
+
+
+def _haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Return great-circle distance in km between two (lat, lon) points."""
+    r = 6371.0
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    return 2 * r * math.asin(math.sqrt(a))
+
+
+def _cluster_detections(
+    detections: list[dict[str, Any]],
+    radius_deg: float,
+) -> list[list[dict[str, Any]]]:
+    """Greedy single-linkage clustering by Euclidean degree distance.
+
+    Returns a list of clusters, each cluster being a list of detection dicts
+    with keys 'lat' and 'lon'.  Simple O(n²) implementation — detection counts
+    per perimeter are expected to be small (< 200).
+    """
+    unassigned = list(detections)
+    clusters: list[list[dict[str, Any]]] = []
+
+    while unassigned:
+        seed = unassigned.pop(0)
+        cluster = [seed]
+        changed = True
+        while changed:
+            changed = False
+            remaining: list[dict[str, Any]] = []
+            for det in unassigned:
+                # Check distance to any existing cluster member
+                in_cluster = False
+                for member in cluster:
+                    dlat = det["lat"] - member["lat"]
+                    dlon = det["lon"] - member["lon"]
+                    if math.sqrt(dlat**2 + dlon**2) <= radius_deg:
+                        in_cluster = True
+                        break
+                if in_cluster:
+                    cluster.append(det)
+                    changed = True
+                else:
+                    remaining.append(det)
+            unassigned = remaining
+        clusters.append(cluster)
+
+    return clusters
+
+
+def check_perimeter_breach(perimeter: dict[str, Any], session: Any) -> dict[str, Any] | None:
+    """Check for spot fire clusters outside a single perimeter.
+
+    Args:
+        perimeter: Dict with keys id, source_id, fire_name, geom (WKT/GeoJSON),
+                   source, acres.
+        session:   SQLAlchemy session.
+
+    Returns:
+        Breach info dict if a qualifying cluster is found, else None.
+    """
+    source_id: str = perimeter["source_id"]
+    fire_name: str = perimeter["fire_name"]
+
+    try:
+        since = datetime.now(timezone.utc) - timedelta(hours=_LOOKBACK_HOURS)
+
+        # Accept WKT string or a GeoJSON dict for the perimeter geometry.
+        geom_input = perimeter["geom"]
+        if isinstance(geom_input, dict):
+            # GeoJSON → use ST_GeomFromGeoJSON
+            geom_sql = "ST_GeomFromGeoJSON(:geom)"
+            geom_param = {"geom": str(geom_input).replace("'", '"')}
+        else:
+            # Assume WKT
+            geom_sql = "ST_GeomFromText(:geom, 4326)"
+            geom_param = {"geom": geom_input}
+
+        # Build parameter dict for the query
+        params: dict[str, Any] = {
+            "since": since,
+            "score_min": _DENOISED_SCORE_MIN,
+            "candidate_radius": _CANDIDATE_RADIUS_DEG,
+            "min_dist": _MIN_DIST_DEG,
+            **geom_param,
+        }
+
+        # Inject geom_sql into the query string (safe — not user input)
+        sql = f"""
+            SELECT
+                fd.id,
+                ST_Y(fd.geom) AS lat,
+                ST_X(fd.geom) AS lon,
+                fd.denoised_score,
+                ST_Distance(fd.geom, {geom_sql}) AS dist_deg
+            FROM fire_detections fd
+            WHERE
+                fd.acq_time >= :since
+                AND fd.is_noise = false
+                AND fd.false_source_masked = false
+                AND fd.denoised_score >= :score_min
+                AND ST_DWithin(fd.geom, {geom_sql}, :candidate_radius)
+                AND NOT ST_Within(fd.geom, {geom_sql})
+                AND ST_Distance(fd.geom, {geom_sql}) >= :min_dist
+        """
+
+        from sqlalchemy import text  # local import to match ingest style
+
+        rows = session.execute(text(sql), params).fetchall()
+
+        if not rows:
+            LOGGER.info(
+                "perimeter_breach_watch: no candidate detections outside perimeter source_id=%s",
+                source_id,
+            )
+            return None
+
+        detections = [
+            {"lat": row.lat, "lon": row.lon, "denoised_score": row.denoised_score, "dist_deg": row.dist_deg}
+            for row in rows
+        ]
+
+        clusters = _cluster_detections(detections, _CLUSTER_RADIUS_DEG)
+
+        for cluster in clusters:
+            if len(cluster) < _MIN_CLUSTER_SIZE:
+                continue
+
+            # Compute cluster centroid
+            lat = sum(d["lat"] for d in cluster) / len(cluster)
+            lon = sum(d["lon"] for d in cluster) / len(cluster)
+            max_score = max(d["denoised_score"] for d in cluster)
+            # Distance: use the minimum dist_deg in the cluster → closest point
+            min_dist_deg = min(d["dist_deg"] for d in cluster)
+            # Convert degrees to km (approximate: 1° ≈ 111 km)
+            dist_km = min_dist_deg * 111.0
+            n_detections = len(cluster)
+
+            LOGGER.warning(
+                "perimeter_breach_watch: spot fire cluster detected outside %s "
+                "source_id=%s n=%d dist_km=%.1f max_score=%.3f",
+                fire_name, source_id, n_detections, dist_km, max_score,
+            )
+
+            notify(
+                f"perimeter_breach:{source_id}",
+                title=f"Spot fire detected outside {fire_name} perimeter",
+                body=(
+                    f"Cluster of {n_detections} confirmed detections found "
+                    f"{dist_km:.1f}km outside perimeter boundary — "
+                    f"possible spot fire or breakover."
+                ),
+                severity="critical",
+                denoised_score=max_score,
+                aoi_id=None,
+                fire_name=fire_name,
+                detection_count=n_detections,
+                cluster_lat=lat,
+                cluster_lon=lon,
+                distance_km=dist_km,
+            )
+
+            return {
+                "source_id": source_id,
+                "fire_name": fire_name,
+                "cluster_lat": lat,
+                "cluster_lon": lon,
+                "detection_count": n_detections,
+                "max_denoised_score": max_score,
+                "distance_km": dist_km,
+            }
+
+        LOGGER.info(
+            "perimeter_breach_watch: no qualifying cluster (all < %d) for source_id=%s",
+            _MIN_CLUSTER_SIZE, source_id,
+        )
+        return None
+
+    except Exception:
+        LOGGER.exception(
+            "perimeter_breach_watch: error checking perimeter source_id=%s", source_id
+        )
+        return None
+
+
+def run_perimeter_breach_checks(session: Any) -> list[dict[str, Any]]:
+    """Check all active perimeters for spot fire clusters.
+
+    Queries fire_perimeters where fire_end IS NULL or fire_end > now(), then
+    calls check_perimeter_breach on each.
+
+    Returns:
+        List of breach dicts for perimeters where a qualifying cluster was found.
+    """
+    try:
+        from sqlalchemy import text  # local import to match ingest style
+
+        now = datetime.now(timezone.utc)
+        sql = """
+            SELECT
+                id,
+                source_id,
+                fire_name,
+                ST_AsText(geom) AS geom,
+                source,
+                acres
+            FROM fire_perimeters
+            WHERE fire_end IS NULL OR fire_end > :now
+        """
+        rows = session.execute(text(sql), {"now": now}).fetchall()
+
+        if not rows:
+            LOGGER.info("perimeter_breach_watch: no active perimeters to check")
+            return []
+
+        LOGGER.info("perimeter_breach_watch: checking %d active perimeter(s)", len(rows))
+
+        results: list[dict[str, Any]] = []
+        for row in rows:
+            perimeter = {
+                "id": row.id,
+                "source_id": row.source_id,
+                "fire_name": row.fire_name,
+                "geom": row.geom,  # WKT from ST_AsText
+                "source": row.source,
+                "acres": row.acres,
+            }
+            result = check_perimeter_breach(perimeter, session)
+            if result is not None:
+                results.append(result)
+
+        LOGGER.info(
+            "perimeter_breach_watch: %d breach(es) detected across %d perimeter(s)",
+            len(results), len(rows),
+        )
+        return results
+
+    except Exception:
+        LOGGER.exception("perimeter_breach_watch: error fetching active perimeters")
+        return []

--- a/ingest/perimeter_growth_watch.py
+++ b/ingest/perimeter_growth_watch.py
@@ -1,0 +1,180 @@
+"""Perimeter growth delta watch.
+
+Detects rapid size increases in official fire perimeters by comparing the two
+most recent perimeter records for each fire.
+
+Thresholds (from NOTIFICATION_CONTRACTS.md):
+  - Growth > 10% AND >= 100 acres absolute → warning
+  - Growth > 25% AND >= 100 acres absolute → critical
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from api.notifications import notify
+
+LOGGER = logging.getLogger(__name__)
+
+_WARN_PCT = 10.0
+_CRITICAL_PCT = 25.0
+_MIN_ACRES = 100.0
+
+_ALL_SOURCES = ["nifc_wfigs", "cwfis", "copernicus_ems"]
+
+
+def _slugify(name: str) -> str:
+    """Return a notification-safe slug from a fire name."""
+    slug = name.lower().strip()
+    slug = re.sub(r"[^a-z0-9]+", "_", slug)
+    return slug.strip("_")
+
+
+def check_perimeter_growth(source: str, session: Any) -> list[dict[str, Any]]:
+    """Check for significant perimeter growth for all fires from *source*.
+
+    For each fire with at least two perimeter records (same fire_name, ordered
+    by created_at DESC), computes growth from the second-most-recent to the
+    most-recent and fires a notification if thresholds are met.
+
+    Args:
+        source:  Perimeter source string, e.g. "nifc_wfigs".
+        session: SQLAlchemy session.
+
+    Returns:
+        List of growth result dicts for fires that triggered an alert.
+    """
+    results: list[dict[str, Any]] = []
+
+    try:
+        from sqlalchemy import text  # local import to match ingest style
+
+        # Retrieve the two most-recent perimeters per fire_name for this source.
+        # We use a window function to rank rows within each fire group.
+        sql = """
+            WITH ranked AS (
+                SELECT
+                    fire_name,
+                    source_id,
+                    acres,
+                    created_at,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY fire_name
+                        ORDER BY created_at DESC
+                    ) AS rn
+                FROM fire_perimeters
+                WHERE source = :source
+                  AND fire_end IS NULL
+                  AND acres IS NOT NULL
+            )
+            SELECT
+                cur.fire_name,
+                cur.source_id       AS current_source_id,
+                cur.acres           AS current_acres,
+                cur.created_at      AS current_created_at,
+                prev.acres          AS prev_acres,
+                prev.created_at     AS prev_created_at
+            FROM ranked cur
+            JOIN ranked prev
+              ON cur.fire_name = prev.fire_name
+             AND cur.rn = 1
+             AND prev.rn = 2
+        """
+        rows = session.execute(text(sql), {"source": source}).fetchall()
+
+        if not rows:
+            LOGGER.info(
+                "perimeter_growth_watch: no fire pairs found for source=%s", source
+            )
+            return results
+
+        LOGGER.info(
+            "perimeter_growth_watch: checking %d fire pair(s) for source=%s",
+            len(rows), source,
+        )
+
+        for row in rows:
+            fire_name: str = row.fire_name
+            prev_acres: float = float(row.prev_acres)
+            current_acres: float = float(row.current_acres)
+
+            if prev_acres <= 0:
+                LOGGER.info(
+                    "perimeter_growth_watch: skipping %s — prev_acres=%.1f",
+                    fire_name, prev_acres,
+                )
+                continue
+
+            growth_pct = (current_acres - prev_acres) / prev_acres * 100.0
+            absolute_growth = current_acres - prev_acres
+
+            if growth_pct < _WARN_PCT or absolute_growth < _MIN_ACRES:
+                LOGGER.info(
+                    "perimeter_growth_watch: %s growth=%.1f%% abs=%.0f acres — below threshold",
+                    fire_name, growth_pct, absolute_growth,
+                )
+                continue
+
+            severity = "critical" if growth_pct >= _CRITICAL_PCT else "warning"
+            fire_name_slug = _slugify(fire_name)
+            event_type = f"perimeter_growth:{source}:{fire_name_slug}"
+
+            LOGGER.warning(
+                "perimeter_growth_watch: %s grew %.1f%% (%.0f → %.0f acres) severity=%s",
+                fire_name, growth_pct, prev_acres, current_acres, severity,
+            )
+
+            notify(
+                event_type,
+                title=f"{fire_name} perimeter grew {growth_pct:.0f}%",
+                body=(
+                    f"Official perimeter grew from {prev_acres:.0f} to "
+                    f"{current_acres:.0f} acres ({growth_pct:+.0f}%) since last update."
+                ),
+                severity=severity,
+                aoi_id=None,
+                fire_name=fire_name,
+                prev_acres=prev_acres,
+                current_acres=current_acres,
+                growth_pct=growth_pct,
+            )
+
+            results.append(
+                {
+                    "fire_name": fire_name,
+                    "source": source,
+                    "prev_acres": prev_acres,
+                    "current_acres": current_acres,
+                    "growth_pct": growth_pct,
+                    "severity": severity,
+                }
+            )
+
+    except Exception:
+        LOGGER.exception(
+            "perimeter_growth_watch: error checking source=%s", source
+        )
+
+    return results
+
+
+def run_perimeter_growth_checks(session: Any) -> list[dict[str, Any]]:
+    """Run perimeter growth checks across all known sources.
+
+    Sources checked: nifc_wfigs, cwfis, copernicus_ems.
+
+    Returns:
+        Flat list of growth result dicts from all sources combined.
+    """
+    all_results: list[dict[str, Any]] = []
+    for source in _ALL_SOURCES:
+        results = check_perimeter_growth(source, session)
+        all_results.extend(results)
+
+    LOGGER.info(
+        "perimeter_growth_watch: %d growth alert(s) across %d source(s)",
+        len(all_results), len(_ALL_SOURCES),
+    )
+    return all_results

--- a/ingest/perimeter_growth_watch.py
+++ b/ingest/perimeter_growth_watch.py
@@ -3,9 +3,14 @@
 Detects rapid size increases in official fire perimeters by comparing the two
 most recent perimeter records for each fire.
 
-Thresholds (from NOTIFICATION_CONTRACTS.md):
-  - Growth > 10% AND >= 100 acres absolute → warning
-  - Growth > 25% AND >= 100 acres absolute → critical
+Thresholds use size-tiered dual gates: alert fires on EITHER the absolute OR
+the percentage threshold, whichever is lower for the fire's current size.
+Critical takes precedence when both levels are exceeded.
+
+Tier table (max_current_acres, warn_pct, crit_pct, warn_abs, crit_abs):
+  - Small  (<  1,000 acres): 10%/25%, 50/200 acres absolute
+  - Medium ( 10,000 acres): 7%/15%, 200/750 acres absolute
+  - Large  (>  10,000 acres): 5%/10%, 500/2,000 acres absolute
 """
 
 from __future__ import annotations
@@ -18,9 +23,16 @@ from api.notifications import notify
 
 LOGGER = logging.getLogger(__name__)
 
-_WARN_PCT = 10.0
-_CRITICAL_PCT = 25.0
-_MIN_ACRES = 100.0
+# Thresholds: (max_current_acres, warn_pct, crit_pct, warn_abs, crit_abs)
+# Checked in order; first matching tier applies.
+_GROWTH_THRESHOLDS: list[tuple[float, float, float, float, float]] = [
+    # small fires  (< 1,000 acres)
+    (1_000.0,      10.0, 25.0,   50.0,   200.0),
+    # medium fires (1,000 – 10,000 acres)
+    (10_000.0,      7.0, 15.0,  200.0,   750.0),
+    # large fires  (> 10,000 acres)
+    (float("inf"),  5.0, 10.0,  500.0, 2_000.0),
+]
 
 _ALL_SOURCES = ["nifc_wfigs", "cwfis", "copernicus_ems"]
 
@@ -30,6 +42,46 @@ def _slugify(name: str) -> str:
     slug = name.lower().strip()
     slug = re.sub(r"[^a-z0-9]+", "_", slug)
     return slug.strip("_")
+
+
+def _determine_severity(
+    current_acres: float,
+    abs_growth: float,
+    growth_pct: float,
+) -> str | None:
+    """Return "critical", "warning", or None for the given growth metrics.
+
+    Looks up the size tier by *current_acres*, then fires on EITHER the
+    absolute OR the percentage gate (whichever is lower for this fire size).
+    Critical takes precedence over warning.
+
+    Args:
+        current_acres: Most-recent perimeter size in acres.
+        abs_growth:    Absolute acreage increase (current − previous).
+        growth_pct:    Percentage increase relative to previous size.
+
+    Returns:
+        "critical", "warning", or None.
+    """
+    warn_pct = crit_pct = warn_abs = crit_abs = None
+
+    for max_acres, wp, cp, wa, ca in _GROWTH_THRESHOLDS:
+        if current_acres <= max_acres:
+            warn_pct, crit_pct, warn_abs, crit_abs = wp, cp, wa, ca
+            break
+
+    if warn_pct is None:
+        # Fallback: use largest-fire tier (should never happen given float("inf"))
+        _, warn_pct, crit_pct, warn_abs, crit_abs = _GROWTH_THRESHOLDS[-1]
+
+    is_crit = growth_pct >= crit_pct or abs_growth >= crit_abs
+    is_warn = growth_pct >= warn_pct or abs_growth >= warn_abs
+
+    if is_crit:
+        return "critical"
+    if is_warn:
+        return "warning"
+    return None
 
 
 def check_perimeter_growth(source: str, session: Any) -> list[dict[str, Any]]:
@@ -108,16 +160,17 @@ def check_perimeter_growth(source: str, session: Any) -> list[dict[str, Any]]:
                 continue
 
             growth_pct = (current_acres - prev_acres) / prev_acres * 100.0
-            absolute_growth = current_acres - prev_acres
+            abs_growth = current_acres - prev_acres
 
-            if growth_pct < _WARN_PCT or absolute_growth < _MIN_ACRES:
+            severity = _determine_severity(current_acres, abs_growth, growth_pct)
+
+            if severity is None:
                 LOGGER.info(
                     "perimeter_growth_watch: %s growth=%.1f%% abs=%.0f acres — below threshold",
-                    fire_name, growth_pct, absolute_growth,
+                    fire_name, growth_pct, abs_growth,
                 )
                 continue
 
-            severity = "critical" if growth_pct >= _CRITICAL_PCT else "warning"
             fire_name_slug = _slugify(fire_name)
             event_type = f"perimeter_growth:{source}:{fire_name_slug}"
 
@@ -131,7 +184,8 @@ def check_perimeter_growth(source: str, session: Any) -> list[dict[str, Any]]:
                 title=f"{fire_name} perimeter grew {growth_pct:.0f}%",
                 body=(
                     f"Official perimeter grew from {prev_acres:.0f} to "
-                    f"{current_acres:.0f} acres ({growth_pct:+.0f}%) since last update."
+                    f"{current_acres:.0f} acres "
+                    f"(+{abs_growth:,.0f} acres, {growth_pct:+.0f}%) since last update."
                 ),
                 severity=severity,
                 aoi_id=None,
@@ -139,6 +193,7 @@ def check_perimeter_growth(source: str, session: Any) -> list[dict[str, Any]]:
                 prev_acres=prev_acres,
                 current_acres=current_acres,
                 growth_pct=growth_pct,
+                abs_growth=abs_growth,
             )
 
             results.append(
@@ -148,6 +203,7 @@ def check_perimeter_growth(source: str, session: Any) -> list[dict[str, Any]]:
                     "prev_acres": prev_acres,
                     "current_acres": current_acres,
                     "growth_pct": growth_pct,
+                    "abs_growth": abs_growth,
                     "severity": severity,
                 }
             )

--- a/ingest/spread_trajectory_watch.py
+++ b/ingest/spread_trajectory_watch.py
@@ -36,7 +36,29 @@ _KM_PER_DEG = 111.0
 
 # Default contour parameters
 _CONTOUR_THRESHOLD = 0.5
-_PREFERRED_HORIZON_H = 12
+
+# ICS operational planning horizons (hours).  Each horizon is checked
+# independently; a missing contour logs a WARNING and skips that horizon.
+_REQUIRED_HORIZONS: list[int] = [12, 24, 48, 72]
+
+# ── Transition gate state ─────────────────────────────────────────────────────
+# Module-level; best-effort (resets on restart).
+# science_grade target: persist to DB so restarts don't re-fire old alerts.
+# Key: "{aoi_id}:{horizon_hours}"
+# Value: {"bearing": float, "run_id": int, "severity": str}
+_last_alerted_state: dict[str, dict] = {}
+
+
+def reset_trajectory_state(aoi_id: str) -> None:
+    """Remove all transition-gate state for *aoi_id* across every horizon.
+
+    Call this when an AOI's watch is disabled, or from tests to get a clean
+    slate without reloading the module.
+    """
+    prefix = f"{aoi_id}:"
+    keys_to_delete = [k for k in _last_alerted_state if k.startswith(prefix)]
+    for k in keys_to_delete:
+        del _last_alerted_state[k]
 
 
 def _angular_difference(a: float, b: float) -> float:
@@ -64,7 +86,9 @@ def _severity_for(direction_change: float, speed_change_pct: float) -> str | Non
     return "critical" if "critical" in sev else "warning"
 
 
-def check_spread_trajectory(aoi: dict[str, Any], session: Any) -> dict[str, Any] | None:
+def check_spread_trajectory(
+    aoi: dict[str, Any], session: Any
+) -> list[dict[str, Any]] | None:
     """Check for significant trajectory shifts between the two most recent spread runs.
 
     Args:
@@ -72,7 +96,10 @@ def check_spread_trajectory(aoi: dict[str, Any], session: Any) -> dict[str, Any]
         session: SQLAlchemy connection/session obtained from the caller.
 
     Returns:
-        A dict with trajectory metadata if a threshold is exceeded, else None.
+        ``None`` if fewer than 2 completed runs exist (cannot compute a delta).
+        ``[]``   if runs exist but no horizon exceeded a threshold.
+        A list of result dicts (one per horizon that triggered), otherwise.
+        Each dict includes ``horizon_hours``.
     """
     aoi_id: UUID | str = aoi["id"]
     aoi_name: str = aoi["name"]
@@ -131,87 +158,7 @@ def check_spread_trajectory(aoi: dict[str, Any], session: Any) -> dict[str, Any]
         curr_run_id, curr_ref_time = runs[0]
         prev_run_id, prev_ref_time = runs[1]
 
-        # ── Step 2: Fetch contour centroids ──────────────────────────────────────
-        def _get_centroid(run_id: int) -> tuple[float, float] | None:
-            """Return (lon, lat) centroid of the best-matching contour, or None."""
-            # Try preferred horizon first; fall back to smallest available
-            centroid_sql = text(
-                """
-                SELECT
-                    ST_X(ST_Centroid(geom)) AS cx,
-                    ST_Y(ST_Centroid(geom)) AS cy,
-                    horizon_hours
-                FROM spread_forecast_contours
-                WHERE run_id = :run_id
-                  AND threshold = :threshold
-                ORDER BY
-                    ABS(horizon_hours - :preferred_h),
-                    horizon_hours
-                LIMIT 1
-                """
-            )
-            row = session.execute(
-                centroid_sql,
-                {
-                    "run_id": run_id,
-                    "threshold": _CONTOUR_THRESHOLD,
-                    "preferred_h": _PREFERRED_HORIZON_H,
-                },
-            ).fetchone()
-            if row is None:
-                return None
-            return (float(row[0]), float(row[1]))
-
-        curr_centroid = _get_centroid(curr_run_id)
-        prev_centroid = _get_centroid(prev_run_id)
-
-        if curr_centroid is None or prev_centroid is None:
-            LOGGER.info(
-                "spread_trajectory_watch: missing contour centroid for AOI %s "
-                "(curr_run=%s prev_run=%s) — skipping",
-                aoi_name, curr_run_id, prev_run_id,
-            )
-            return None
-
-        # ── Step 3: Compute bearings ──────────────────────────────────────────────
-        prev_lon, prev_lat = prev_centroid
-        curr_lon, curr_lat = curr_centroid
-
-        # Bearing from previous centroid to current centroid
-        delta_lon = curr_lon - prev_lon
-        delta_lat = curr_lat - prev_lat
-        current_bearing = math.degrees(math.atan2(delta_lon, delta_lat)) % 360.0
-
-        # ── Step 4 & 5: Speed proxy ───────────────────────────────────────────────
-        dist_sql = text(
-            """
-            SELECT ST_Distance(
-                ST_SetSRID(ST_MakePoint(:prev_lon, :prev_lat), 4326),
-                ST_SetSRID(ST_MakePoint(:curr_lon, :curr_lat), 4326)
-            ) AS dist_deg
-            """
-        )
-        dist_row = session.execute(
-            dist_sql,
-            {
-                "prev_lon": prev_lon,
-                "prev_lat": prev_lat,
-                "curr_lon": curr_lon,
-                "curr_lat": curr_lat,
-            },
-        ).fetchone()
-        dist_deg: float = float(dist_row[0]) if dist_row else 0.0
-        dist_km: float = dist_deg * _KM_PER_DEG
-
-        hours_between = abs(
-            (curr_ref_time - prev_ref_time).total_seconds() / 3600.0
-        )
-        current_speed_kmh = dist_km / hours_between if hours_between > 0 else 0.0
-
-        # ── Need the previous run's heading to compute direction change ───────────
-        # We need a third (even older) run to get the previous bearing.  Since the
-        # contract only asks us to compare consecutive runs, the "previous heading"
-        # is computed as the vector from the run-before-prev to prev.  Fetch it.
+        # ── Step 2: Fetch an older run for computing the previous heading ─────────
         older_sql = text(
             """
             SELECT id, forecast_reference_time
@@ -240,87 +187,206 @@ def check_spread_trajectory(aoi: dict[str, Any], session: Any) -> dict[str, Any]
             },
         ).fetchone()
 
-        direction_change = 0.0
-        speed_change_pct = 0.0
-        previous_bearing: float | None = None
+        older_run_id = older_run_row[0] if older_run_row is not None else None
+        older_ref_time = older_run_row[1] if older_run_row is not None else None
 
-        if older_run_row is not None:
-            older_run_id = older_run_row[0]
-            older_ref_time = older_run_row[1]
-            older_centroid = _get_centroid(older_run_id)
-
-            if older_centroid is not None:
-                older_lon, older_lat = older_centroid
-                d_lon = prev_lon - older_lon
-                d_lat = prev_lat - older_lat
-                previous_bearing = (
-                    math.degrees(math.atan2(d_lon, d_lat)) % 360.0
-                )
-
-                # Direction change
-                direction_change = _angular_difference(previous_bearing, current_bearing)
-
-                # Previous speed
-                prev_dist_deg = math.sqrt(
-                    (prev_lon - older_lon) ** 2 + (prev_lat - older_lat) ** 2
-                )
-                prev_dist_km = prev_dist_deg * _KM_PER_DEG
-                prev_hours = abs(
-                    (prev_ref_time - older_ref_time).total_seconds() / 3600.0
-                )
-                previous_speed_kmh = (
-                    prev_dist_km / prev_hours if prev_hours > 0 else 0.0
-                )
-
-                if previous_speed_kmh > 0:
-                    speed_change_pct = (
-                        (current_speed_kmh - previous_speed_kmh) / previous_speed_kmh * 100.0
-                    )
-                else:
-                    speed_change_pct = 0.0
-
-        # ── Step 8: Apply thresholds ──────────────────────────────────────────────
-        severity = _severity_for(direction_change, speed_change_pct)
-
-        if severity is None:
-            LOGGER.info(
-                "spread_trajectory_watch: AOI %s — direction_change=%.1f° "
-                "speed_change=%.1f%% — no threshold exceeded",
-                aoi_name, direction_change, speed_change_pct,
+        # ── Step 3: Helper — fetch the centroid for a specific horizon ────────────
+        def _get_centroid_at(
+            run_id: int, horizon_h: int
+        ) -> tuple[float, float] | None:
+            """Return (lon, lat) centroid for the exact horizon, or None."""
+            centroid_sql = text(
+                """
+                SELECT
+                    ST_X(ST_Centroid(geom)) AS cx,
+                    ST_Y(ST_Centroid(geom)) AS cy
+                FROM spread_forecast_contours
+                WHERE run_id = :run_id
+                  AND threshold = :threshold
+                  AND horizon_hours = :horizon_h
+                LIMIT 1
+                """
             )
-            return None
+            row = session.execute(
+                centroid_sql,
+                {
+                    "run_id": run_id,
+                    "threshold": _CONTOUR_THRESHOLD,
+                    "horizon_h": horizon_h,
+                },
+            ).fetchone()
+            if row is None:
+                return None
+            return (float(row[0]), float(row[1]))
 
-        # ── Step 9: Notify ────────────────────────────────────────────────────────
-        LOGGER.warning(
-            "spread_trajectory_watch: AOI %s — direction_change=%.1f° "
-            "speed_change=%.1f%% — severity=%s",
-            aoi_name, direction_change, speed_change_pct, severity,
-        )
-        notify(
-            f"spread_trajectory_shift:{aoi_id}",
-            title=f"Spread trajectory shifted for {aoi_name}",
-            body=(
-                f"Projected spread direction rotated {direction_change:.0f}° "
-                f"and speed changed {speed_change_pct:+.0f}% vs previous model run."
-            ),
-            severity=severity,
-            denoised_score=None,
-            aoi_id=str(aoi_id),
-            direction_change_deg=direction_change,
-            speed_change_pct=speed_change_pct,
-            current_bearing_deg=current_bearing,
-        )
+        # ── Step 4: Loop over required horizons ───────────────────────────────────
+        results: list[dict[str, Any]] = []
 
-        return {
-            "aoi_id": str(aoi_id),
-            "aoi_name": aoi_name,
-            "severity": severity,
-            "direction_change_deg": direction_change,
-            "speed_change_pct": speed_change_pct,
-            "current_bearing_deg": current_bearing,
-            "previous_bearing_deg": previous_bearing,
-            "current_speed_kmh": current_speed_kmh,
-        }
+        for h in _REQUIRED_HORIZONS:
+            curr_centroid = _get_centroid_at(curr_run_id, h)
+            if curr_centroid is None:
+                LOGGER.warning(
+                    "spread_trajectory_watch: no contour at %dh for AOI %s — "
+                    "ICS %dh outlook unavailable",
+                    h, aoi_name, h,
+                )
+                continue
+
+            prev_centroid = _get_centroid_at(prev_run_id, h)
+            if prev_centroid is None:
+                LOGGER.warning(
+                    "spread_trajectory_watch: no contour at %dh for AOI %s — "
+                    "ICS %dh outlook unavailable",
+                    h, aoi_name, h,
+                )
+                continue
+
+            # ── Bearing and speed for curr→prev leg ──────────────────────────────
+            prev_lon, prev_lat = prev_centroid
+            curr_lon, curr_lat = curr_centroid
+
+            delta_lon = curr_lon - prev_lon
+            delta_lat = curr_lat - prev_lat
+            current_bearing = (
+                math.degrees(math.atan2(delta_lon, delta_lat)) % 360.0
+            )
+
+            dist_sql = text(
+                """
+                SELECT ST_Distance(
+                    ST_SetSRID(ST_MakePoint(:prev_lon, :prev_lat), 4326),
+                    ST_SetSRID(ST_MakePoint(:curr_lon, :curr_lat), 4326)
+                ) AS dist_deg
+                """
+            )
+            dist_row = session.execute(
+                dist_sql,
+                {
+                    "prev_lon": prev_lon,
+                    "prev_lat": prev_lat,
+                    "curr_lon": curr_lon,
+                    "curr_lat": curr_lat,
+                },
+            ).fetchone()
+            dist_deg: float = float(dist_row[0]) if dist_row else 0.0
+            dist_km: float = dist_deg * _KM_PER_DEG
+
+            hours_between = abs(
+                (curr_ref_time - prev_ref_time).total_seconds() / 3600.0
+            )
+            current_speed_kmh = (
+                dist_km / hours_between if hours_between > 0 else 0.0
+            )
+
+            # ── Direction change and previous speed (need older run) ──────────────
+            direction_change = 0.0
+            speed_change_pct = 0.0
+            previous_bearing: float | None = None
+
+            if older_run_id is not None:
+                older_centroid = _get_centroid_at(older_run_id, h)
+
+                if older_centroid is not None:
+                    older_lon, older_lat = older_centroid
+
+                    d_lon = prev_lon - older_lon
+                    d_lat = prev_lat - older_lat
+                    previous_bearing = (
+                        math.degrees(math.atan2(d_lon, d_lat)) % 360.0
+                    )
+
+                    direction_change = _angular_difference(
+                        previous_bearing, current_bearing
+                    )
+
+                    prev_dist_deg = math.sqrt(
+                        (prev_lon - older_lon) ** 2 + (prev_lat - older_lat) ** 2
+                    )
+                    prev_dist_km = prev_dist_deg * _KM_PER_DEG
+                    prev_hours = abs(
+                        (prev_ref_time - older_ref_time).total_seconds() / 3600.0
+                    )
+                    previous_speed_kmh = (
+                        prev_dist_km / prev_hours if prev_hours > 0 else 0.0
+                    )
+
+                    if previous_speed_kmh > 0:
+                        speed_change_pct = (
+                            (current_speed_kmh - previous_speed_kmh)
+                            / previous_speed_kmh
+                            * 100.0
+                        )
+
+            # ── Apply thresholds ──────────────────────────────────────────────────
+            severity = _severity_for(direction_change, speed_change_pct)
+
+            if severity is None:
+                LOGGER.info(
+                    "spread_trajectory_watch: AOI %s %dh — direction_change=%.1f° "
+                    "speed_change=%.1f%% — no threshold exceeded",
+                    aoi_name, h, direction_change, speed_change_pct,
+                )
+                continue
+
+            # ── Transition gate: suppress re-alerts on sustained shifts ───────────
+            gate_key = f"{aoi_id}:{h}"
+            prior = _last_alerted_state.get(gate_key)
+            if prior is not None:
+                additional_shift = _angular_difference(
+                    prior["bearing"], current_bearing
+                )
+                if additional_shift < _DIR_WARN_DEG and severity == prior["severity"]:
+                    LOGGER.info(
+                        "spread_trajectory_watch: suppressing re-alert for AOI %s "
+                        "%dh (additional_shift=%.1f°, same severity)",
+                        aoi_name, h, additional_shift,
+                    )
+                    continue
+
+            # ── Notify ────────────────────────────────────────────────────────────
+            LOGGER.warning(
+                "spread_trajectory_watch: AOI %s %dh — direction_change=%.1f° "
+                "speed_change=%.1f%% — severity=%s",
+                aoi_name, h, direction_change, speed_change_pct, severity,
+            )
+            notify(
+                f"spread_trajectory_shift:{aoi_id}:{h}",
+                title=f"Spread trajectory shifted ({h}h outlook) for {aoi_name}",
+                body=(
+                    f"Projected spread direction rotated {direction_change:.0f}° "
+                    f"and speed changed {speed_change_pct:+.0f}% vs previous model run."
+                ),
+                severity=severity,
+                denoised_score=None,
+                aoi_id=str(aoi_id),
+                horizon_hours=h,
+                direction_change_deg=direction_change,
+                speed_change_pct=speed_change_pct,
+                current_bearing_deg=current_bearing,
+            )
+
+            # Update transition gate state
+            _last_alerted_state[gate_key] = {
+                "bearing": current_bearing,
+                "run_id": curr_run_id,
+                "severity": severity,
+            }
+
+            results.append(
+                {
+                    "aoi_id": str(aoi_id),
+                    "aoi_name": aoi_name,
+                    "horizon_hours": h,
+                    "severity": severity,
+                    "direction_change_deg": direction_change,
+                    "speed_change_pct": speed_change_pct,
+                    "current_bearing_deg": current_bearing,
+                    "previous_bearing_deg": previous_bearing,
+                    "current_speed_kmh": current_speed_kmh,
+                }
+            )
+
+        return results
 
     except Exception as exc:
         LOGGER.error(
@@ -342,11 +408,11 @@ def run_spread_trajectory_checks(
         session: SQLAlchemy connection/session.
 
     Returns:
-        List of non-None results from check_spread_trajectory.
+        Flat list of result dicts from all AOIs and all horizons that triggered.
     """
     results: list[dict[str, Any]] = []
     for aoi in aois:
-        result = check_spread_trajectory(aoi, session)
-        if result is not None:
-            results.append(result)
+        horizon_results = check_spread_trajectory(aoi, session)
+        if horizon_results is not None:
+            results.extend(horizon_results)
     return results

--- a/ingest/spread_trajectory_watch.py
+++ b/ingest/spread_trajectory_watch.py
@@ -21,6 +21,7 @@ from uuid import UUID
 
 from sqlalchemy import text
 
+from api.aoi_utils import _is_notifications_paused
 from api.notifications import notify
 
 LOGGER = logging.getLogger(__name__)
@@ -412,6 +413,12 @@ def run_spread_trajectory_checks(
     """
     results: list[dict[str, Any]] = []
     for aoi in aois:
+        if _is_notifications_paused(aoi):
+            LOGGER.info(
+                "spread_trajectory_watch: notifications paused for AOI %s — skipping",
+                aoi.get("name"),
+            )
+            continue
         horizon_results = check_spread_trajectory(aoi, session)
         if horizon_results is not None:
             results.extend(horizon_results)

--- a/ingest/spread_trajectory_watch.py
+++ b/ingest/spread_trajectory_watch.py
@@ -350,7 +350,7 @@ def check_spread_trajectory(
                 "speed_change=%.1f%% — severity=%s",
                 aoi_name, h, direction_change, speed_change_pct, severity,
             )
-            notify(
+            dispatched = notify(
                 f"spread_trajectory_shift:{aoi_id}:{h}",
                 title=f"Spread trajectory shifted ({h}h outlook) for {aoi_name}",
                 body=(
@@ -366,12 +366,22 @@ def check_spread_trajectory(
                 current_bearing_deg=current_bearing,
             )
 
-            # Update transition gate state
-            _last_alerted_state[gate_key] = {
-                "bearing": current_bearing,
-                "run_id": curr_run_id,
-                "severity": severity,
-            }
+            # Only advance the transition gate when the notification was actually
+            # dispatched.  If notify() returned False (burst cap, rate limit, no
+            # channel), the gate must NOT be updated — the next genuine shift must
+            # still be allowed to fire.
+            if dispatched:
+                _last_alerted_state[gate_key] = {
+                    "bearing": current_bearing,
+                    "run_id": curr_run_id,
+                    "severity": severity,
+                }
+            else:
+                LOGGER.debug(
+                    "spread_trajectory_watch: notify() suppressed for AOI %s %dh — "
+                    "gate state NOT advanced",
+                    aoi_name, h,
+                )
 
             results.append(
                 {

--- a/ingest/spread_trajectory_watch.py
+++ b/ingest/spread_trajectory_watch.py
@@ -1,0 +1,352 @@
+"""Spread trajectory deviation watch.
+
+Checks whether consecutive spread forecast runs show a significant change in
+projected fire spread direction or speed.  Called as part of the operational
+watch cycle; results in a notify() call when thresholds from the shared
+notification contract are exceeded.
+
+Spread deviation thresholds (NOTIFICATION_CONTRACTS.md):
+    Direction rotation > 30°: Warning
+    Direction rotation > 45°: Critical
+    Speed increase  > 50%:   Warning
+    Speed increase  > 100%:  Critical
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+
+from api.notifications import notify
+
+LOGGER = logging.getLogger(__name__)
+
+# ── Thresholds ────────────────────────────────────────────────────────────────
+_DIR_WARN_DEG = 30.0
+_DIR_CRIT_DEG = 45.0
+_SPEED_WARN_PCT = 50.0
+_SPEED_CRIT_PCT = 100.0
+
+# km per degree of latitude (approximate)
+_KM_PER_DEG = 111.0
+
+# Default contour parameters
+_CONTOUR_THRESHOLD = 0.5
+_PREFERRED_HORIZON_H = 12
+
+
+def _angular_difference(a: float, b: float) -> float:
+    """Return the absolute shortest angular difference between two bearings (0-180°)."""
+    diff = abs(a - b) % 360.0
+    return diff if diff <= 180.0 else 360.0 - diff
+
+
+def _severity_for(direction_change: float, speed_change_pct: float) -> str | None:
+    """Return the max severity triggered, or None if no threshold is exceeded."""
+    sev: list[str] = []
+
+    if direction_change > _DIR_CRIT_DEG:
+        sev.append("critical")
+    elif direction_change > _DIR_WARN_DEG:
+        sev.append("warning")
+
+    if speed_change_pct > _SPEED_CRIT_PCT:
+        sev.append("critical")
+    elif speed_change_pct > _SPEED_WARN_PCT:
+        sev.append("warning")
+
+    if not sev:
+        return None
+    return "critical" if "critical" in sev else "warning"
+
+
+def check_spread_trajectory(aoi: dict[str, Any], session: Any) -> dict[str, Any] | None:
+    """Check for significant trajectory shifts between the two most recent spread runs.
+
+    Args:
+        aoi:     Dict with at least ``id``, ``name``, and ``bbox`` (GeoJSON Polygon).
+        session: SQLAlchemy connection/session obtained from the caller.
+
+    Returns:
+        A dict with trajectory metadata if a threshold is exceeded, else None.
+    """
+    aoi_id: UUID | str = aoi["id"]
+    aoi_name: str = aoi["name"]
+
+    try:
+        bbox: dict[str, Any] = aoi["bbox"]
+        coords = bbox["coordinates"][0]
+        lons = [c[0] for c in coords]
+        lats = [c[1] for c in coords]
+        min_lon, max_lon = min(lons), max(lons)
+        min_lat, max_lat = min(lats), max(lats)
+    except (KeyError, IndexError, TypeError) as exc:
+        LOGGER.error(
+            "spread_trajectory_watch: could not parse bbox for AOI %s (%s): %s",
+            aoi_name, aoi_id, exc,
+        )
+        return None
+
+    try:
+        # ── Step 1: Fetch the two most recent COMPLETED runs that intersect the AOI ──
+        runs_sql = text(
+            """
+            SELECT id, forecast_reference_time
+            FROM spread_forecast_runs
+            WHERE status = 'completed'
+              AND ST_Intersects(
+                    bbox,
+                    ST_SetSRID(
+                        ST_MakeEnvelope(:min_lon, :min_lat, :max_lon, :max_lat),
+                        4326
+                    )
+                  )
+            ORDER BY forecast_reference_time DESC
+            LIMIT 2
+            """
+        )
+        runs = session.execute(
+            runs_sql,
+            {
+                "min_lon": min_lon,
+                "min_lat": min_lat,
+                "max_lon": max_lon,
+                "max_lat": max_lat,
+            },
+        ).fetchall()
+
+        if len(runs) < 2:
+            LOGGER.info(
+                "spread_trajectory_watch: only %d completed run(s) for AOI %s — "
+                "cannot compute delta, skipping",
+                len(runs), aoi_name,
+            )
+            return None
+
+        # runs[0] is the most recent (current), runs[1] is the previous
+        curr_run_id, curr_ref_time = runs[0]
+        prev_run_id, prev_ref_time = runs[1]
+
+        # ── Step 2: Fetch contour centroids ──────────────────────────────────────
+        def _get_centroid(run_id: int) -> tuple[float, float] | None:
+            """Return (lon, lat) centroid of the best-matching contour, or None."""
+            # Try preferred horizon first; fall back to smallest available
+            centroid_sql = text(
+                """
+                SELECT
+                    ST_X(ST_Centroid(geom)) AS cx,
+                    ST_Y(ST_Centroid(geom)) AS cy,
+                    horizon_hours
+                FROM spread_forecast_contours
+                WHERE run_id = :run_id
+                  AND threshold = :threshold
+                ORDER BY
+                    ABS(horizon_hours - :preferred_h),
+                    horizon_hours
+                LIMIT 1
+                """
+            )
+            row = session.execute(
+                centroid_sql,
+                {
+                    "run_id": run_id,
+                    "threshold": _CONTOUR_THRESHOLD,
+                    "preferred_h": _PREFERRED_HORIZON_H,
+                },
+            ).fetchone()
+            if row is None:
+                return None
+            return (float(row[0]), float(row[1]))
+
+        curr_centroid = _get_centroid(curr_run_id)
+        prev_centroid = _get_centroid(prev_run_id)
+
+        if curr_centroid is None or prev_centroid is None:
+            LOGGER.info(
+                "spread_trajectory_watch: missing contour centroid for AOI %s "
+                "(curr_run=%s prev_run=%s) — skipping",
+                aoi_name, curr_run_id, prev_run_id,
+            )
+            return None
+
+        # ── Step 3: Compute bearings ──────────────────────────────────────────────
+        prev_lon, prev_lat = prev_centroid
+        curr_lon, curr_lat = curr_centroid
+
+        # Bearing from previous centroid to current centroid
+        delta_lon = curr_lon - prev_lon
+        delta_lat = curr_lat - prev_lat
+        current_bearing = math.degrees(math.atan2(delta_lon, delta_lat)) % 360.0
+
+        # ── Step 4 & 5: Speed proxy ───────────────────────────────────────────────
+        dist_sql = text(
+            """
+            SELECT ST_Distance(
+                ST_SetSRID(ST_MakePoint(:prev_lon, :prev_lat), 4326),
+                ST_SetSRID(ST_MakePoint(:curr_lon, :curr_lat), 4326)
+            ) AS dist_deg
+            """
+        )
+        dist_row = session.execute(
+            dist_sql,
+            {
+                "prev_lon": prev_lon,
+                "prev_lat": prev_lat,
+                "curr_lon": curr_lon,
+                "curr_lat": curr_lat,
+            },
+        ).fetchone()
+        dist_deg: float = float(dist_row[0]) if dist_row else 0.0
+        dist_km: float = dist_deg * _KM_PER_DEG
+
+        hours_between = abs(
+            (curr_ref_time - prev_ref_time).total_seconds() / 3600.0
+        )
+        current_speed_kmh = dist_km / hours_between if hours_between > 0 else 0.0
+
+        # ── Need the previous run's heading to compute direction change ───────────
+        # We need a third (even older) run to get the previous bearing.  Since the
+        # contract only asks us to compare consecutive runs, the "previous heading"
+        # is computed as the vector from the run-before-prev to prev.  Fetch it.
+        older_sql = text(
+            """
+            SELECT id, forecast_reference_time
+            FROM spread_forecast_runs
+            WHERE status = 'completed'
+              AND ST_Intersects(
+                    bbox,
+                    ST_SetSRID(
+                        ST_MakeEnvelope(:min_lon, :min_lat, :max_lon, :max_lat),
+                        4326
+                    )
+                  )
+              AND forecast_reference_time < :prev_ref_time
+            ORDER BY forecast_reference_time DESC
+            LIMIT 1
+            """
+        )
+        older_run_row = session.execute(
+            older_sql,
+            {
+                "min_lon": min_lon,
+                "min_lat": min_lat,
+                "max_lon": max_lon,
+                "max_lat": max_lat,
+                "prev_ref_time": prev_ref_time,
+            },
+        ).fetchone()
+
+        direction_change = 0.0
+        speed_change_pct = 0.0
+        previous_bearing: float | None = None
+
+        if older_run_row is not None:
+            older_run_id = older_run_row[0]
+            older_ref_time = older_run_row[1]
+            older_centroid = _get_centroid(older_run_id)
+
+            if older_centroid is not None:
+                older_lon, older_lat = older_centroid
+                d_lon = prev_lon - older_lon
+                d_lat = prev_lat - older_lat
+                previous_bearing = (
+                    math.degrees(math.atan2(d_lon, d_lat)) % 360.0
+                )
+
+                # Direction change
+                direction_change = _angular_difference(previous_bearing, current_bearing)
+
+                # Previous speed
+                prev_dist_deg = math.sqrt(
+                    (prev_lon - older_lon) ** 2 + (prev_lat - older_lat) ** 2
+                )
+                prev_dist_km = prev_dist_deg * _KM_PER_DEG
+                prev_hours = abs(
+                    (prev_ref_time - older_ref_time).total_seconds() / 3600.0
+                )
+                previous_speed_kmh = (
+                    prev_dist_km / prev_hours if prev_hours > 0 else 0.0
+                )
+
+                if previous_speed_kmh > 0:
+                    speed_change_pct = (
+                        (current_speed_kmh - previous_speed_kmh) / previous_speed_kmh * 100.0
+                    )
+                else:
+                    speed_change_pct = 0.0
+
+        # ── Step 8: Apply thresholds ──────────────────────────────────────────────
+        severity = _severity_for(direction_change, speed_change_pct)
+
+        if severity is None:
+            LOGGER.info(
+                "spread_trajectory_watch: AOI %s — direction_change=%.1f° "
+                "speed_change=%.1f%% — no threshold exceeded",
+                aoi_name, direction_change, speed_change_pct,
+            )
+            return None
+
+        # ── Step 9: Notify ────────────────────────────────────────────────────────
+        LOGGER.warning(
+            "spread_trajectory_watch: AOI %s — direction_change=%.1f° "
+            "speed_change=%.1f%% — severity=%s",
+            aoi_name, direction_change, speed_change_pct, severity,
+        )
+        notify(
+            f"spread_trajectory_shift:{aoi_id}",
+            title=f"Spread trajectory shifted for {aoi_name}",
+            body=(
+                f"Projected spread direction rotated {direction_change:.0f}° "
+                f"and speed changed {speed_change_pct:+.0f}% vs previous model run."
+            ),
+            severity=severity,
+            denoised_score=None,
+            aoi_id=str(aoi_id),
+            direction_change_deg=direction_change,
+            speed_change_pct=speed_change_pct,
+            current_bearing_deg=current_bearing,
+        )
+
+        return {
+            "aoi_id": str(aoi_id),
+            "aoi_name": aoi_name,
+            "severity": severity,
+            "direction_change_deg": direction_change,
+            "speed_change_pct": speed_change_pct,
+            "current_bearing_deg": current_bearing,
+            "previous_bearing_deg": previous_bearing,
+            "current_speed_kmh": current_speed_kmh,
+        }
+
+    except Exception as exc:
+        LOGGER.error(
+            "spread_trajectory_watch: unexpected error for AOI %s (%s): %s",
+            aoi_name, aoi_id, exc,
+            exc_info=True,
+        )
+        return None
+
+
+def run_spread_trajectory_checks(
+    aois: list[dict[str, Any]],
+    session: Any,
+) -> list[dict[str, Any]]:
+    """Run spread trajectory checks for every watched AOI.
+
+    Args:
+        aois:    List of AOI dicts (same shape as produced by list_watched_aois_due).
+        session: SQLAlchemy connection/session.
+
+    Returns:
+        List of non-None results from check_spread_trajectory.
+    """
+    results: list[dict[str, Any]] = []
+    for aoi in aois:
+        result = check_spread_trajectory(aoi, session)
+        if result is not None:
+            results.append(result)
+    return results

--- a/ingest/tests/test_aoi_pause_notifications.py
+++ b/ingest/tests/test_aoi_pause_notifications.py
@@ -1,0 +1,229 @@
+"""Tests for per-AOI notification pause (operator mute) feature."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+_NOW = datetime(2026, 4, 3, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_aoi(**overrides) -> dict:
+    base = {
+        "id": uuid4(),
+        "name": "Test AOI",
+        "bbox": {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]},
+        "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]},
+        "watch_enabled": True,
+        "watch_interval_minutes": 30,
+        "watch_alert_threshold": 0.5,
+        "watch_last_checked_at": None,
+        "watch_last_alerted_at": None,
+        "watch_last_spread_prob": None,
+        "watch_notifications_paused_until": None,
+    }
+    base.update(overrides)
+    return base
+
+
+# ── check_new_ignition: paused AOI skips notify ───────────────────────────────
+
+def test_paused_aoi_skips_notify_in_new_ignition():
+    """When notifications are paused, check_new_ignition runs the DB query but
+    does NOT call notify()."""
+    from ingest.aoi_watch import check_new_ignition
+
+    aoi = _make_aoi(
+        watch_notifications_paused_until=_NOW + timedelta(hours=2),
+    )
+
+    # Two qualifying detections within the cluster radius, both new
+    mock_rows = [
+        {
+            "id": uuid4(),
+            "lat": 37.0,
+            "lon": -120.0,
+            "acq_time": _NOW - timedelta(minutes=30),
+            "denoised_score": 0.85,
+            "event_id": None,
+            "event_started_at": None,
+        },
+        {
+            "id": uuid4(),
+            "lat": 37.001,
+            "lon": -120.001,
+            "acq_time": _NOW - timedelta(minutes=25),
+            "denoised_score": 0.90,
+            "event_id": None,
+            "event_started_at": None,
+        },
+    ]
+
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value.mappings.return_value.all.return_value = mock_rows
+    mock_engine = MagicMock()
+    mock_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    mock_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch("ingest.aoi_watch.notify") as mock_notify, \
+         patch("ingest.aoi_watch.get_engine", return_value=mock_engine):
+        result = check_new_ignition(aoi, engine=mock_engine, _now=_NOW)
+
+    # A cluster was found but notify must not have been called
+    assert result is not None
+    mock_notify.assert_not_called()
+
+
+def test_expired_pause_allows_notify():
+    """When the pause timestamp is in the past (expired), notify IS called."""
+    from datetime import datetime, timezone
+
+    from ingest.aoi_watch import check_new_ignition
+
+    # Use real now() so the expired timestamp is genuinely in the past.
+    real_now = datetime.now(timezone.utc)
+    aoi = _make_aoi(
+        watch_notifications_paused_until=real_now - timedelta(hours=1),
+    )
+
+    mock_rows = [
+        {
+            "id": uuid4(),
+            "lat": 37.0,
+            "lon": -120.0,
+            "acq_time": _NOW - timedelta(minutes=30),
+            "denoised_score": 0.85,
+            "event_id": None,
+            "event_started_at": None,
+        },
+        {
+            "id": uuid4(),
+            "lat": 37.001,
+            "lon": -120.001,
+            "acq_time": _NOW - timedelta(minutes=25),
+            "denoised_score": 0.90,
+            "event_id": None,
+            "event_started_at": None,
+        },
+    ]
+
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value.mappings.return_value.all.return_value = mock_rows
+    mock_engine = MagicMock()
+    mock_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    mock_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch("ingest.aoi_watch.notify") as mock_notify, \
+         patch("ingest.aoi_watch.get_engine", return_value=mock_engine):
+        result = check_new_ignition(aoi, engine=mock_engine, _now=_NOW)
+
+    assert result is not None
+    mock_notify.assert_called_once()
+
+
+def test_no_pause_field_allows_notify():
+    """AOI with no paused_until key treats notifications as active."""
+    from ingest.aoi_watch import check_new_ignition
+
+    aoi = _make_aoi()
+    # Verify the field is absent, not just None
+    aoi.pop("watch_notifications_paused_until", None)
+
+    mock_rows = [
+        {
+            "id": uuid4(),
+            "lat": 37.0,
+            "lon": -120.0,
+            "acq_time": _NOW - timedelta(minutes=30),
+            "denoised_score": 0.85,
+            "event_id": None,
+            "event_started_at": None,
+        },
+        {
+            "id": uuid4(),
+            "lat": 37.001,
+            "lon": -120.001,
+            "acq_time": _NOW - timedelta(minutes=25),
+            "denoised_score": 0.90,
+            "event_id": None,
+            "event_started_at": None,
+        },
+    ]
+
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value.mappings.return_value.all.return_value = mock_rows
+    mock_engine = MagicMock()
+    mock_engine.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    mock_engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch("ingest.aoi_watch.notify") as mock_notify, \
+         patch("ingest.aoi_watch.get_engine", return_value=mock_engine):
+        result = check_new_ignition(aoi, engine=mock_engine, _now=_NOW)
+
+    assert result is not None
+    mock_notify.assert_called_once()
+
+
+# ── run_spread_trajectory_checks: paused AOI skips check_spread_trajectory ────
+
+def test_spread_trajectory_skips_paused_aoi():
+    """run_spread_trajectory_checks skips check_spread_trajectory for paused AOIs."""
+    from ingest.spread_trajectory_watch import run_spread_trajectory_checks
+
+    paused_aoi = _make_aoi(
+        watch_notifications_paused_until=_NOW + timedelta(hours=3),
+    )
+    session = MagicMock()
+
+    with patch("ingest.spread_trajectory_watch.check_spread_trajectory") as mock_check:
+        results = run_spread_trajectory_checks([paused_aoi], session)
+
+    mock_check.assert_not_called()
+    assert results == []
+
+
+def test_spread_trajectory_runs_for_active_aoi():
+    """run_spread_trajectory_checks calls check_spread_trajectory when not paused."""
+    from ingest.spread_trajectory_watch import run_spread_trajectory_checks
+
+    active_aoi = _make_aoi()
+    session = MagicMock()
+
+    with patch("ingest.spread_trajectory_watch.check_spread_trajectory", return_value=[]) as mock_check:
+        results = run_spread_trajectory_checks([active_aoi], session)
+
+    mock_check.assert_called_once_with(active_aoi, session)
+
+
+# ── run_weather_threshold_checks: paused AOI skips check_weather_thresholds ───
+
+def test_weather_threshold_skips_paused_aoi():
+    """run_weather_threshold_checks skips check_weather_thresholds for paused AOIs."""
+    from ingest.weather_threshold_watch import run_weather_threshold_checks
+
+    paused_aoi = _make_aoi(
+        watch_notifications_paused_until=_NOW + timedelta(hours=1),
+    )
+    session = MagicMock()
+
+    with patch("ingest.weather_threshold_watch.check_weather_thresholds") as mock_check:
+        results = run_weather_threshold_checks([paused_aoi], session)
+
+    mock_check.assert_not_called()
+    assert results == []
+
+
+def test_weather_threshold_runs_for_active_aoi():
+    """run_weather_threshold_checks calls check_weather_thresholds when not paused."""
+    from ingest.weather_threshold_watch import run_weather_threshold_checks
+
+    active_aoi = _make_aoi()
+    session = MagicMock()
+
+    with patch("ingest.weather_threshold_watch.check_weather_thresholds", return_value=None) as mock_check:
+        results = run_weather_threshold_checks([active_aoi], session)
+
+    mock_check.assert_called_once_with(active_aoi, session)

--- a/ingest/tests/test_aoi_pause_notifications.py
+++ b/ingest/tests/test_aoi_pause_notifications.py
@@ -6,8 +6,6 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
-import pytest
-
 _NOW = datetime(2026, 4, 3, 12, 0, 0, tzinfo=timezone.utc)
 
 
@@ -193,7 +191,7 @@ def test_spread_trajectory_runs_for_active_aoi():
     session = MagicMock()
 
     with patch("ingest.spread_trajectory_watch.check_spread_trajectory", return_value=[]) as mock_check:
-        results = run_spread_trajectory_checks([active_aoi], session)
+        run_spread_trajectory_checks([active_aoi], session)
 
     mock_check.assert_called_once_with(active_aoi, session)
 
@@ -224,6 +222,6 @@ def test_weather_threshold_runs_for_active_aoi():
     session = MagicMock()
 
     with patch("ingest.weather_threshold_watch.check_weather_thresholds", return_value=None) as mock_check:
-        results = run_weather_threshold_checks([active_aoi], session)
+        run_weather_threshold_checks([active_aoi], session)
 
     mock_check.assert_called_once_with(active_aoi, session)

--- a/ingest/tests/test_new_ignition_watch.py
+++ b/ingest/tests/test_new_ignition_watch.py
@@ -1,0 +1,308 @@
+"""Tests for check_new_ignition in ingest.aoi_watch."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+
+from ingest.aoi_watch import check_new_ignition
+
+_NOW = datetime(2026, 4, 3, 12, 0, 0, tzinfo=timezone.utc)
+_TWO_H_AGO = _NOW - timedelta(hours=2)
+_THREE_H_AGO = _NOW - timedelta(hours=3)
+
+# A minimal GeoJSON polygon that wraps roughly (0°,0°) to (1°,1°).
+_AOI_GEOMETRY = {
+    "type": "Polygon",
+    "coordinates": [[[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]]],
+}
+
+
+def _make_aoi(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "id": uuid4(),
+        "name": "Test AOI",
+        "geometry": _AOI_GEOMETRY,
+        "watch_enabled": True,
+        "watch_interval_minutes": 30,
+        "watch_alert_threshold": 0.5,
+        "watch_last_checked_at": None,
+        "watch_last_alerted_at": None,
+        "watch_last_spread_prob": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_detection(
+    *,
+    lat: float = 0.5,
+    lon: float = 0.5,
+    denoised_score: float = 0.85,
+    is_noise: bool = False,
+    false_source_masked: bool = False,
+    event_id: str | None = None,
+    event_started_at: datetime | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": str(uuid4()),
+        "lat": lat,
+        "lon": lon,
+        "denoised_score": denoised_score,
+        "is_noise": is_noise,
+        "false_source_masked": false_source_masked,
+        "event_id": event_id,
+        "event_started_at": event_started_at,
+    }
+
+
+class _MockMappings:
+    """Mimics SQLAlchemy .mappings().all() result."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def mappings(self) -> "_MockMappings":
+        return self
+
+    def all(self) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class _MockConn:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def execute(self, stmt, params=None) -> _MockMappings:
+        return _MockMappings(self._rows)
+
+
+class _MockEngine:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    @contextmanager
+    def begin(self):
+        yield _MockConn(self._rows)
+
+
+# ── qualifying cluster → notify called ────────────────────────────────────────
+
+
+def test_qualifying_cluster_fires_notify() -> None:
+    """Two qualifying detections close together trigger a new_ignition notification."""
+    aoi = _make_aoi()
+    aoi_id = str(aoi["id"])
+
+    detections = [
+        _make_detection(lat=0.5, lon=0.5, denoised_score=0.90),
+        _make_detection(lat=0.501, lon=0.501, denoised_score=0.80),  # ~140 m apart
+    ]
+    engine = _MockEngine(detections)
+
+    mock_notify = MagicMock()
+    with patch("ingest.aoi_watch.notify", mock_notify):
+        result = check_new_ignition(aoi, engine=engine, _now=_NOW)
+
+    assert result is not None, "Expected a cluster result dict"
+    mock_notify.assert_called_once()
+
+    call_kwargs = mock_notify.call_args.kwargs if mock_notify.call_args.kwargs else {}
+    call_args = mock_notify.call_args.args if mock_notify.call_args.args else ()
+
+    # event_type is the first positional arg.
+    event_type = call_args[0] if call_args else call_kwargs.get("event_type", "")
+    assert event_type == f"new_ignition:{aoi_id}"
+
+    assert call_kwargs.get("severity") == "critical"
+    assert float(call_kwargs.get("denoised_score", 0)) > 0
+    assert call_kwargs.get("aoi_id") == aoi_id
+    assert int(call_kwargs.get("detection_count", 0)) >= 2
+
+
+def test_qualifying_cluster_returns_cluster_info() -> None:
+    """Return dict contains the expected keys and valid values."""
+    aoi = _make_aoi()
+    detections = [
+        _make_detection(lat=0.5, lon=0.5, denoised_score=0.95),
+        _make_detection(lat=0.501, lon=0.501, denoised_score=0.75),
+    ]
+    engine = _MockEngine(detections)
+
+    with patch("ingest.aoi_watch.notify"):
+        result = check_new_ignition(aoi, engine=engine)
+
+    assert result is not None
+    assert result["aoi_id"] == str(aoi["id"])
+    assert result["detection_count"] >= 2
+    assert result["max_denoised_score"] > 0
+    assert isinstance(result["centroid_lat"], float)
+    assert isinstance(result["centroid_lon"], float)
+
+
+# ── no detections → notify not called ─────────────────────────────────────────
+
+
+def test_no_detections_returns_none_and_no_notify() -> None:
+    """When the DB returns no detections, check_new_ignition returns None without notifying."""
+    aoi = _make_aoi()
+    engine = _MockEngine([])
+
+    mock_notify = MagicMock()
+    with patch("ingest.aoi_watch.notify", mock_notify):
+        result = check_new_ignition(aoi, engine=engine, _now=_NOW)
+
+    assert result is None
+    mock_notify.assert_not_called()
+
+
+# ── detections are noise → notify not called ──────────────────────────────────
+
+
+def test_noise_detections_excluded_by_query() -> None:
+    """Detections with is_noise=True are excluded at the SQL query level.
+
+    The DB query filters them out before we ever see them.  We simulate this
+    by returning an empty result (as the real DB would).
+    """
+    aoi = _make_aoi()
+    # Simulate DB returning no rows because the WHERE clause excluded noise.
+    engine = _MockEngine([])
+
+    mock_notify = MagicMock()
+    with patch("ingest.aoi_watch.notify", mock_notify):
+        result = check_new_ignition(aoi, engine=engine, _now=_NOW)
+
+    assert result is None
+    mock_notify.assert_not_called()
+
+
+def test_noise_detections_single_qualifying_below_cluster_threshold() -> None:
+    """Only one qualifying detection — not enough for a cluster of ≥ 2."""
+    aoi = _make_aoi()
+    detections = [
+        _make_detection(lat=0.5, lon=0.5, denoised_score=0.90, is_noise=False),
+    ]
+    engine = _MockEngine(detections)
+
+    mock_notify = MagicMock()
+    with patch("ingest.aoi_watch.notify", mock_notify):
+        result = check_new_ignition(aoi, engine=engine, _now=_NOW)
+
+    assert result is None
+    mock_notify.assert_not_called()
+
+
+# ── old fire event → notify not called ────────────────────────────────────────
+
+
+def test_detections_with_old_event_suppressed() -> None:
+    """Detections linked to a fire_event that started > 2 h ago are treated as existing fires."""
+    aoi = _make_aoi()
+    old_event_start = _NOW - timedelta(hours=5)  # > 2 h ago
+
+    detections = [
+        _make_detection(
+            lat=0.5, lon=0.5, denoised_score=0.90,
+            event_id=str(uuid4()), event_started_at=old_event_start,
+        ),
+        _make_detection(
+            lat=0.501, lon=0.501, denoised_score=0.85,
+            event_id=str(uuid4()), event_started_at=old_event_start,
+        ),
+    ]
+    engine = _MockEngine(detections)
+
+    mock_notify = MagicMock()
+    with patch("ingest.aoi_watch.notify", mock_notify):
+        result = check_new_ignition(aoi, engine=engine, _now=_NOW)
+
+    assert result is None
+    mock_notify.assert_not_called()
+
+
+def test_detections_with_recent_event_qualifies() -> None:
+    """Detections linked to an event that started < 2 h ago are treated as new ignitions."""
+    aoi = _make_aoi()
+    recent_event_start = _NOW - timedelta(hours=1)  # < 2 h ago — qualifies
+
+    detections = [
+        _make_detection(
+            lat=0.5, lon=0.5, denoised_score=0.90,
+            event_id=str(uuid4()), event_started_at=recent_event_start,
+        ),
+        _make_detection(
+            lat=0.501, lon=0.501, denoised_score=0.85,
+            event_id=str(uuid4()), event_started_at=recent_event_start,
+        ),
+    ]
+    engine = _MockEngine(detections)
+
+    mock_notify = MagicMock()
+    with patch("ingest.aoi_watch.notify", mock_notify):
+        result = check_new_ignition(aoi, engine=engine, _now=_NOW)
+
+    assert result is not None
+    mock_notify.assert_called_once()
+
+
+# ── cluster too sparse → notify not called ────────────────────────────────────
+
+
+def test_detections_too_far_apart_no_cluster() -> None:
+    """Two detections more than 1 km apart do not form a qualifying cluster."""
+    aoi = _make_aoi()
+    # ~0.05° lat ≈ 5.5 km apart — well beyond the 1 km cluster radius.
+    detections = [
+        _make_detection(lat=0.1, lon=0.1, denoised_score=0.90),
+        _make_detection(lat=0.15, lon=0.1, denoised_score=0.85),
+    ]
+    engine = _MockEngine(detections)
+
+    mock_notify = MagicMock()
+    with patch("ingest.aoi_watch.notify", mock_notify):
+        result = check_new_ignition(aoi, engine=engine, _now=_NOW)
+
+    assert result is None
+    mock_notify.assert_not_called()
+
+
+# ── missing geometry → graceful return None ───────────────────────────────────
+
+
+def test_aoi_without_geometry_returns_none() -> None:
+    """AOI with no geometry key returns None without raising."""
+    aoi = _make_aoi(geometry=None)
+    engine = _MockEngine([])
+
+    mock_notify = MagicMock()
+    with patch("ingest.aoi_watch.notify", mock_notify):
+        result = check_new_ignition(aoi, engine=engine, _now=_NOW)
+
+    assert result is None
+    mock_notify.assert_not_called()
+
+
+# ── db exception → graceful return None ───────────────────────────────────────
+
+
+def test_db_exception_returns_none() -> None:
+    """DB errors are caught and None is returned without raising."""
+    aoi = _make_aoi()
+
+    class _BrokenEngine:
+        @contextmanager
+        def begin(self):
+            raise RuntimeError("connection refused")
+            yield  # pragma: no cover
+
+    mock_notify = MagicMock()
+    with patch("ingest.aoi_watch.notify", mock_notify):
+        result = check_new_ignition(aoi, engine=_BrokenEngine())
+
+    assert result is None
+    mock_notify.assert_not_called()

--- a/ingest/tests/test_new_ignition_watch.py
+++ b/ingest/tests/test_new_ignition_watch.py
@@ -47,6 +47,7 @@ def _make_detection(
     false_source_masked: bool = False,
     event_id: str | None = None,
     event_started_at: datetime | None = None,
+    acq_time: datetime | None = None,
 ) -> dict[str, Any]:
     return {
         "id": str(uuid4()),
@@ -57,6 +58,7 @@ def _make_detection(
         "false_source_masked": false_source_masked,
         "event_id": event_id,
         "event_started_at": event_started_at,
+        "acq_time": acq_time,
     }
 
 
@@ -303,6 +305,83 @@ def test_db_exception_returns_none() -> None:
     mock_notify = MagicMock()
     with patch("ingest.aoi_watch.notify", mock_notify):
         result = check_new_ignition(aoi, engine=_BrokenEngine())
+
+    assert result is None
+    mock_notify.assert_not_called()
+
+
+# ── data_as_of / data_lag_minutes ─────────────────────────────────────────────
+
+_ACQ_TIME = _NOW - timedelta(minutes=90)  # 90 minutes before _NOW
+
+
+def test_data_as_of_in_notification_context() -> None:
+    """notify() receives data_as_of (ISO string) and data_lag_minutes=90."""
+    aoi = _make_aoi()
+    detections = [
+        _make_detection(lat=0.5, lon=0.5, denoised_score=0.90, acq_time=_ACQ_TIME),
+        _make_detection(lat=0.501, lon=0.501, denoised_score=0.80, acq_time=_ACQ_TIME),
+    ]
+    engine = _MockEngine(detections)
+
+    mock_notify = MagicMock()
+    with patch("ingest.aoi_watch.notify", mock_notify):
+        check_new_ignition(aoi, engine=engine, _now=_NOW)
+
+    mock_notify.assert_called_once()
+    call_kwargs = mock_notify.call_args.kwargs
+
+    assert call_kwargs.get("data_as_of") == _ACQ_TIME.isoformat()
+    assert call_kwargs.get("data_lag_minutes") == 90
+
+
+def test_data_lag_in_notification_body() -> None:
+    """The notification body contains a UTC time reference when acq_time is known."""
+    aoi = _make_aoi()
+    detections = [
+        _make_detection(lat=0.5, lon=0.5, denoised_score=0.90, acq_time=_ACQ_TIME),
+        _make_detection(lat=0.501, lon=0.501, denoised_score=0.80, acq_time=_ACQ_TIME),
+    ]
+    engine = _MockEngine(detections)
+
+    mock_notify = MagicMock()
+    with patch("ingest.aoi_watch.notify", mock_notify):
+        check_new_ignition(aoi, engine=engine, _now=_NOW)
+
+    mock_notify.assert_called_once()
+    body: str = mock_notify.call_args.kwargs.get("body", "")
+
+    assert "UTC" in body
+    # The time portion of _ACQ_TIME formatted as %H:%M should appear in the body.
+    assert _ACQ_TIME.strftime("%H:%M") in body
+
+
+def test_data_as_of_in_returned_dict() -> None:
+    """Returned dict from check_new_ignition includes data_as_of and data_lag_minutes."""
+    aoi = _make_aoi()
+    detections = [
+        _make_detection(lat=0.5, lon=0.5, denoised_score=0.90, acq_time=_ACQ_TIME),
+        _make_detection(lat=0.501, lon=0.501, denoised_score=0.80, acq_time=_ACQ_TIME),
+    ]
+    engine = _MockEngine(detections)
+
+    with patch("ingest.aoi_watch.notify"):
+        result = check_new_ignition(aoi, engine=engine, _now=_NOW)
+
+    assert result is not None
+    assert "data_as_of" in result
+    assert result["data_as_of"] == _ACQ_TIME
+    assert result["data_lag_minutes"] == 90
+
+
+def test_data_as_of_none_when_no_detections() -> None:
+    """When there are no qualifying detections the function returns None (existing behaviour)."""
+    aoi = _make_aoi()
+    engine = _MockEngine([])
+
+    mock_notify = MagicMock()
+    with patch("ingest.aoi_watch.notify", mock_notify):
+        result = check_new_ignition(aoi, engine=engine, _now=_NOW)
 
     assert result is None
     mock_notify.assert_not_called()

--- a/ingest/tests/test_nifc_pl_watch.py
+++ b/ingest/tests/test_nifc_pl_watch.py
@@ -1,0 +1,149 @@
+"""Tests for ingest.nifc_pl_watch."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+import ingest.nifc_pl_watch as _mod
+from ingest.nifc_pl_watch import (
+    clear_cache,
+    get_preparedness_level,
+    get_preparedness_level_context,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Clear the in-memory PL cache before every test."""
+    clear_cache()
+    yield
+    clear_cache()
+
+
+# ── get_preparedness_level ────────────────────────────────────────────────────
+
+
+def test_returns_none_when_no_source_configured(monkeypatch):
+    monkeypatch.delenv("NIFC_PL_URL", raising=False)
+    monkeypatch.delenv("NIFC_PL_OVERRIDE", raising=False)
+    assert get_preparedness_level() is None
+
+
+def test_override_env_var_returns_pl(monkeypatch):
+    monkeypatch.delenv("NIFC_PL_URL", raising=False)
+    monkeypatch.setenv("NIFC_PL_OVERRIDE", "4")
+    assert get_preparedness_level() == 4
+
+
+def test_override_clamped_to_valid_range(monkeypatch):
+    """NIFC_PL_OVERRIDE=6 is invalid — should return None."""
+    monkeypatch.delenv("NIFC_PL_URL", raising=False)
+    monkeypatch.setenv("NIFC_PL_OVERRIDE", "6")
+    assert get_preparedness_level() is None
+
+
+def test_override_clamped_to_valid_range_zero(monkeypatch):
+    """NIFC_PL_OVERRIDE=0 is invalid — should return None."""
+    monkeypatch.delenv("NIFC_PL_URL", raising=False)
+    monkeypatch.setenv("NIFC_PL_OVERRIDE", "0")
+    assert get_preparedness_level() is None
+
+
+def test_cache_returns_cached_value(monkeypatch):
+    """Second call hits cache and does not re-read the override env var."""
+    monkeypatch.delenv("NIFC_PL_URL", raising=False)
+    monkeypatch.setenv("NIFC_PL_OVERRIDE", "3")
+
+    first = get_preparedness_level()
+    assert first == 3
+
+    # Remove the override — but cached value should still be returned.
+    monkeypatch.delenv("NIFC_PL_OVERRIDE", raising=False)
+    second = get_preparedness_level()
+    assert second == 3
+
+
+def test_clear_cache_resets(monkeypatch):
+    """After clear_cache(), removing the override causes None to be returned."""
+    monkeypatch.delenv("NIFC_PL_URL", raising=False)
+    monkeypatch.setenv("NIFC_PL_OVERRIDE", "2")
+
+    assert get_preparedness_level() == 2
+
+    clear_cache()
+    monkeypatch.delenv("NIFC_PL_OVERRIDE", raising=False)
+
+    assert get_preparedness_level() is None
+
+
+# ── get_preparedness_level_context ────────────────────────────────────────────
+
+
+def test_context_empty_when_pl_none(monkeypatch):
+    monkeypatch.delenv("NIFC_PL_URL", raising=False)
+    monkeypatch.delenv("NIFC_PL_OVERRIDE", raising=False)
+    assert get_preparedness_level_context() == {}
+
+
+def test_context_pl_below_4_no_warning(monkeypatch):
+    monkeypatch.delenv("NIFC_PL_URL", raising=False)
+    monkeypatch.setenv("NIFC_PL_OVERRIDE", "2")
+    ctx = get_preparedness_level_context()
+    assert ctx == {"nifc_preparedness_level": 2}
+    assert "nifc_pl_resource_warning" not in ctx
+
+
+def test_context_pl_4_includes_warning(monkeypatch):
+    monkeypatch.delenv("NIFC_PL_URL", raising=False)
+    monkeypatch.setenv("NIFC_PL_OVERRIDE", "4")
+    ctx = get_preparedness_level_context()
+    assert ctx["nifc_preparedness_level"] == 4
+    assert "nifc_pl_resource_warning" in ctx
+    assert "mutual aid" in ctx["nifc_pl_resource_warning"]
+
+
+def test_context_pl_5_includes_critical_warning(monkeypatch):
+    monkeypatch.delenv("NIFC_PL_URL", raising=False)
+    monkeypatch.setenv("NIFC_PL_OVERRIDE", "5")
+    ctx = get_preparedness_level_context()
+    assert ctx["nifc_preparedness_level"] == 5
+    assert "all national resources" in ctx["nifc_pl_resource_warning"]
+
+
+# ── URL source ────────────────────────────────────────────────────────────────
+
+
+def test_url_source_fetches_and_caches(monkeypatch):
+    """With NIFC_PL_URL set and a mock client returning PL=3, returns 3."""
+    monkeypatch.setenv("NIFC_PL_URL", "http://fake-nifc.example.com/pl.json")
+    monkeypatch.delenv("NIFC_PL_OVERRIDE", raising=False)
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"preparedness_level": 3}
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.get.return_value = mock_response
+
+    result = get_preparedness_level(http_client=mock_client)
+    assert result == 3
+
+    # Confirm it was cached — second call must not call client.get again.
+    result2 = get_preparedness_level(http_client=mock_client)
+    assert result2 == 3
+    assert mock_client.get.call_count == 1
+
+
+def test_url_source_falls_back_to_override_on_failure(monkeypatch):
+    """When URL fetch raises httpx.HTTPError, falls back to NIFC_PL_OVERRIDE."""
+    monkeypatch.setenv("NIFC_PL_URL", "http://fake-nifc.example.com/pl.json")
+    monkeypatch.setenv("NIFC_PL_OVERRIDE", "2")
+
+    mock_client = MagicMock(spec=httpx.Client)
+    mock_client.get.side_effect = httpx.HTTPError("connection refused")
+
+    result = get_preparedness_level(http_client=mock_client)
+    assert result == 2

--- a/ingest/tests/test_nifc_pl_watch.py
+++ b/ingest/tests/test_nifc_pl_watch.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
-import ingest.nifc_pl_watch as _mod
 from ingest.nifc_pl_watch import (
     clear_cache,
     get_preparedness_level,

--- a/ingest/tests/test_perimeter_watch.py
+++ b/ingest/tests/test_perimeter_watch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -10,9 +11,12 @@ import pytest
 from ingest.perimeter_breach_watch import (
     _cluster_detections,
     check_perimeter_breach,
+    get_active_breaches,
+    reset_breach_state,
     run_perimeter_breach_checks,
 )
 from ingest.perimeter_growth_watch import (
+    _determine_severity,
     check_perimeter_growth,
     run_perimeter_growth_checks,
 )
@@ -31,9 +35,20 @@ _PERIMETER = {
 }
 
 
+# Use a relative past time so that data_lag_minutes is always >= 0 regardless of
+# when the test suite runs.  One hour ago is safely in the past for any test clock.
+_ACQ_TIME = datetime.now(timezone.utc) - timedelta(hours=1)
+
+
 def _make_detection(lat: float, lon: float, score: float = 0.85) -> SimpleNamespace:
     """Return a fake DB row with the columns expected by check_perimeter_breach."""
-    return SimpleNamespace(lat=lat, lon=lon, denoised_score=score, dist_deg=0.02)
+    return SimpleNamespace(
+        lat=lat,
+        lon=lon,
+        denoised_score=score,
+        dist_deg=0.02,
+        max_acq_time=_ACQ_TIME,
+    )
 
 
 def _make_session(rows: list) -> MagicMock:
@@ -218,11 +233,11 @@ class TestCheckPerimeterBreach:
         # Cluster A: 4 detections near lat=39.0
         # Cluster B: 1 detection far away — below threshold alone
         cluster_a = [
-            SimpleNamespace(lat=39.0 + i * 0.001, lon=-119.3, denoised_score=0.8, dist_deg=0.02)
+            SimpleNamespace(lat=39.0 + i * 0.001, lon=-119.3, denoised_score=0.8, dist_deg=0.02, max_acq_time=_ACQ_TIME)
             for i in range(4)
         ]
         cluster_b = [
-            SimpleNamespace(lat=40.5, lon=-120.0, denoised_score=0.8, dist_deg=0.03)
+            SimpleNamespace(lat=40.5, lon=-120.0, denoised_score=0.8, dist_deg=0.03, max_acq_time=_ACQ_TIME)
         ]
         session = _make_session(cluster_a + cluster_b)
         mock_notify = MagicMock()
@@ -235,12 +250,84 @@ class TestCheckPerimeterBreach:
 
 
 # ---------------------------------------------------------------------------
-# run_perimeter_breach_checks
+# Fix 1: NEW vs ONGOING breach watermark
+# ---------------------------------------------------------------------------
+
+
+class TestBreachWatermark:
+    """Tests for the module-level breach state tracker."""
+
+    def setup_method(self):
+        """Ensure breach state is clean before each test."""
+        reset_breach_state(_PERIMETER["source_id"])
+
+    def test_breach_first_detection_is_new(self):
+        """First call with a qualifying cluster → title contains 'NEW', state populated."""
+        rows = _outside_rows(3)
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            check_perimeter_breach(_PERIMETER, session)
+
+        mock_notify.assert_called_once()
+        title = mock_notify.call_args.kwargs["title"]
+        assert "NEW" in title
+        # State must be recorded.
+        active = get_active_breaches()
+        assert _PERIMETER["source_id"] in active
+        assert "first_detected_at" in active[_PERIMETER["source_id"]]
+
+    def test_breach_second_detection_is_ongoing(self):
+        """Two consecutive calls with same source_id → second notify title contains 'ONGOING' and duration."""
+        rows = _outside_rows(3)
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            # First call — NEW
+            check_perimeter_breach(_PERIMETER, session)
+            # Second call — ONGOING
+            check_perimeter_breach(_PERIMETER, session)
+
+        assert mock_notify.call_count == 2
+        second_title = mock_notify.call_args_list[1].kwargs["title"]
+        second_body = mock_notify.call_args_list[1].kwargs["body"]
+        assert "ONGOING" in second_title
+        assert "ago, still active" in second_body
+
+    def test_breach_resolved_clears_state(self):
+        """Cluster present on first call, absent on second → state entry removed."""
+        rows = _outside_rows(3)
+        session_with = _make_session(rows)
+        session_empty = _make_session([])
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            check_perimeter_breach(_PERIMETER, session_with)
+
+        # Breach is active.
+        assert _PERIMETER["source_id"] in get_active_breaches()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            check_perimeter_breach(_PERIMETER, session_empty)
+
+        # Breach should be resolved.
+        assert _PERIMETER["source_id"] not in get_active_breaches()
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: Perimeter age guard (run_perimeter_breach_checks)
 # ---------------------------------------------------------------------------
 
 
 class TestRunPerimeterBreachChecks:
-    def _active_perimeter_row(self, source_id: str = "wfigs-001") -> SimpleNamespace:
+    def _active_perimeter_row(
+        self,
+        source_id: str = "wfigs-001",
+        age_hours: float = 1.0,
+    ) -> SimpleNamespace:
+        created_at = datetime.now(timezone.utc) - timedelta(hours=age_hours)
         return SimpleNamespace(
             id=1,
             source_id=source_id,
@@ -248,6 +335,7 @@ class TestRunPerimeterBreachChecks:
             geom="MULTIPOLYGON(((-119.5 37.5, -119.0 37.5, -119.0 38.0, -119.5 38.0, -119.5 37.5)))",
             source="nifc_wfigs",
             acres=5000.0,
+            created_at=created_at,
         )
 
     def test_no_active_perimeters_returns_empty(self):
@@ -283,6 +371,75 @@ class TestRunPerimeterBreachChecks:
         result = run_perimeter_breach_checks(session)
 
         assert result == []
+
+    def test_stale_perimeter_emits_stale_warning_not_breach(self):
+        """Perimeter older than 48 h → stale notify fired, check_perimeter_breach NOT called."""
+        stale_row = self._active_perimeter_row("stale-src", age_hours=50.0)
+        session = MagicMock()
+        session.execute.return_value.fetchall.return_value = [stale_row]
+        mock_notify = MagicMock()
+
+        with (
+            patch("ingest.perimeter_breach_watch.notify", mock_notify),
+            patch("ingest.perimeter_breach_watch.check_perimeter_breach") as mock_check,
+        ):
+            run_perimeter_breach_checks(session)
+
+        # check_perimeter_breach must NOT be called for stale perimeters.
+        mock_check.assert_not_called()
+        # Stale warning notify must have been fired with event_type starting "perimeter_stale:".
+        mock_notify.assert_called_once()
+        event_type = mock_notify.call_args.args[0]
+        assert event_type.startswith("perimeter_stale:")
+        assert mock_notify.call_args.kwargs["severity"] == "warning"
+
+    def test_fresh_perimeter_runs_breach_check(self):
+        """Perimeter with recent created_at → check_perimeter_breach is called normally."""
+        fresh_row = self._active_perimeter_row("fresh-src", age_hours=1.0)
+        session = MagicMock()
+        session.execute.return_value.fetchall.return_value = [fresh_row]
+
+        with patch(
+            "ingest.perimeter_breach_watch.check_perimeter_breach",
+            return_value=None,
+        ) as mock_check:
+            run_perimeter_breach_checks(session)
+
+        mock_check.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: data_as_of in breach notification (check_perimeter_breach)
+# ---------------------------------------------------------------------------
+
+
+class TestDataAsOfInBreachNotification:
+    """Verify that breach notifications carry satellite data freshness metadata."""
+
+    def setup_method(self):
+        reset_breach_state(_PERIMETER["source_id"])
+
+    def test_data_as_of_in_breach_notification(self):
+        """notify() must receive data_as_of and data_lag_minutes kwargs."""
+        rows = _outside_rows(3)
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            result = check_perimeter_breach(_PERIMETER, session)
+
+        assert result is not None
+        kwargs = mock_notify.call_args.kwargs
+        assert "data_as_of" in kwargs, "notify() missing data_as_of"
+        assert "data_lag_minutes" in kwargs, "notify() missing data_lag_minutes"
+        # data_as_of must be an ISO-8601 string.
+        assert isinstance(kwargs["data_as_of"], str)
+        assert "T" in kwargs["data_as_of"]  # basic ISO-8601 shape
+        # data_lag_minutes must be a non-negative integer.
+        assert isinstance(kwargs["data_lag_minutes"], int)
+        assert kwargs["data_lag_minutes"] >= 0
+        # data_as_of must be present in the return dict.
+        assert "data_as_of" in result
 
 
 # ---------------------------------------------------------------------------
@@ -366,8 +523,12 @@ class TestCheckPerimeterGrowth:
         mock_notify.assert_not_called()
         assert result == []
 
-    def test_growth_15pct_but_only_50_acres_does_not_trigger(self):
-        """15% growth but only 50 acres absolute → below 100-acre minimum → no notify."""
+    def test_growth_15pct_fires_on_small_fire_percent_gate(self):
+        """15% growth on a small fire (383 acres) → warning via percent gate.
+
+        The old AND-gate suppressed this (abs=50 < old 100-acre minimum).
+        The new OR-gate fires because 15% >= small-tier warn_pct of 10%.
+        """
         rows = [_make_growth_row("Brush Fire", current_acres=383.0, prev_acres=333.0)]  # ~15%, ~50 acres
         session = _make_session(rows)
         mock_notify = MagicMock()
@@ -375,8 +536,9 @@ class TestCheckPerimeterGrowth:
         with patch("ingest.perimeter_growth_watch.notify", mock_notify):
             result = check_perimeter_growth("nifc_wfigs", session)
 
-        mock_notify.assert_not_called()
-        assert result == []
+        mock_notify.assert_called_once()
+        assert len(result) == 1
+        assert result[0]["severity"] == "warning"
 
     def test_only_one_perimeter_record_no_notify(self):
         """Single perimeter (no previous snapshot) → no notify.
@@ -496,3 +658,128 @@ class TestRunPerimeterGrowthChecks:
         assert len(result) == 2
         fire_names = {r["fire_name"] for r in result}
         assert fire_names == {"Oak Fire", "Maple Fire"}
+
+
+# ---------------------------------------------------------------------------
+# _determine_severity unit tests (size-tiered dual-gate logic)
+# ---------------------------------------------------------------------------
+
+
+class TestDetermineSeverity:
+    def test_small_fire_percent_gate(self):
+        """800-acre fire grows 15% (120 acres) → warning (percent gate fires).
+
+        Small tier: warn_pct=10, warn_abs=50.  15% >= 10% → warning.
+        """
+        # current=920, prev=800: growth=120 acres, 15%
+        severity = _determine_severity(
+            current_acres=920.0,
+            abs_growth=120.0,
+            growth_pct=15.0,
+        )
+        assert severity == "warning"
+
+    def test_small_fire_abs_gate_fires_below_percent(self):
+        """800-acre fire grows 8% but 65 acres → warning via abs gate.
+
+        Small tier: warn_pct=10, warn_abs=50.  8% < 10% but 65 >= 50 → warning.
+        """
+        severity = _determine_severity(
+            current_acres=865.0,
+            abs_growth=65.0,
+            growth_pct=8.0,
+        )
+        assert severity == "warning"
+
+    def test_large_fire_percent_below_abs_gate(self):
+        """50k-acre fire grows 3% (1,500 acres) → warning via abs gate.
+
+        Large tier: warn_pct=5, warn_abs=500.  3% < 5% but 1500 >= 500 → warning.
+        This is the key scenario the old thresholds got wrong.
+        """
+        severity = _determine_severity(
+            current_acres=51_500.0,
+            abs_growth=1_500.0,
+            growth_pct=3.0,
+        )
+        assert severity == "warning"
+
+    def test_large_fire_no_alert_below_both_gates(self):
+        """50k-acre fire grows 1% (500 acres) → NO alert.
+
+        Large tier: warn_pct=5, warn_abs=500.  1% < 5% and 500 is NOT > 500
+        (condition is >=, so 500 == 500 triggers).  Use 499 acres to be safe.
+        """
+        severity = _determine_severity(
+            current_acres=50_499.0,
+            abs_growth=499.0,
+            growth_pct=1.0,
+        )
+        assert severity is None
+
+    def test_large_fire_exact_abs_warn_threshold_triggers(self):
+        """50k-acre fire grows exactly 500 acres (abs warn threshold) → warning.
+
+        Condition is abs_growth >= warn_abs, so equality triggers.
+        """
+        severity = _determine_severity(
+            current_acres=50_500.0,
+            abs_growth=500.0,
+            growth_pct=1.0,
+        )
+        assert severity == "warning"
+
+    def test_medium_fire_critical_abs_gate(self):
+        """5k-acre fire grows 4% (200 acres) → warning (abs 200 == medium warn threshold).
+
+        Medium tier: warn_pct=7, warn_abs=200.  4% < 7% but 200 >= 200 → warning.
+        """
+        severity = _determine_severity(
+            current_acres=5_200.0,
+            abs_growth=200.0,
+            growth_pct=4.0,
+        )
+        assert severity == "warning"
+
+    def test_critical_takes_precedence_over_warning(self):
+        """Fire meeting critical threshold → severity='critical', not 'warning'.
+
+        Small tier: crit_pct=25, crit_abs=200.  30% >= 25 → critical.
+        """
+        severity = _determine_severity(
+            current_acres=650.0,
+            abs_growth=150.0,
+            growth_pct=30.0,
+        )
+        assert severity == "critical"
+
+    def test_hundred_thousand_acre_fire_600_acres_warns(self):
+        """Acceptance criterion: 100k-acre fire growing 600 acres triggers a warning.
+
+        Large tier: warn_abs=500.  600 >= 500 → warning (even at ~0.6%).
+        """
+        severity = _determine_severity(
+            current_acres=100_600.0,
+            abs_growth=600.0,
+            growth_pct=0.6,
+        )
+        assert severity == "warning"
+
+
+class TestGrowthNotificationBody:
+    def test_both_abs_and_pct_in_body(self):
+        """Notification body must contain both absolute acreage change and percentage."""
+        # Large fire: 50k → 51.5k acres (+1500, +3%)
+        rows = [_make_growth_row("Rim Fire", current_acres=51_500.0, prev_acres=50_000.0)]
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_growth_watch.notify", mock_notify):
+            result = check_perimeter_growth("nifc_wfigs", session)
+
+        assert len(result) == 1
+        body: str = mock_notify.call_args.kwargs["body"]
+        # Body must contain the absolute acreage increase
+        assert "1,500" in body
+        # Body must contain the percentage (formatted with sign)
+        assert "3%" in body or "+3%" in body

--- a/ingest/tests/test_perimeter_watch.py
+++ b/ingest/tests/test_perimeter_watch.py
@@ -1,0 +1,498 @@
+"""Tests for perimeter_breach_watch and perimeter_growth_watch."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ingest.perimeter_breach_watch import (
+    _cluster_detections,
+    check_perimeter_breach,
+    run_perimeter_breach_checks,
+)
+from ingest.perimeter_growth_watch import (
+    check_perimeter_growth,
+    run_perimeter_growth_checks,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PERIMETER = {
+    "id": 1,
+    "source_id": "wfigs-abc123",
+    "fire_name": "Oak Fire",
+    "geom": "MULTIPOLYGON(((-119.5 37.5, -119.0 37.5, -119.0 38.0, -119.5 38.0, -119.5 37.5)))",
+    "source": "nifc_wfigs",
+    "acres": 5000.0,
+}
+
+
+def _make_detection(lat: float, lon: float, score: float = 0.85) -> SimpleNamespace:
+    """Return a fake DB row with the columns expected by check_perimeter_breach."""
+    return SimpleNamespace(lat=lat, lon=lon, denoised_score=score, dist_deg=0.02)
+
+
+def _make_session(rows: list) -> MagicMock:
+    """Return a mock SQLAlchemy session whose execute().fetchall() returns *rows*."""
+    session = MagicMock()
+    session.execute.return_value.fetchall.return_value = rows
+    return session
+
+
+# ---------------------------------------------------------------------------
+# _cluster_detections unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_groups_nearby_points():
+    detections = [
+        {"lat": 37.6, "lon": -119.2, "denoised_score": 0.8, "dist_deg": 0.02},
+        {"lat": 37.601, "lon": -119.2, "denoised_score": 0.9, "dist_deg": 0.02},
+        {"lat": 37.602, "lon": -119.2, "denoised_score": 0.85, "dist_deg": 0.02},
+    ]
+    clusters = _cluster_detections(detections, radius_deg=0.01)
+    assert len(clusters) == 1
+    assert len(clusters[0]) == 3
+
+
+def test_cluster_separates_distant_points():
+    detections = [
+        {"lat": 37.6, "lon": -119.2, "denoised_score": 0.8, "dist_deg": 0.02},
+        {"lat": 38.5, "lon": -120.5, "denoised_score": 0.9, "dist_deg": 0.02},
+    ]
+    clusters = _cluster_detections(detections, radius_deg=0.01)
+    assert len(clusters) == 2
+
+
+# ---------------------------------------------------------------------------
+# Feature 3: check_perimeter_breach
+# ---------------------------------------------------------------------------
+
+
+def _outside_rows(n: int, score: float = 0.85) -> list[SimpleNamespace]:
+    """Return *n* detection rows clearly outside the perimeter (large dist_deg)."""
+    base_lat = 39.0  # well north of the dummy perimeter polygon
+    return [
+        _make_detection(lat=base_lat + i * 0.001, lon=-119.3, score=score)
+        for i in range(n)
+    ]
+
+
+class TestCheckPerimeterBreach:
+    def test_cluster_of_3_triggers_notify(self):
+        """Cluster of 3+ qualifying detections → notify called with severity=critical."""
+        rows = _outside_rows(3)
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            result = check_perimeter_breach(_PERIMETER, session)
+
+        mock_notify.assert_called_once()
+        call_args = mock_notify.call_args
+        # First positional arg is event_type
+        event_type = call_args.args[0]
+        assert event_type == f"perimeter_breach:{_PERIMETER['source_id']}"
+        assert call_args.kwargs["severity"] == "critical"
+        assert call_args.kwargs["detection_count"] == 3
+        assert call_args.kwargs["denoised_score"] == pytest.approx(0.85, abs=1e-3)
+        assert result is not None
+        assert result["source_id"] == _PERIMETER["source_id"]
+
+    def test_cluster_of_5_triggers_notify(self):
+        """Cluster of 5 detections also triggers — validate count in body."""
+        rows = _outside_rows(5, score=0.9)
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            result = check_perimeter_breach(_PERIMETER, session)
+
+        mock_notify.assert_called_once()
+        assert result is not None
+        assert result["detection_count"] == 5
+
+    def test_cluster_of_2_does_not_trigger_notify(self):
+        """Cluster of only 2 detections → notify NOT called (below min cluster size)."""
+        rows = _outside_rows(2)
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            result = check_perimeter_breach(_PERIMETER, session)
+
+        mock_notify.assert_not_called()
+        assert result is None
+
+    def test_no_detections_returns_none(self):
+        """Zero candidate detections from DB → no notify, returns None."""
+        session = _make_session([])
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            result = check_perimeter_breach(_PERIMETER, session)
+
+        mock_notify.assert_not_called()
+        assert result is None
+
+    def test_detections_inside_perimeter_excluded(self):
+        """If the SQL filter (NOT ST_Within) means no rows returned → no alert.
+
+        We simulate this by having the session return an empty list — the
+        PostGIS WHERE clause would have excluded detections inside the
+        perimeter before they reach Python.
+        """
+        # The spatial filter is in SQL; we test the Python path that receives
+        # zero rows after the inside-perimeter filter.
+        session = _make_session([])
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            result = check_perimeter_breach(_PERIMETER, session)
+
+        mock_notify.assert_not_called()
+        assert result is None
+
+    def test_noise_detections_excluded(self):
+        """Detections flagged as noise never reach Python (excluded in SQL).
+
+        We simulate the SQL filter returning empty — as noise rows have
+        is_noise=True so they wouldn't appear in the result set.
+        """
+        session = _make_session([])
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            result = check_perimeter_breach(_PERIMETER, session)
+
+        mock_notify.assert_not_called()
+        assert result is None
+
+    def test_edge_detections_within_500m_excluded(self):
+        """Detections within 500 m of boundary are filtered out by SQL (dist < 0.004°).
+
+        Simulate with empty return — the ST_Distance >= 0.004 predicate would
+        exclude them.
+        """
+        session = _make_session([])
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            result = check_perimeter_breach(_PERIMETER, session)
+
+        mock_notify.assert_not_called()
+        assert result is None
+
+    def test_exception_returns_none(self):
+        """Any unexpected exception is caught and returns None."""
+        session = MagicMock()
+        session.execute.side_effect = RuntimeError("DB error")
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            result = check_perimeter_breach(_PERIMETER, session)
+
+        mock_notify.assert_not_called()
+        assert result is None
+
+    def test_notify_receives_required_context_fields(self):
+        """notify() must include denoised_score and aoi_id per contract."""
+        rows = _outside_rows(3, score=0.92)
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            check_perimeter_breach(_PERIMETER, session)
+
+        kwargs = mock_notify.call_args.kwargs
+        assert "denoised_score" in kwargs
+        assert "aoi_id" in kwargs
+        assert kwargs["aoi_id"] is None
+
+    def test_two_separate_clusters_fires_on_first_qualifying(self):
+        """When two spatially separate clusters exist and first qualifies, notify is called once."""
+        # Cluster A: 4 detections near lat=39.0
+        # Cluster B: 1 detection far away — below threshold alone
+        cluster_a = [
+            SimpleNamespace(lat=39.0 + i * 0.001, lon=-119.3, denoised_score=0.8, dist_deg=0.02)
+            for i in range(4)
+        ]
+        cluster_b = [
+            SimpleNamespace(lat=40.5, lon=-120.0, denoised_score=0.8, dist_deg=0.03)
+        ]
+        session = _make_session(cluster_a + cluster_b)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_breach_watch.notify", mock_notify):
+            result = check_perimeter_breach(_PERIMETER, session)
+
+        mock_notify.assert_called_once()
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# run_perimeter_breach_checks
+# ---------------------------------------------------------------------------
+
+
+class TestRunPerimeterBreachChecks:
+    def _active_perimeter_row(self, source_id: str = "wfigs-001") -> SimpleNamespace:
+        return SimpleNamespace(
+            id=1,
+            source_id=source_id,
+            fire_name="Test Fire",
+            geom="MULTIPOLYGON(((-119.5 37.5, -119.0 37.5, -119.0 38.0, -119.5 38.0, -119.5 37.5)))",
+            source="nifc_wfigs",
+            acres=5000.0,
+        )
+
+    def test_no_active_perimeters_returns_empty(self):
+        session = MagicMock()
+        session.execute.return_value.fetchall.return_value = []
+
+        result = run_perimeter_breach_checks(session)
+
+        assert result == []
+
+    def test_calls_check_for_each_active_perimeter(self):
+        rows = [
+            self._active_perimeter_row("src-1"),
+            self._active_perimeter_row("src-2"),
+        ]
+        session = MagicMock()
+        session.execute.return_value.fetchall.return_value = rows
+
+        with patch(
+            "ingest.perimeter_breach_watch.check_perimeter_breach",
+            side_effect=[{"source_id": "src-1"}, None],
+        ) as mock_check:
+            result = run_perimeter_breach_checks(session)
+
+        assert mock_check.call_count == 2
+        assert len(result) == 1
+        assert result[0]["source_id"] == "src-1"
+
+    def test_exception_returns_empty(self):
+        session = MagicMock()
+        session.execute.side_effect = RuntimeError("DB error")
+
+        result = run_perimeter_breach_checks(session)
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Feature 6: check_perimeter_growth
+# ---------------------------------------------------------------------------
+
+
+def _make_growth_row(
+    fire_name: str,
+    current_acres: float,
+    prev_acres: float,
+    source_id: str = "wfigs-g1",
+) -> SimpleNamespace:
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime(2026, 4, 3, 12, 0, 0, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        fire_name=fire_name,
+        current_source_id=source_id,
+        current_acres=current_acres,
+        current_created_at=now,
+        prev_acres=prev_acres,
+        prev_created_at=now - timedelta(hours=6),
+    )
+
+
+class TestCheckPerimeterGrowth:
+    def test_growth_30pct_200acres_is_critical(self):
+        """30% growth with 200 acres absolute → critical severity."""
+        rows = [_make_growth_row("Elk Fire", current_acres=1000.0, prev_acres=800.0)]  # 25%
+        # 25% is exactly the critical threshold — use 30% to be clearly above
+        rows = [_make_growth_row("Elk Fire", current_acres=1040.0, prev_acres=800.0)]  # 30%
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_growth_watch.notify", mock_notify):
+            result = check_perimeter_growth("nifc_wfigs", session)
+
+        mock_notify.assert_called_once()
+        kwargs = mock_notify.call_args.kwargs
+        assert kwargs["severity"] == "critical"
+        assert len(result) == 1
+        assert result[0]["severity"] == "critical"
+
+    def test_growth_exactly_25pct_is_critical(self):
+        """Exactly 25% growth → critical (boundary case)."""
+        rows = [_make_growth_row("Cedar Fire", current_acres=1000.0, prev_acres=800.0)]
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_growth_watch.notify", mock_notify):
+            result = check_perimeter_growth("nifc_wfigs", session)
+
+        mock_notify.assert_called_once()
+        assert result[0]["severity"] == "critical"
+
+    def test_growth_12pct_150acres_is_warning(self):
+        """12% growth with 150 acres absolute → warning severity."""
+        rows = [_make_growth_row("Pine Fire", current_acres=1400.0, prev_acres=1250.0)]  # 12%
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_growth_watch.notify", mock_notify):
+            result = check_perimeter_growth("cwfis", session)
+
+        mock_notify.assert_called_once()
+        kwargs = mock_notify.call_args.kwargs
+        assert kwargs["severity"] == "warning"
+        assert len(result) == 1
+        assert result[0]["severity"] == "warning"
+
+    def test_growth_5pct_does_not_trigger(self):
+        """5% growth → below 10% threshold → no notify."""
+        rows = [_make_growth_row("Ash Fire", current_acres=1050.0, prev_acres=1000.0)]
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_growth_watch.notify", mock_notify):
+            result = check_perimeter_growth("nifc_wfigs", session)
+
+        mock_notify.assert_not_called()
+        assert result == []
+
+    def test_growth_15pct_but_only_50_acres_does_not_trigger(self):
+        """15% growth but only 50 acres absolute → below 100-acre minimum → no notify."""
+        rows = [_make_growth_row("Brush Fire", current_acres=383.0, prev_acres=333.0)]  # ~15%, ~50 acres
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_growth_watch.notify", mock_notify):
+            result = check_perimeter_growth("nifc_wfigs", session)
+
+        mock_notify.assert_not_called()
+        assert result == []
+
+    def test_only_one_perimeter_record_no_notify(self):
+        """Single perimeter (no previous snapshot) → no notify.
+
+        The SQL JOIN requires rn=1 and rn=2 to both exist; if only one row
+        exists the JOIN returns nothing, so check_perimeter_growth receives [].
+        """
+        session = _make_session([])  # SQL returns empty — JOIN produced no pairs
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_growth_watch.notify", mock_notify):
+            result = check_perimeter_growth("nifc_wfigs", session)
+
+        mock_notify.assert_not_called()
+        assert result == []
+
+    def test_no_fires_returns_empty(self):
+        """No rows from DB → empty result."""
+        session = _make_session([])
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_growth_watch.notify", mock_notify):
+            result = check_perimeter_growth("copernicus_ems", session)
+
+        mock_notify.assert_not_called()
+        assert result == []
+
+    def test_event_type_contains_source_and_slug(self):
+        """Event type must be perimeter_growth:{source}:{fire_name_slug}."""
+        rows = [_make_growth_row("Big Creek Fire", current_acres=1500.0, prev_acres=1000.0)]
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_growth_watch.notify", mock_notify):
+            check_perimeter_growth("nifc_wfigs", session)
+
+        event_type = mock_notify.call_args.args[0]
+        assert event_type == "perimeter_growth:nifc_wfigs:big_creek_fire"
+
+    def test_notify_receives_required_context_fields(self):
+        """aoi_id must be present per contract; denoised_score must be absent."""
+        rows = [_make_growth_row("Ridge Fire", current_acres=1200.0, prev_acres=1000.0)]
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_growth_watch.notify", mock_notify):
+            check_perimeter_growth("nifc_wfigs", session)
+
+        kwargs = mock_notify.call_args.kwargs
+        assert "aoi_id" in kwargs
+        assert kwargs["aoi_id"] is None
+        # denoised_score must NOT be passed for this event (not applicable)
+        assert "denoised_score" not in kwargs
+
+    def test_exception_returns_empty_list(self):
+        """Unexpected exception is caught and returns []."""
+        session = MagicMock()
+        session.execute.side_effect = RuntimeError("DB timeout")
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_growth_watch.notify", mock_notify):
+            result = check_perimeter_growth("nifc_wfigs", session)
+
+        mock_notify.assert_not_called()
+        assert result == []
+
+    def test_multiple_fires_independent(self):
+        """Each fire is evaluated independently; only qualifying ones alert."""
+        rows = [
+            _make_growth_row("Big Fire", current_acres=2000.0, prev_acres=1000.0),  # 100% → critical
+            _make_growth_row("Small Fire", current_acres=105.0, prev_acres=100.0),   # 5% → skip
+        ]
+        session = _make_session(rows)
+        mock_notify = MagicMock()
+
+        with patch("ingest.perimeter_growth_watch.notify", mock_notify):
+            result = check_perimeter_growth("nifc_wfigs", session)
+
+        assert mock_notify.call_count == 1
+        assert len(result) == 1
+        assert result[0]["fire_name"] == "Big Fire"
+
+
+# ---------------------------------------------------------------------------
+# run_perimeter_growth_checks
+# ---------------------------------------------------------------------------
+
+
+class TestRunPerimeterGrowthChecks:
+    def test_runs_all_three_sources(self):
+        """run_perimeter_growth_checks calls check_perimeter_growth for each source."""
+        session = MagicMock()
+
+        with patch(
+            "ingest.perimeter_growth_watch.check_perimeter_growth",
+            return_value=[],
+        ) as mock_check:
+            run_perimeter_growth_checks(session)
+
+        sources_checked = [c.args[0] for c in mock_check.call_args_list]
+        assert set(sources_checked) == {"nifc_wfigs", "cwfis", "copernicus_ems"}
+
+    def test_aggregates_results_from_all_sources(self):
+        """Results from all sources are combined into a single list."""
+        session = MagicMock()
+
+        def fake_check(source: str, _session: object) -> list:
+            if source == "nifc_wfigs":
+                return [{"fire_name": "Oak Fire", "source": source}]
+            if source == "cwfis":
+                return [{"fire_name": "Maple Fire", "source": source}]
+            return []
+
+        with patch("ingest.perimeter_growth_watch.check_perimeter_growth", side_effect=fake_check):
+            result = run_perimeter_growth_checks(session)
+
+        assert len(result) == 2
+        fire_names = {r["fire_name"] for r in result}
+        assert fire_names == {"Oak Fire", "Maple Fire"}

--- a/ingest/tests/test_weather_spread_watch.py
+++ b/ingest/tests/test_weather_spread_watch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import math
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
@@ -10,7 +11,9 @@ from uuid import uuid4
 import pytest
 
 from ingest.spread_trajectory_watch import (
+    _last_alerted_state,
     check_spread_trajectory,
+    reset_trajectory_state,
     run_spread_trajectory_checks,
 )
 from ingest.weather_threshold_watch import (
@@ -48,18 +51,32 @@ def _make_spread_session(
     centroid_rows: dict[int, tuple[float, float] | None],
     older_run_row: tuple | None = None,
     dist_deg: float = 0.1,
+    horizons: list[int] | None = None,
 ) -> MagicMock:
     """Build a mock SQLAlchemy session for spread trajectory tests.
 
-    centroid_rows maps run_id -> (cx, cy) or None.
-    SQL calls are dispatched in order:
-      1. runs query  → run_rows
-      2. centroid for curr_run_id
-      3. centroid for prev_run_id
-      4. ST_Distance query
-      5. older run query  → older_run_row
-      6. centroid for older_run_id (if older_run_row is not None)
+    centroid_rows maps run_id -> (cx, cy) or None (applies to every horizon).
+    horizons controls which horizons get real centroid data.  Horizons NOT in
+    this list return None for the curr centroid (simulating a missing contour).
+
+    New SQL call order (matches refactored implementation):
+      1.  runs query        → fetchall → run_rows
+      2.  older run query   → fetchone → older_run_row
+      For each horizon in _REQUIRED_HORIZONS:
+        If horizon IS in horizons:
+          3.  centroid for curr_run_id  → fetchone
+          4.  centroid for prev_run_id  → fetchone
+          5.  ST_Distance               → fetchone
+          If older_run_row is not None:
+            6.  centroid for older_run_id → fetchone
+        Else (missing horizon):
+          3.  centroid for curr_run_id  → fetchone (None) → code skips via continue
     """
+    from ingest.spread_trajectory_watch import _REQUIRED_HORIZONS
+
+    if horizons is None:
+        horizons = list(_REQUIRED_HORIZONS)
+
     session = MagicMock()
     call_results: list = []
 
@@ -72,40 +89,58 @@ def _make_spread_session(
         curr_run_id = run_rows[0][0]
         prev_run_id = run_rows[1][0]
 
-        # 2. centroid for curr
-        curr_cent = centroid_rows.get(curr_run_id)
-        curr_mock = MagicMock()
-        curr_mock.fetchone.return_value = (
-            (curr_cent[0], curr_cent[1], 12) if curr_cent else None
-        )
-        call_results.append(curr_mock)
-
-        # 3. centroid for prev
-        prev_cent = centroid_rows.get(prev_run_id)
-        prev_mock = MagicMock()
-        prev_mock.fetchone.return_value = (
-            (prev_cent[0], prev_cent[1], 12) if prev_cent else None
-        )
-        call_results.append(prev_mock)
-
-        # 4. ST_Distance
-        dist_mock = MagicMock()
-        dist_mock.fetchone.return_value = (dist_deg,)
-        call_results.append(dist_mock)
-
-        # 5. older run
+        # 2. older run query
         older_mock = MagicMock()
         older_mock.fetchone.return_value = older_run_row
         call_results.append(older_mock)
 
-        if older_run_row is not None:
-            older_run_id = older_run_row[0]
-            older_cent = centroid_rows.get(older_run_id)
-            older_cent_mock = MagicMock()
-            older_cent_mock.fetchone.return_value = (
-                (older_cent[0], older_cent[1], 12) if older_cent else None
+        older_run_id = older_run_row[0] if older_run_row is not None else None
+
+        for h in _REQUIRED_HORIZONS:
+            if h not in horizons:
+                # Missing horizon: only the curr centroid query fires (returns None)
+                # The code then logs a warning and calls `continue`.
+                missing_mock = MagicMock()
+                missing_mock.fetchone.return_value = None
+                call_results.append(missing_mock)
+                continue
+
+            # curr centroid
+            curr_cent = centroid_rows.get(curr_run_id)
+            curr_mock = MagicMock()
+            curr_mock.fetchone.return_value = (
+                (curr_cent[0], curr_cent[1]) if curr_cent else None
             )
-            call_results.append(older_cent_mock)
+            call_results.append(curr_mock)
+
+            if curr_cent is None:
+                # If curr is None the code also logs warning and continues
+                continue
+
+            # prev centroid
+            prev_cent = centroid_rows.get(prev_run_id)
+            prev_mock = MagicMock()
+            prev_mock.fetchone.return_value = (
+                (prev_cent[0], prev_cent[1]) if prev_cent else None
+            )
+            call_results.append(prev_mock)
+
+            if prev_cent is None:
+                continue
+
+            # ST_Distance
+            dist_mock = MagicMock()
+            dist_mock.fetchone.return_value = (dist_deg,)
+            call_results.append(dist_mock)
+
+            # older centroid (only if older run exists)
+            if older_run_id is not None:
+                older_cent = centroid_rows.get(older_run_id)
+                older_cent_mock = MagicMock()
+                older_cent_mock.fetchone.return_value = (
+                    (older_cent[0], older_cent[1]) if older_cent else None
+                )
+                call_results.append(older_cent_mock)
 
     session.execute.side_effect = call_results
     return session
@@ -117,6 +152,10 @@ def _bearing(from_lon: float, from_lat: float, to_lon: float, to_lat: float) -> 
 
 class TestSpreadTrajectory:
     """Feature 4: spread trajectory deviation."""
+
+    def setup_method(self) -> None:
+        """Clear module-level gate state before every test."""
+        _last_alerted_state.clear()
 
     def test_direction_40deg_is_warning(self) -> None:
         """Direction rotates 40° → notify called with severity='warning'."""
@@ -151,10 +190,12 @@ class TestSpreadTrajectory:
             result = check_spread_trajectory(aoi, session)
 
         assert result is not None
-        mock_notify.assert_called_once()
-        # event_type is passed as first positional arg; other fields are kwargs
-        assert mock_notify.call_args.args[0] == f"spread_trajectory_shift:{aoi_id}"
-        call_kw = mock_notify.call_args.kwargs
+        assert len(result) > 0
+        mock_notify.assert_called()
+        # event_type includes aoi_id and horizon
+        event_types = [c.args[0] for c in mock_notify.call_args_list]
+        assert any(str(aoi_id) in et for et in event_types)
+        call_kw = mock_notify.call_args_list[0].kwargs
         assert call_kw["severity"] == "warning"
         assert call_kw["aoi_id"] == str(aoi_id)
 
@@ -185,8 +226,9 @@ class TestSpreadTrajectory:
             result = check_spread_trajectory(aoi, session)
 
         assert result is not None
-        mock_notify.assert_called_once()
-        call_kw = mock_notify.call_args.kwargs
+        assert len(result) > 0
+        mock_notify.assert_called()
+        call_kw = mock_notify.call_args_list[0].kwargs
         assert call_kw["severity"] == "critical"
 
     def test_speed_increase_60pct_is_warning(self) -> None:
@@ -216,8 +258,9 @@ class TestSpreadTrajectory:
             result = check_spread_trajectory(aoi, session)
 
         assert result is not None
-        mock_notify.assert_called_once()
-        call_kw = mock_notify.call_args.kwargs
+        assert len(result) > 0
+        mock_notify.assert_called()
+        call_kw = mock_notify.call_args_list[0].kwargs
         assert call_kw["severity"] == "warning"
 
     def test_only_one_run_returns_none(self) -> None:
@@ -237,7 +280,7 @@ class TestSpreadTrajectory:
         mock_notify.assert_not_called()
 
     def test_no_significant_change_does_not_notify(self) -> None:
-        """Direction < 30° and speed change < 50% → notify NOT called."""
+        """Direction < 30° and speed change < 50% → notify NOT called, returns []."""
         aoi = _make_aoi()
 
         # 10° direction change, same speed
@@ -263,7 +306,8 @@ class TestSpreadTrajectory:
         with patch("ingest.spread_trajectory_watch.notify") as mock_notify:
             result = check_spread_trajectory(aoi, session)
 
-        assert result is None
+        # Runs exist but no horizon triggered → empty list, not None
+        assert result == []
         mock_notify.assert_not_called()
 
     def test_run_spread_trajectory_checks_aggregates(self) -> None:
@@ -274,12 +318,186 @@ class TestSpreadTrajectory:
         with patch(
             "ingest.spread_trajectory_watch.check_spread_trajectory"
         ) as mock_check:
-            mock_check.side_effect = [{"aoi_name": "AOI 1"}, None]
+            # check_spread_trajectory now returns list[dict] | None
+            mock_check.side_effect = [[{"aoi_name": "AOI 1"}], None]
             session = MagicMock()
             results = run_spread_trajectory_checks([aoi1, aoi2], session)
 
         assert len(results) == 1
         assert results[0]["aoi_name"] == "AOI 1"
+
+    # ── Transition gate tests (Fix 1) ─────────────────────────────────────────
+
+    def test_trajectory_suppresses_repeat_with_same_bearing(self) -> None:
+        """First alert at bearing 45°, second call with same bearing → suppressed."""
+        aoi = _make_aoi()
+        aoi_id = str(aoi["id"])
+
+        # Pre-populate gate state as if a prior alert fired at bearing 45° for h=12
+        _last_alerted_state[f"{aoi_id}:12"] = {
+            "bearing": 45.0,
+            "run_id": 99,
+            "severity": "warning",
+        }
+
+        # Construct a 40° direction change (triggers 'warning') landing at ~45° bearing
+        angle_rad = math.radians(45.0)
+        older_cent = (-119.5, 37.4)
+        prev_cent = (-119.5, 37.5)
+        curr_cent = (
+            -119.5 + 0.1 * math.sin(angle_rad),
+            37.5 + 0.1 * math.cos(angle_rad),
+        )
+
+        run_rows = [(1, _T2), (2, _T1)]
+        older_run_row = (3, _T0)
+        centroids = {1: curr_cent, 2: prev_cent, 3: older_cent}
+
+        # Only h=12 is served with real data; 24/48/72 missing (return None)
+        session = _make_spread_session(
+            run_rows=run_rows,
+            centroid_rows=centroids,
+            older_run_row=older_run_row,
+            dist_deg=0.1,
+            horizons=[12],
+        )
+
+        with patch("ingest.spread_trajectory_watch.notify") as mock_notify:
+            result = check_spread_trajectory(aoi, session)
+
+        # The 12h horizon is suppressed (same bearing, same severity) → no notify
+        mock_notify.assert_not_called()
+        assert result == []
+
+    def test_trajectory_re_alerts_on_additional_shift(self) -> None:
+        """First alert at 45°, second call rotated to 90° (45° additional) → re-alerts."""
+        aoi = _make_aoi()
+        aoi_id = str(aoi["id"])
+
+        # Prior alert was at bearing 45°
+        _last_alerted_state[f"{aoi_id}:12"] = {
+            "bearing": 45.0,
+            "run_id": 99,
+            "severity": "warning",
+        }
+
+        # Now the trajectory has rotated another ~45° (from 45° to ~90°, due east).
+        # older→prev leg points NE (bearing ~45°)
+        # prev→curr leg points E (bearing ~90°)
+        # direction_change ≈ 45° > _DIR_CRIT_DEG (45°) → critical
+        # additional_shift from prior bearing (45°) to current bearing (~90°) = ~45° ≥ 30°
+        older_cent = (-119.5, 37.4)
+        prev_cent = (
+            -119.5 + 0.1 * math.sin(math.radians(45.0)),
+            37.4 + 0.1 * math.cos(math.radians(45.0)),
+        )
+        curr_cent = (
+            prev_cent[0] + 0.1,  # due east from prev
+            prev_cent[1],
+        )
+
+        run_rows = [(1, _T2), (2, _T1)]
+        older_run_row = (3, _T0)
+        centroids = {1: curr_cent, 2: prev_cent, 3: older_cent}
+
+        session = _make_spread_session(
+            run_rows=run_rows,
+            centroid_rows=centroids,
+            older_run_row=older_run_row,
+            dist_deg=0.1,
+            horizons=[12],
+        )
+
+        with patch("ingest.spread_trajectory_watch.notify") as mock_notify:
+            result = check_spread_trajectory(aoi, session)
+
+        # additional_shift ≥ _DIR_WARN_DEG → should re-alert
+        mock_notify.assert_called_once()
+        assert result is not None
+        assert len(result) == 1
+
+    def test_trajectory_multi_horizon_12h_triggers_24h_does_not(self) -> None:
+        """12h contour exceeds threshold, 24h absent → only one notify() call (for 12h)."""
+        aoi = _make_aoi()
+
+        # 40° direction change — exceeds warning threshold
+        angle_rad = math.radians(40.0)
+        older_cent = (-119.5, 37.4)
+        prev_cent = (-119.5, 37.5)
+        curr_cent = (
+            -119.5 + 0.1 * math.sin(angle_rad),
+            37.5 + 0.1 * math.cos(angle_rad),
+        )
+
+        run_rows = [(1, _T2), (2, _T1)]
+        older_run_row = (3, _T0)
+        centroids = {1: curr_cent, 2: prev_cent, 3: older_cent}
+
+        # Only h=12 gets real data; 24/48/72 are missing
+        session = _make_spread_session(
+            run_rows=run_rows,
+            centroid_rows=centroids,
+            older_run_row=older_run_row,
+            dist_deg=0.1,
+            horizons=[12],
+        )
+
+        with patch("ingest.spread_trajectory_watch.notify") as mock_notify:
+            result = check_spread_trajectory(aoi, session)
+
+        # Only h=12 should have triggered → exactly one notify call
+        mock_notify.assert_called_once()
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["horizon_hours"] == 12
+
+    def test_trajectory_horizon_missing_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """48h contour absent → WARNING logged, 48h skipped, other horizons proceed."""
+        aoi = _make_aoi()
+
+        # 40° direction change at h=12
+        angle_rad = math.radians(40.0)
+        older_cent = (-119.5, 37.4)
+        prev_cent = (-119.5, 37.5)
+        curr_cent = (
+            -119.5 + 0.1 * math.sin(angle_rad),
+            37.5 + 0.1 * math.cos(angle_rad),
+        )
+
+        run_rows = [(1, _T2), (2, _T1)]
+        older_run_row = (3, _T0)
+        centroids = {1: curr_cent, 2: prev_cent, 3: older_cent}
+
+        # Serve only h=12; 24/48/72 will be missing (returns None → WARNING logged)
+        session = _make_spread_session(
+            run_rows=run_rows,
+            centroid_rows=centroids,
+            older_run_row=older_run_row,
+            dist_deg=0.1,
+            horizons=[12],
+        )
+
+        with patch("ingest.spread_trajectory_watch.notify"):
+            with caplog.at_level(logging.WARNING, logger="ingest.spread_trajectory_watch"):
+                result = check_spread_trajectory(aoi, session)
+
+        # At least one WARNING about missing ICS outlook must appear
+        warning_msgs = [
+            r.message for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "ICS" in r.message
+            and "outlook unavailable" in r.message
+        ]
+        assert warning_msgs, (
+            "Expected at least one WARNING about missing ICS outlook. "
+            f"Got records: {[r.message for r in caplog.records]}"
+        )
+        # 48h should be explicitly mentioned
+        assert any("48h" in m for m in warning_msgs)
+        # h=12 still ran; result is not None and has an entry
+        assert result is not None
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -381,7 +599,6 @@ class TestWeatherThresholds:
         session = _make_weather_session(curr_metadata=metadata)
 
         with patch("ingest.weather_threshold_watch.notify") as mock_notify:
-            import logging
             with caplog.at_level(logging.WARNING, logger="ingest.weather_threshold_watch"):
                 result = check_weather_thresholds(aoi, session)
 

--- a/ingest/tests/test_weather_spread_watch.py
+++ b/ingest/tests/test_weather_spread_watch.py
@@ -1,0 +1,433 @@
+"""Tests for spread_trajectory_watch and weather_threshold_watch."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from ingest.spread_trajectory_watch import (
+    check_spread_trajectory,
+    run_spread_trajectory_checks,
+)
+from ingest.weather_threshold_watch import (
+    check_weather_thresholds,
+    run_weather_threshold_checks,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+_T0 = datetime(2026, 3, 27, 6, 0, 0, tzinfo=timezone.utc)
+_T1 = _T0 + timedelta(hours=6)
+_T2 = _T1 + timedelta(hours=6)
+
+
+def _make_aoi(**overrides: object) -> dict:
+    base: dict = {
+        "id": uuid4(),
+        "name": "Test AOI",
+        "bbox": {
+            "type": "Polygon",
+            "coordinates": [[[-120.0, 37.0], [-119.0, 37.0], [-119.0, 38.0], [-120.0, 38.0], [-120.0, 37.0]]],
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Feature 4: Spread Trajectory Deviation
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_spread_session(
+    *,
+    run_rows: list,
+    centroid_rows: dict[int, tuple[float, float] | None],
+    older_run_row: tuple | None = None,
+    dist_deg: float = 0.1,
+) -> MagicMock:
+    """Build a mock SQLAlchemy session for spread trajectory tests.
+
+    centroid_rows maps run_id -> (cx, cy) or None.
+    SQL calls are dispatched in order:
+      1. runs query  → run_rows
+      2. centroid for curr_run_id
+      3. centroid for prev_run_id
+      4. ST_Distance query
+      5. older run query  → older_run_row
+      6. centroid for older_run_id (if older_run_row is not None)
+    """
+    session = MagicMock()
+    call_results: list = []
+
+    # 1. runs
+    runs_mock = MagicMock()
+    runs_mock.fetchall.return_value = run_rows
+    call_results.append(runs_mock)
+
+    if len(run_rows) >= 2:
+        curr_run_id = run_rows[0][0]
+        prev_run_id = run_rows[1][0]
+
+        # 2. centroid for curr
+        curr_cent = centroid_rows.get(curr_run_id)
+        curr_mock = MagicMock()
+        curr_mock.fetchone.return_value = (
+            (curr_cent[0], curr_cent[1], 12) if curr_cent else None
+        )
+        call_results.append(curr_mock)
+
+        # 3. centroid for prev
+        prev_cent = centroid_rows.get(prev_run_id)
+        prev_mock = MagicMock()
+        prev_mock.fetchone.return_value = (
+            (prev_cent[0], prev_cent[1], 12) if prev_cent else None
+        )
+        call_results.append(prev_mock)
+
+        # 4. ST_Distance
+        dist_mock = MagicMock()
+        dist_mock.fetchone.return_value = (dist_deg,)
+        call_results.append(dist_mock)
+
+        # 5. older run
+        older_mock = MagicMock()
+        older_mock.fetchone.return_value = older_run_row
+        call_results.append(older_mock)
+
+        if older_run_row is not None:
+            older_run_id = older_run_row[0]
+            older_cent = centroid_rows.get(older_run_id)
+            older_cent_mock = MagicMock()
+            older_cent_mock.fetchone.return_value = (
+                (older_cent[0], older_cent[1], 12) if older_cent else None
+            )
+            call_results.append(older_cent_mock)
+
+    session.execute.side_effect = call_results
+    return session
+
+
+def _bearing(from_lon: float, from_lat: float, to_lon: float, to_lat: float) -> float:
+    return math.degrees(math.atan2(to_lon - from_lon, to_lat - from_lat)) % 360.0
+
+
+class TestSpreadTrajectory:
+    """Feature 4: spread trajectory deviation."""
+
+    def test_direction_40deg_is_warning(self) -> None:
+        """Direction rotates 40° → notify called with severity='warning'."""
+        aoi = _make_aoi()
+        aoi_id = aoi["id"]
+
+        # We need the older→prev bearing and the prev→curr bearing to differ by ~40°.
+        # Place points such that the angular delta is exactly 40°.
+        # older centroid = (0, 0) lon/lat
+        # prev centroid  = (0, 0.1) — heading due north (0°)
+        # curr centroid  = (0.1*sin40°, 0.1*cos40°) — heading 40° from north
+        angle_rad = math.radians(40.0)
+        older_cent = (-119.5, 37.4)
+        prev_cent = (-119.5, 37.5)  # due north from older
+        curr_cent = (
+            -119.5 + 0.1 * math.sin(angle_rad),
+            37.5 + 0.1 * math.cos(angle_rad),
+        )
+
+        run_rows = [(1, _T2), (2, _T1)]
+        older_run_row = (3, _T0)
+        centroids = {1: curr_cent, 2: prev_cent, 3: older_cent}
+
+        session = _make_spread_session(
+            run_rows=run_rows,
+            centroid_rows=centroids,
+            older_run_row=older_run_row,
+            dist_deg=0.1,
+        )
+
+        with patch("ingest.spread_trajectory_watch.notify") as mock_notify:
+            result = check_spread_trajectory(aoi, session)
+
+        assert result is not None
+        mock_notify.assert_called_once()
+        # event_type is passed as first positional arg; other fields are kwargs
+        assert mock_notify.call_args.args[0] == f"spread_trajectory_shift:{aoi_id}"
+        call_kw = mock_notify.call_args.kwargs
+        assert call_kw["severity"] == "warning"
+        assert call_kw["aoi_id"] == str(aoi_id)
+
+    def test_direction_50deg_is_critical(self) -> None:
+        """Direction rotates 50° → notify called with severity='critical'."""
+        aoi = _make_aoi()
+
+        angle_rad = math.radians(50.0)
+        older_cent = (-119.5, 37.4)
+        prev_cent = (-119.5, 37.5)
+        curr_cent = (
+            -119.5 + 0.1 * math.sin(angle_rad),
+            37.5 + 0.1 * math.cos(angle_rad),
+        )
+
+        run_rows = [(1, _T2), (2, _T1)]
+        older_run_row = (3, _T0)
+        centroids = {1: curr_cent, 2: prev_cent, 3: older_cent}
+
+        session = _make_spread_session(
+            run_rows=run_rows,
+            centroid_rows=centroids,
+            older_run_row=older_run_row,
+            dist_deg=0.1,
+        )
+
+        with patch("ingest.spread_trajectory_watch.notify") as mock_notify:
+            result = check_spread_trajectory(aoi, session)
+
+        assert result is not None
+        mock_notify.assert_called_once()
+        call_kw = mock_notify.call_args.kwargs
+        assert call_kw["severity"] == "critical"
+
+    def test_speed_increase_60pct_is_warning(self) -> None:
+        """Speed increases 60% → notify called with severity='warning'."""
+        aoi = _make_aoi()
+
+        # Keep direction same (0° change) but vary distances to create speed increase.
+        # older→prev: 0.1 deg in 6h → speed_prev = 0.1*111/6 = 1.85 km/h
+        # prev→curr:  0.16 deg in 6h → speed_curr = 0.16*111/6 = 2.96 km/h → +60%
+        older_cent = (-119.5, 37.3)
+        prev_cent = (-119.5, 37.4)   # 0.1 deg north of older
+        curr_cent = (-119.5, 37.56)  # 0.16 deg north of prev (same direction)
+
+        run_rows = [(1, _T2), (2, _T1)]
+        older_run_row = (3, _T0)
+        centroids = {1: curr_cent, 2: prev_cent, 3: older_cent}
+
+        # ST_Distance for prev→curr: 0.16 deg
+        session = _make_spread_session(
+            run_rows=run_rows,
+            centroid_rows=centroids,
+            older_run_row=older_run_row,
+            dist_deg=0.16,
+        )
+
+        with patch("ingest.spread_trajectory_watch.notify") as mock_notify:
+            result = check_spread_trajectory(aoi, session)
+
+        assert result is not None
+        mock_notify.assert_called_once()
+        call_kw = mock_notify.call_args.kwargs
+        assert call_kw["severity"] == "warning"
+
+    def test_only_one_run_returns_none(self) -> None:
+        """Only one forecast run → notify NOT called, returns None."""
+        aoi = _make_aoi()
+        run_rows = [(1, _T2)]  # only one
+
+        session = MagicMock()
+        runs_mock = MagicMock()
+        runs_mock.fetchall.return_value = run_rows
+        session.execute.return_value = runs_mock
+
+        with patch("ingest.spread_trajectory_watch.notify") as mock_notify:
+            result = check_spread_trajectory(aoi, session)
+
+        assert result is None
+        mock_notify.assert_not_called()
+
+    def test_no_significant_change_does_not_notify(self) -> None:
+        """Direction < 30° and speed change < 50% → notify NOT called."""
+        aoi = _make_aoi()
+
+        # 10° direction change, same speed
+        angle_rad = math.radians(10.0)
+        older_cent = (-119.5, 37.4)
+        prev_cent = (-119.5, 37.5)
+        curr_cent = (
+            -119.5 + 0.1 * math.sin(angle_rad),
+            37.5 + 0.1 * math.cos(angle_rad),
+        )
+
+        run_rows = [(1, _T2), (2, _T1)]
+        older_run_row = (3, _T0)
+        centroids = {1: curr_cent, 2: prev_cent, 3: older_cent}
+
+        session = _make_spread_session(
+            run_rows=run_rows,
+            centroid_rows=centroids,
+            older_run_row=older_run_row,
+            dist_deg=0.1,  # same distance as older→prev (0.1 deg)
+        )
+
+        with patch("ingest.spread_trajectory_watch.notify") as mock_notify:
+            result = check_spread_trajectory(aoi, session)
+
+        assert result is None
+        mock_notify.assert_not_called()
+
+    def test_run_spread_trajectory_checks_aggregates(self) -> None:
+        """run_spread_trajectory_checks collects results from each AOI."""
+        aoi1 = _make_aoi(name="AOI 1")
+        aoi2 = _make_aoi(name="AOI 2")
+
+        with patch(
+            "ingest.spread_trajectory_watch.check_spread_trajectory"
+        ) as mock_check:
+            mock_check.side_effect = [{"aoi_name": "AOI 1"}, None]
+            session = MagicMock()
+            results = run_spread_trajectory_checks([aoi1, aoi2], session)
+
+        assert len(results) == 1
+        assert results[0]["aoi_name"] == "AOI 1"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Feature 5: Critical Weather Threshold at Fire Location
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_weather_session(
+    *,
+    curr_metadata: dict | None,
+    prev_metadata: dict | None = None,
+    has_curr_run: bool = True,
+) -> MagicMock:
+    """Build a mock session for weather threshold tests."""
+    session = MagicMock()
+
+    if not has_curr_run:
+        result_mock = MagicMock()
+        result_mock.fetchall.return_value = []
+        session.execute.return_value = result_mock
+        return session
+
+    rows: list = []
+    if has_curr_run:
+        rows.append((101, _T2, curr_metadata))
+    if prev_metadata is not None:
+        rows.append((100, _T1, prev_metadata))
+
+    result_mock = MagicMock()
+    result_mock.fetchall.return_value = rows
+    session.execute.return_value = result_mock
+    return session
+
+
+class TestWeatherThresholds:
+    """Feature 5: critical weather threshold at fire location."""
+
+    def test_rh20_is_warning(self) -> None:
+        """rh2m_min=20 (< 25%) → notify called with severity='warning'."""
+        aoi = _make_aoi()
+        aoi_id = aoi["id"]
+
+        metadata = {"summary": {"rh2m_min": 20.0, "wind_bearing_deg": 180.0}}
+        session = _make_weather_session(curr_metadata=metadata)
+
+        with patch("ingest.weather_threshold_watch.notify") as mock_notify:
+            result = check_weather_thresholds(aoi, session)
+
+        assert result is not None
+        mock_notify.assert_called_once()
+        # event_type is the first positional arg
+        assert mock_notify.call_args.args[0] == f"weather_threshold:{aoi_id}"
+        call_kw = mock_notify.call_args.kwargs
+        assert call_kw["severity"] == "warning"
+        assert call_kw["aoi_id"] == str(aoi_id)
+        assert call_kw["rh_pct"] == 20.0
+
+    def test_rh12_is_critical(self) -> None:
+        """rh2m_min=12 (< 15%) → notify called with severity='critical'."""
+        aoi = _make_aoi()
+
+        metadata = {"summary": {"rh2m_min": 12.0, "wind_bearing_deg": 90.0}}
+        session = _make_weather_session(curr_metadata=metadata)
+
+        with patch("ingest.weather_threshold_watch.notify") as mock_notify:
+            result = check_weather_thresholds(aoi, session)
+
+        assert result is not None
+        mock_notify.assert_called_once()
+        call_kw = mock_notify.call_args.kwargs
+        assert call_kw["severity"] == "critical"
+
+    def test_wind_shift_35deg_is_warning(self) -> None:
+        """Wind shift 35° → notify called with severity='warning'."""
+        aoi = _make_aoi()
+
+        curr_metadata = {"summary": {"rh2m_min": 40.0, "wind_bearing_deg": 215.0}}
+        prev_metadata = {"summary": {"rh2m_min": 40.0, "wind_bearing_deg": 180.0}}
+        session = _make_weather_session(
+            curr_metadata=curr_metadata,
+            prev_metadata=prev_metadata,
+        )
+
+        with patch("ingest.weather_threshold_watch.notify") as mock_notify:
+            result = check_weather_thresholds(aoi, session)
+
+        assert result is not None
+        mock_notify.assert_called_once()
+        call_kw = mock_notify.call_args.kwargs
+        assert call_kw["severity"] == "warning"
+        conditions = call_kw["conditions"]
+        assert any("wind_shift" in c for c in conditions)
+
+    def test_no_summary_key_skips_and_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """weather_runs metadata has no 'summary' key → notify NOT called, WARNING logged."""
+        aoi = _make_aoi()
+
+        # metadata present but no 'summary' key
+        metadata = {"variables": ["u10", "v10", "rh2m"]}
+        session = _make_weather_session(curr_metadata=metadata)
+
+        with patch("ingest.weather_threshold_watch.notify") as mock_notify:
+            import logging
+            with caplog.at_level(logging.WARNING, logger="ingest.weather_threshold_watch"):
+                result = check_weather_thresholds(aoi, session)
+
+        assert result is None
+        mock_notify.assert_not_called()
+        assert any("weather summary not available" in r.message for r in caplog.records)
+
+    def test_rh30_wind_shift_20_does_not_notify(self) -> None:
+        """RH=30% and wind shift 20° → no threshold exceeded, notify NOT called."""
+        aoi = _make_aoi()
+
+        curr_metadata = {"summary": {"rh2m_min": 30.0, "wind_bearing_deg": 200.0}}
+        prev_metadata = {"summary": {"rh2m_min": 32.0, "wind_bearing_deg": 180.0}}
+        session = _make_weather_session(
+            curr_metadata=curr_metadata,
+            prev_metadata=prev_metadata,
+        )
+
+        with patch("ingest.weather_threshold_watch.notify") as mock_notify:
+            result = check_weather_thresholds(aoi, session)
+
+        assert result is None
+        mock_notify.assert_not_called()
+
+    def test_run_weather_threshold_checks_aggregates(self) -> None:
+        """run_weather_threshold_checks collects non-None results."""
+        aoi1 = _make_aoi(name="AOI 1")
+        aoi2 = _make_aoi(name="AOI 2")
+
+        with patch(
+            "ingest.weather_threshold_watch.check_weather_thresholds"
+        ) as mock_check:
+            mock_check.side_effect = [None, {"aoi_name": "AOI 2"}]
+            session = MagicMock()
+            results = run_weather_threshold_checks([aoi1, aoi2], session)
+
+        assert len(results) == 1
+        assert results[0]["aoi_name"] == "AOI 2"
+
+    def test_no_completed_runs_returns_none(self) -> None:
+        """No completed weather runs → returns None, notify NOT called."""
+        aoi = _make_aoi()
+        session = _make_weather_session(curr_metadata=None, has_curr_run=False)
+
+        with patch("ingest.weather_threshold_watch.notify") as mock_notify:
+            result = check_weather_thresholds(aoi, session)
+
+        assert result is None
+        mock_notify.assert_not_called()

--- a/ingest/tests/test_weather_spread_watch.py
+++ b/ingest/tests/test_weather_spread_watch.py
@@ -13,7 +13,6 @@ import pytest
 from ingest.spread_trajectory_watch import (
     _last_alerted_state,
     check_spread_trajectory,
-    reset_trajectory_state,
     run_spread_trajectory_checks,
 )
 from ingest.weather_threshold_watch import (

--- a/ingest/tests/test_weather_spread_watch.py
+++ b/ingest/tests/test_weather_spread_watch.py
@@ -500,6 +500,44 @@ class TestSpreadTrajectory:
         assert result is not None
 
 
+    def test_gate_not_advanced_when_notify_suppressed(self) -> None:
+        """Gate state must NOT update when notify() returns False (burst/rate-limit)."""
+        aoi = _make_aoi()
+        aoi_id = str(aoi["id"])
+
+        # 40° direction change triggers warning
+        angle_rad = math.radians(40.0)
+        older_cent = (-119.5, 37.4)
+        prev_cent = (-119.5, 37.5)
+        curr_cent = (
+            -119.5 + 0.1 * math.sin(angle_rad),
+            37.5 + 0.1 * math.cos(angle_rad),
+        )
+        run_rows = [(1, _T2), (2, _T1)]
+        older_run_row = (3, _T0)
+        centroids = {1: curr_cent, 2: prev_cent, 3: older_cent}
+        session = _make_spread_session(
+            run_rows=run_rows,
+            centroid_rows=centroids,
+            older_run_row=older_run_row,
+            dist_deg=0.1,
+            horizons=[12],
+        )
+
+        gate_key = f"{aoi_id}:12"
+        assert gate_key not in _last_alerted_state
+
+        # Simulate burst cap suppression: notify() returns False
+        with patch("ingest.spread_trajectory_watch.notify", return_value=False):
+            result = check_spread_trajectory(aoi, session)
+
+        # Gate state must remain empty — notify was not delivered
+        assert gate_key not in _last_alerted_state
+        # Result still contains the triggered horizon (detection occurred)
+        assert result is not None
+        assert len(result) == 1
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Feature 5: Critical Weather Threshold at Fire Location
 # ─────────────────────────────────────────────────────────────────────────────

--- a/ingest/weather_threshold_watch.py
+++ b/ingest/weather_threshold_watch.py
@@ -34,6 +34,7 @@ from uuid import UUID
 
 from sqlalchemy import text
 
+from api.aoi_utils import _is_notifications_paused
 from api.notifications import notify
 
 LOGGER = logging.getLogger(__name__)
@@ -276,6 +277,12 @@ def run_weather_threshold_checks(
     """
     results: list[dict[str, Any]] = []
     for aoi in aois:
+        if _is_notifications_paused(aoi):
+            LOGGER.info(
+                "weather_threshold_watch: notifications paused for AOI %s — skipping",
+                aoi.get("name"),
+            )
+            continue
         result = check_weather_thresholds(aoi, session)
         if result is not None:
             results.append(result)

--- a/ingest/weather_threshold_watch.py
+++ b/ingest/weather_threshold_watch.py
@@ -10,6 +10,20 @@ Fire weather thresholds (NOTIFICATION_CONTRACTS.md):
     RH < 15%:        Critical
     Wind shift > 30°: Warning
     Wind shift > 45°: Critical
+
+RH Threshold Crossing (Transition Gate):
+    Alerts fire only when RH *crosses* a threshold boundary, not on every run
+    where conditions are already bad.  This prevents alert fatigue when adverse
+    conditions persist unchanged across many hourly runs.
+
+    Rules (compared against prev_rh from the previous run's summary):
+        - prev_rh > 25% AND curr_rh <= 25%  → newly entered Warning territory
+        - prev_rh > 15% AND curr_rh <= 15%  → newly entered Critical territory
+        - prev_rh <= 15% AND curr_rh < prev_rh  → already Critical, worsening
+        - If no previous run exists, falls back to absolute threshold check.
+
+    Wind shift is already delta-based (angular change between runs) and is
+    unchanged by this gate.
 """
 
 from __future__ import annotations
@@ -50,7 +64,10 @@ def check_weather_thresholds(aoi: dict[str, Any], session: Any) -> dict[str, Any
         session: SQLAlchemy connection/session obtained from the caller.
 
     Returns:
-        A dict describing triggered conditions if thresholds are exceeded, else None.
+        A dict describing triggered conditions if thresholds are *newly crossed*
+        or are worsening (see module-level docstring), else None.  Returns None
+        when conditions are already bad but unchanged — use the transition gate
+        to prevent alert fatigue on persistent adverse conditions.
     """
     aoi_id: UUID | str = aoi["id"]
     aoi_name: str = aoi["name"]
@@ -129,26 +146,60 @@ def check_weather_thresholds(aoi: dict[str, Any], session: Any) -> dict[str, Any
 
         triggers: list[tuple[str, str]] = []  # (condition_name, severity)
 
-        # ── Step 3a: RH thresholds ────────────────────────────────────────────────
+        # ── Step 3a: RH threshold-crossing gate ──────────────────────────────────
+        # Pull previous run summary once so we can use it for both RH and wind.
+        prev_summary: dict[str, Any] | None = None
+        if len(runs) >= 2:
+            prev_metadata: dict[str, Any] = runs[1][2] or {}
+            prev_summary = prev_metadata.get("summary")
+
+        prev_rh: float | None = prev_summary.get("rh2m_min") if prev_summary else None
+        rh_body_detail: str = ""
+
         if rh2m_min is not None:
-            if rh2m_min < _RH_CRIT_PCT:
-                triggers.append(("low_rh_critical", "critical"))
-            elif rh2m_min < _RH_WARN_PCT:
-                triggers.append(("low_rh_warning", "warning"))
+            curr_rh = rh2m_min
+            if prev_rh is not None:
+                # Transition gate: only alert on threshold crossings or worsening.
+                if prev_rh > _RH_WARN_PCT and curr_rh <= _RH_WARN_PCT:
+                    # Newly entered Warning territory (may also cross Critical below).
+                    triggers.append(("low_rh_warning", "warning"))
+                    rh_body_detail = (
+                        f"RH dropped below warning threshold "
+                        f"(prev: {prev_rh:.0f}%, now: {curr_rh:.0f}%)"
+                    )
+                if prev_rh > _RH_CRIT_PCT and curr_rh <= _RH_CRIT_PCT:
+                    # Newly crossed Critical threshold (supersedes Warning entry above).
+                    triggers.append(("low_rh_critical", "critical"))
+                    rh_body_detail = (
+                        f"RH dropped below critical threshold "
+                        f"(prev: {prev_rh:.0f}%, now: {curr_rh:.0f}%)"
+                    )
+                elif prev_rh <= _RH_CRIT_PCT and curr_rh < prev_rh:
+                    # Already Critical and still dropping — re-alert.
+                    triggers.append(("low_rh_critical", "critical"))
+                    rh_body_detail = (
+                        f"RH still dropping in critical range "
+                        f"(prev: {prev_rh:.0f}%, now: {curr_rh:.0f}%)"
+                    )
+            else:
+                # No previous run available — fall back to absolute threshold check.
+                if curr_rh <= _RH_CRIT_PCT:
+                    triggers.append(("low_rh_critical", "critical"))
+                    rh_body_detail = f"RH {curr_rh:.0f}%"
+                elif curr_rh <= _RH_WARN_PCT:
+                    triggers.append(("low_rh_warning", "warning"))
+                    rh_body_detail = f"RH {curr_rh:.0f}%"
 
         # ── Step 3b: Wind shift vs previous run ───────────────────────────────────
         wind_shift: float | None = None
-        if wind_bearing_deg is not None and len(runs) >= 2:
-            prev_metadata: dict[str, Any] = runs[1][2] or {}
-            prev_summary = prev_metadata.get("summary")
-            if prev_summary is not None:
-                prev_wind_bearing: float | None = prev_summary.get("wind_bearing_deg")
-                if prev_wind_bearing is not None:
-                    wind_shift = _angular_difference(wind_bearing_deg, prev_wind_bearing)
-                    if wind_shift > _WIND_SHIFT_CRIT_DEG:
-                        triggers.append(("wind_shift_critical", "critical"))
-                    elif wind_shift > _WIND_SHIFT_WARN_DEG:
-                        triggers.append(("wind_shift_warning", "warning"))
+        if wind_bearing_deg is not None and prev_summary is not None:
+            prev_wind_bearing: float | None = prev_summary.get("wind_bearing_deg")
+            if prev_wind_bearing is not None:
+                wind_shift = _angular_difference(wind_bearing_deg, prev_wind_bearing)
+                if wind_shift > _WIND_SHIFT_CRIT_DEG:
+                    triggers.append(("wind_shift_critical", "critical"))
+                elif wind_shift > _WIND_SHIFT_WARN_DEG:
+                    triggers.append(("wind_shift_warning", "warning"))
 
         # ── Step 3c: Evaluate triggers ────────────────────────────────────────────
         if not triggers:
@@ -164,8 +215,8 @@ def check_weather_thresholds(aoi: dict[str, Any], session: Any) -> dict[str, Any
 
         # ── Step 3d: Build human-readable body ────────────────────────────────────
         body_parts: list[str] = []
-        if rh2m_min is not None:
-            body_parts.append(f"RH {rh2m_min:.0f}%")
+        if rh_body_detail:
+            body_parts.append(rh_body_detail)
         if wind_shift is not None:
             body_parts.append(f"wind shift {wind_shift:.0f}°")
         body = (

--- a/ingest/weather_threshold_watch.py
+++ b/ingest/weather_threshold_watch.py
@@ -1,0 +1,231 @@
+"""Weather threshold watch.
+
+Checks the most recent completed weather run intersecting an AOI bbox for
+critical fire-weather conditions.  Relies on a pre-computed ``summary`` key
+inside the ``weather_runs.metadata`` JSONB column — see the STAGE-GAP comment
+below for the promotion requirement.
+
+Fire weather thresholds (NOTIFICATION_CONTRACTS.md):
+    RH < 25%:        Warning
+    RH < 15%:        Critical
+    Wind shift > 30°: Warning
+    Wind shift > 45°: Critical
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+
+from api.notifications import notify
+
+LOGGER = logging.getLogger(__name__)
+
+# STAGE-GAP WARNING (mvp_operational → science_grade): weather_threshold_watch
+# requires weather_runs.metadata to include a 'summary' key with pre-computed
+# bbox aggregates (rh2m_min, wind_bearing_deg). Without it, threshold checks
+# are skipped. Target: add summary computation to weather ingest pipeline.
+
+# ── Thresholds ────────────────────────────────────────────────────────────────
+_RH_WARN_PCT = 25.0
+_RH_CRIT_PCT = 15.0
+_WIND_SHIFT_WARN_DEG = 30.0
+_WIND_SHIFT_CRIT_DEG = 45.0
+
+
+def _angular_difference(a: float, b: float) -> float:
+    """Return the absolute shortest angular difference between two bearings (0-180°)."""
+    diff = abs(a - b) % 360.0
+    return diff if diff <= 180.0 else 360.0 - diff
+
+
+def check_weather_thresholds(aoi: dict[str, Any], session: Any) -> dict[str, Any] | None:
+    """Check the most recent weather run for critical fire-weather thresholds.
+
+    Args:
+        aoi:     Dict with at least ``id``, ``name``, and ``bbox`` (GeoJSON Polygon).
+        session: SQLAlchemy connection/session obtained from the caller.
+
+    Returns:
+        A dict describing triggered conditions if thresholds are exceeded, else None.
+    """
+    aoi_id: UUID | str = aoi["id"]
+    aoi_name: str = aoi["name"]
+
+    try:
+        bbox: dict[str, Any] = aoi["bbox"]
+        coords = bbox["coordinates"][0]
+        lons = [c[0] for c in coords]
+        lats = [c[1] for c in coords]
+        min_lon, max_lon = min(lons), max(lons)
+        min_lat, max_lat = min(lats), max(lats)
+    except (KeyError, IndexError, TypeError) as exc:
+        LOGGER.error(
+            "weather_threshold_watch: could not parse bbox for AOI %s (%s): %s",
+            aoi_name, aoi_id, exc,
+        )
+        return None
+
+    try:
+        # ── Step 1: Fetch the two most recent COMPLETED weather runs that intersect ──
+        # We fetch 2 so we can compare wind bearing shift between them.
+        runs_sql = text(
+            """
+            SELECT id, run_time, metadata
+            FROM weather_runs
+            WHERE status = 'completed'
+              AND bbox_min_lon <= :max_lon
+              AND bbox_max_lon >= :min_lon
+              AND bbox_min_lat <= :max_lat
+              AND bbox_max_lat >= :min_lat
+            ORDER BY run_time DESC
+            LIMIT 2
+            """
+        )
+        runs = session.execute(
+            runs_sql,
+            {
+                "min_lon": min_lon,
+                "max_lon": max_lon,
+                "min_lat": min_lat,
+                "max_lat": max_lat,
+            },
+        ).fetchall()
+
+        if not runs:
+            LOGGER.info(
+                "weather_threshold_watch: no completed weather runs found for AOI %s — skipping",
+                aoi_name,
+            )
+            return None
+
+        curr_row = runs[0]
+        curr_run_id = curr_row[0]
+        curr_metadata: dict[str, Any] = curr_row[2] or {}
+
+        # ── Step 2: Require pre-computed summary ──────────────────────────────────
+        summary = curr_metadata.get("summary")
+        if summary is None:
+            LOGGER.warning(
+                "weather_threshold_watch: weather summary not available for run %s — "
+                "weather threshold checks require summarized weather_runs metadata",
+                curr_run_id,
+            )
+            return None
+
+        rh2m_min: float | None = summary.get("rh2m_min")
+        wind_bearing_deg: float | None = summary.get("wind_bearing_deg")
+
+        if rh2m_min is None and wind_bearing_deg is None:
+            LOGGER.info(
+                "weather_threshold_watch: summary present but missing rh2m_min and "
+                "wind_bearing_deg for AOI %s run %s — skipping",
+                aoi_name, curr_run_id,
+            )
+            return None
+
+        triggers: list[tuple[str, str]] = []  # (condition_name, severity)
+
+        # ── Step 3a: RH thresholds ────────────────────────────────────────────────
+        if rh2m_min is not None:
+            if rh2m_min < _RH_CRIT_PCT:
+                triggers.append(("low_rh_critical", "critical"))
+            elif rh2m_min < _RH_WARN_PCT:
+                triggers.append(("low_rh_warning", "warning"))
+
+        # ── Step 3b: Wind shift vs previous run ───────────────────────────────────
+        wind_shift: float | None = None
+        if wind_bearing_deg is not None and len(runs) >= 2:
+            prev_metadata: dict[str, Any] = runs[1][2] or {}
+            prev_summary = prev_metadata.get("summary")
+            if prev_summary is not None:
+                prev_wind_bearing: float | None = prev_summary.get("wind_bearing_deg")
+                if prev_wind_bearing is not None:
+                    wind_shift = _angular_difference(wind_bearing_deg, prev_wind_bearing)
+                    if wind_shift > _WIND_SHIFT_CRIT_DEG:
+                        triggers.append(("wind_shift_critical", "critical"))
+                    elif wind_shift > _WIND_SHIFT_WARN_DEG:
+                        triggers.append(("wind_shift_warning", "warning"))
+
+        # ── Step 3c: Evaluate triggers ────────────────────────────────────────────
+        if not triggers:
+            LOGGER.info(
+                "weather_threshold_watch: AOI %s — rh2m_min=%s wind_shift=%s — "
+                "no threshold exceeded",
+                aoi_name, rh2m_min, wind_shift,
+            )
+            return None
+
+        severity = "critical" if any(s == "critical" for _, s in triggers) else "warning"
+        condition_names = [c for c, _ in triggers]
+
+        # ── Step 3d: Build human-readable body ────────────────────────────────────
+        body_parts: list[str] = []
+        if rh2m_min is not None:
+            body_parts.append(f"RH {rh2m_min:.0f}%")
+        if wind_shift is not None:
+            body_parts.append(f"wind shift {wind_shift:.0f}°")
+        body = (
+            f"Critical fire weather detected in {aoi_name}: "
+            + ", ".join(body_parts)
+            + "."
+        )
+
+        # ── Step 3e: Notify ───────────────────────────────────────────────────────
+        LOGGER.warning(
+            "weather_threshold_watch: AOI %s — triggers=%s — severity=%s",
+            aoi_name, condition_names, severity,
+        )
+        notify(
+            f"weather_threshold:{aoi_id}",
+            title=f"Critical fire weather in {aoi_name}",
+            body=body,
+            severity=severity,
+            denoised_score=None,
+            aoi_id=str(aoi_id),
+            rh_pct=rh2m_min,
+            wind_bearing=wind_bearing_deg,
+            conditions=condition_names,
+        )
+
+        return {
+            "aoi_id": str(aoi_id),
+            "aoi_name": aoi_name,
+            "severity": severity,
+            "rh2m_min": rh2m_min,
+            "wind_bearing_deg": wind_bearing_deg,
+            "wind_shift_deg": wind_shift,
+            "conditions": condition_names,
+        }
+
+    except Exception as exc:
+        LOGGER.error(
+            "weather_threshold_watch: unexpected error for AOI %s (%s): %s",
+            aoi_name, aoi_id, exc,
+            exc_info=True,
+        )
+        return None
+
+
+def run_weather_threshold_checks(
+    aois: list[dict[str, Any]],
+    session: Any,
+) -> list[dict[str, Any]]:
+    """Run weather threshold checks for every watched AOI.
+
+    Args:
+        aois:    List of AOI dicts.
+        session: SQLAlchemy connection/session.
+
+    Returns:
+        List of non-None results from check_weather_thresholds.
+    """
+    results: list[dict[str, Any]] = []
+    for aoi in aois:
+        result = check_weather_thresholds(aoi, session)
+        if result is not None:
+            results.append(result)
+    return results


### PR DESCRIPTION
## Summary

- **6 new operational notification event types** targeting incident commanders and dispatchers: new ignition detection, situational picture staleness, perimeter breach (spot fires), perimeter growth, spread trajectory deviation, and fire weather thresholds
- **Alert fatigue mitigations**: transition gates (RH threshold-crossing only, spread trajectory re-alerts only on additional 30° rotation), per-AOI burst cap (3 events/60s) with digest consolidation, NEW vs ONGOING watermark for spot fire clusters
- **Per-AOI notification pause**: `watch_notifications_paused_until` DB column, Alembic migration, `POST /aois/{id}/pause-notifications` and `POST /aois/{id}/resume-notifications` API endpoints
- **Severity-based webhook routing**: `NOTIFICATION_WEBHOOK_URL_CRITICAL/WARNING/INFO` env vars with fallback to global URL; `NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY` flag
- **NIFC Preparedness Level context**: `nifc_pl_watch.py` with 30-min cache, three-tier URL resolution, PL ≥ 4 resource-warning context attached to critical alerts
- **`notify()` returns `bool`**: True if dispatched, False if suppressed — prevents spread trajectory gate from advancing on burst-suppressed events (critical bug fix)
- **Batch watch checks wired into AOI cycle**: weather threshold, spread trajectory, and perimeter breach run every `aoi_watch` cycle; perimeter breach runs unconditionally (not gated on AOI scheduling)
- **IC-readable staleness body**: names each stale source with age and operational implication (e.g. "new ignitions since 09:30 UTC may not be visible")

## Test plan

- [ ] `cd api && uv run pytest tests/test_notifications.py tests/test_data_staleness_user.py tests/test_aoi_pause_routes.py -m "not integration"` — 569 unit tests pass
- [ ] `cd ingest && uv run pytest tests/test_new_ignition_watch.py tests/test_perimeter_watch.py tests/test_weather_spread_watch.py tests/test_aoi_pause_notifications.py tests/test_nifc_pl_watch.py` — 349 tests pass
- [ ] Set `NOTIFICATION_WEBHOOK_URL` and verify a test alert reaches Slack/Discord
- [ ] Set `NOTIFICATION_WEBHOOK_URL_CRITICAL_ONLY=true` and verify warning events are dropped
- [ ] `POST /aois/{id}/pause-notifications` with `duration_hours=2`, confirm subsequent watch cycle skips alerts for that AOI
- [ ] Confirm `run_perimeter_breach_checks` fires even when no AOIs are scheduled in a cycle

## Stage-gap notes (mvp_operational)

- `weather_threshold_watch` requires `weather_runs.metadata["summary"]` to be populated by the weather ingest pipeline — checks log a WARNING and skip gracefully until this is added
- `_active_breaches` and `_last_alerted_state` are in-process dicts (reset on restart); science_grade target is to persist to DB
- NIFC PL context is attached to notify() kwargs but not yet surfaced in the webhook body template

🤖 Generated with [Claude Code](https://claude.com/claude-code)