### PR TITLE
fix: stop ArchiveRangeScrubber auto-play on failed ingest status (closes #244)

### DIFF
--- a/ui/src/components/ArchiveRangeScrubber.tsx
+++ b/ui/src/components/ArchiveRangeScrubber.tsx
@@ -97,10 +97,15 @@ export default function ArchiveRangeScrubber({
       return;
     }
     const nextDate = currentDates[idx + 1];
+    const nextStatus = currentStatusByDate[nextDate];
     // Only advance to dates that have finished ingesting
-    if (currentStatusByDate[nextDate] === "finished") {
+    if (nextStatus === "finished") {
       onScrubRef.current(nextDate);
+    } else if (nextStatus === "failed") {
+      // Dead-end — stop rather than loop forever
+      stopPlayRef.current();
     }
+    // 'started' / 'queued': silently wait and retry on the next interval tick (expected)
   }, []); // stable — intentionally no deps; reads from refs above
 
   // Restart interval only when play state or speed changes (not on every scrub step)


### PR DESCRIPTION
## Summary
Fixes #244

When the archive scrubber encounters a failed ingest day, playback now stops instead of looping forever. This prevents the infinite interval tick that kept the player in a playing state with no user feedback.

## Changes
- Added check for failed status in `advanceToNext` callback
- Calls `stopPlayRef.current()` when next day status is 'failed'
- Allows 'started' and 'queued' to wait silently and retry as expected

## Test plan
- [ ] UI loads without errors
- [ ] Auto-play stops when encountering a failed ingest day
- [ ] 'started' and 'queued' days still pause and wait