### PR TITLE
Add CRS and pixel registration validation for LULC WorldCover

### DIFF
--- a/ingest/lulc_worldcover_ingest.py
+++ b/ingest/lulc_worldcover_ingest.py
@@ -19,6 +19,7 @@ from urllib.request import urlopen
 
 import numpy as np
 import rasterio
+from rasterio.crs import CRS as RasterioCRS
 from sqlalchemy import text
 
 from api.db import get_engine
@@ -42,6 +43,13 @@ _CLASS_LABELS: dict[int, str] = {
     95: "Mangroves",
     100: "Moss and lichen",
 }
+
+_EXPECTED_CRS = RasterioCRS.from_epsg(4326)
+
+# Warn when a coordinate falls within this fraction of a pixel edge.
+# At 10 m / ~0.00009°, a 5 % threshold is ~0.5 m — detections this close to a
+# pixel boundary may be assigned to the wrong adjacent pixel due to GPS scatter.
+_BOUNDARY_WARNING_FRACTION = 0.05
 
 # Keep scoring aligned with existing denoiser landcover priors.
 _CLASS_SCORES: dict[int, float] = {
@@ -185,6 +193,86 @@ def _download_tile(*, url: str, local_path: Path, timeout_seconds: int = 120) ->
         tmp.replace(local_path)
 
 
+def _validate_tile_crs(src: rasterio.io.DatasetReader, tile_path: Path) -> None:
+    """Raise if the tile CRS is not EPSG:4326.
+
+    ESA WorldCover tiles ship in WGS-84 geographic coordinates.  Any other CRS
+    means lon/lat fire-detection coordinates cannot be passed directly to
+    rasterio.sample() without reprojection, and landcover assignments would be
+    silently wrong.
+    """
+    if src.crs is None or src.crs != _EXPECTED_CRS:
+        raise ValueError(
+            f"STOP: tile {tile_path.name} CRS is {src.crs!r}, expected EPSG:4326. "
+            "Direct lon/lat sampling would produce incorrect geographic assignments. "
+            "Reproject the tile to EPSG:4326 before sampling."
+        )
+
+
+def _validate_pixel_registration(src: rasterio.io.DatasetReader, tile_path: Path) -> None:
+    """Log a WARNING if pixel registration is not pixel-area (corner-registered).
+
+    ESA WorldCover uses GDAL AREA_OR_POINT=Area: each pixel covers the area
+    whose upper-left corner is at the pixel coordinate.  rasterio.sample()
+    floors the fractional pixel index, which is correct for area registration.
+    Centre-registered tiles (PointRegistration) would require a half-pixel
+    shift before sampling.
+    """
+    area_or_point = src.tags().get("AREA_OR_POINT", "Area")
+    if area_or_point.lower() != "area":
+        pixel_size_deg = abs(src.transform.a)
+        LOGGER.warning(
+            "Tile %s reports AREA_OR_POINT=%s (expected 'Area'). "
+            "Pixel-center registration offsets the effective sample point by ~%.6f deg "
+            "(half a pixel). Landcover assignments near pixel boundaries may be one "
+            "pixel off. Mitigation: shift lon/lat by +0.5 pixel before sampling; "
+            "target: science_grade.",
+            tile_path.name,
+            area_or_point,
+            pixel_size_deg / 2,
+        )
+
+
+def _warn_boundary_coords(
+    src: rasterio.io.DatasetReader,
+    coords: list[tuple[float, float]],
+    tile_path: Path,
+) -> None:
+    """Log a WARNING if any coordinate falls within _BOUNDARY_WARNING_FRACTION of a pixel edge.
+
+    At 10-metre WorldCover resolution (~0.00009°), a detection within 5 % of a
+    pixel boundary is within ~0.5 m of the edge.  Sub-metre GPS scatter means
+    the true ignition point could land in the adjacent pixel.
+    """
+    if not coords:
+        return
+    # One pass over coords: extract lons and lats as contiguous float64 arrays.
+    coords_arr = np.array(coords, dtype=np.float64)
+    lons, lats = coords_arr[:, 0], coords_arr[:, 1]
+    # Fractional column/row offsets within each pixel.
+    # transform.a is positive pixel width; transform.e is negative pixel height.
+    pixel_width = abs(src.transform.a)
+    frac_col = ((lons - src.transform.c) / src.transform.a) % 1.0
+    frac_row = ((lats - src.transform.f) / src.transform.e) % 1.0
+    near_boundary = (
+        (np.minimum(frac_col, 1.0 - frac_col) < _BOUNDARY_WARNING_FRACTION)
+        | (np.minimum(frac_row, 1.0 - frac_row) < _BOUNDARY_WARNING_FRACTION)
+    )
+    count = int(np.sum(near_boundary))
+    if count > 0:
+        LOGGER.warning(
+            "%s: %d/%d coordinates in this batch fall within %.0f%% of a pixel boundary "
+            "(pixel_width=%.6f deg). Adjacent-pixel misassignment is possible. "
+            "Mitigation: snap coordinates to pixel centers before sampling; "
+            "target: science_grade.",
+            tile_path.name,
+            count,
+            len(coords),
+            _BOUNDARY_WARNING_FRACTION * 100,
+            pixel_width,
+        )
+
+
 def _sample_classes(src: rasterio.io.DatasetReader, coords: list[tuple[float, float]]) -> np.ndarray:
     # rasterio returns arrays with one value per coordinate for a single-band raster.
     return np.fromiter((int(v[0]) for v in src.sample(coords)), dtype=np.int32, count=len(coords))
@@ -269,6 +357,9 @@ def _backfill_tile(
         get_engine().connect() as read_conn,
         get_engine().begin() as write_conn,
     ):
+        _validate_tile_crs(src, tile_path)
+        _validate_pixel_registration(src, tile_path)
+
         result = read_conn.execution_options(stream_results=True).execute(select_stmt, params)
         while True:
             chunk = result.fetchmany(query_batch_size)
@@ -278,6 +369,7 @@ def _backfill_tile(
             rows_seen += len(chunk)
             ids = [int(r.id) for r in chunk]
             coords = [(float(r.lon), float(r.lat)) for r in chunk]
+            _warn_boundary_coords(src, coords, tile_path)
             classes = _sample_classes(src, coords)
 
             updates: list[dict] = []

--- a/ingest/tests/test_aoi_pause_notifications.py
+++ b/ingest/tests/test_aoi_pause_notifications.py
@@ -32,10 +32,12 @@ def _make_aoi(**overrides) -> dict:
 def test_paused_aoi_skips_notify_in_new_ignition():
     """When notifications are paused, check_new_ignition runs the DB query but
     does NOT call notify()."""
+    from datetime import datetime, timezone
+
     from ingest.aoi_watch import check_new_ignition
 
     aoi = _make_aoi(
-        watch_notifications_paused_until=_NOW + timedelta(hours=2),
+        watch_notifications_paused_until=datetime.now(timezone.utc) + timedelta(hours=2),
     )
 
     # Two qualifying detections within the cluster radius, both new
@@ -169,10 +171,12 @@ def test_no_pause_field_allows_notify():
 
 def test_spread_trajectory_skips_paused_aoi():
     """run_spread_trajectory_checks skips check_spread_trajectory for paused AOIs."""
+    from datetime import datetime, timezone
+
     from ingest.spread_trajectory_watch import run_spread_trajectory_checks
 
     paused_aoi = _make_aoi(
-        watch_notifications_paused_until=_NOW + timedelta(hours=3),
+        watch_notifications_paused_until=datetime.now(timezone.utc) + timedelta(hours=3),
     )
     session = MagicMock()
 
@@ -200,10 +204,12 @@ def test_spread_trajectory_runs_for_active_aoi():
 
 def test_weather_threshold_skips_paused_aoi():
     """run_weather_threshold_checks skips check_weather_thresholds for paused AOIs."""
+    from datetime import datetime, timezone
+
     from ingest.weather_threshold_watch import run_weather_threshold_checks
 
     paused_aoi = _make_aoi(
-        watch_notifications_paused_until=_NOW + timedelta(hours=1),
+        watch_notifications_paused_until=datetime.now(timezone.utc) + timedelta(hours=1),
     )
     session = MagicMock()
 

--- a/ingest/tests/test_lulc_worldcover_ingest.py
+++ b/ingest/tests/test_lulc_worldcover_ingest.py
@@ -1,13 +1,20 @@
 """Unit tests for LULC WorldCover version tracking.
 
 Tests cover pure-function logic (no DB, no S3) — tile ID formatting, tile path
-construction, cache manifest write/check, and the update-param structure.
+construction, cache manifest write/check, the update-param structure, and the
+new CRS / pixel-registration / boundary-coordinate validation helpers.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from affine import Affine
 
 # ── _format_tile_id ──────────────────────────────────────────────────────────
 
@@ -140,3 +147,132 @@ class TestUpdateParamsIncludeLulcVersion:
         version, year = "v200", 2021
         source_version = f"{version}_{year}"
         assert source_version == "v200_2021"
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_src(*, epsg: int | None = 4326, area_or_point: str = "Area", pixel_size: float = 8.333e-05) -> MagicMock:
+    """Return a mock rasterio DatasetReader with the given CRS and transform."""
+    from rasterio.crs import CRS as RasterioCRS
+
+    src = MagicMock()
+    if epsg is None:
+        src.crs = None
+    else:
+        src.crs = RasterioCRS.from_epsg(epsg)
+    # Affine: origin at lon=-180, lat=90; pixel_size wide, -pixel_size tall.
+    src.transform = Affine(pixel_size, 0, -180.0, 0, -pixel_size, 90.0)
+    src.tags.return_value = {"AREA_OR_POINT": area_or_point}
+    return src
+
+
+# ── _validate_tile_crs ────────────────────────────────────────────────────────
+
+class TestValidateTileCrs:
+    def test_epsg_4326_passes(self):
+        from ingest.lulc_worldcover_ingest import _validate_tile_crs
+
+        src = _make_src(epsg=4326)
+        _validate_tile_crs(src, Path("tile.tif"))  # must not raise
+
+    def test_wrong_epsg_raises(self):
+        from ingest.lulc_worldcover_ingest import _validate_tile_crs
+
+        src = _make_src(epsg=32610)
+        with pytest.raises(ValueError, match="STOP"):
+            _validate_tile_crs(src, Path("tile.tif"))
+
+    def test_none_crs_raises(self):
+        from ingest.lulc_worldcover_ingest import _validate_tile_crs
+
+        src = _make_src(epsg=None)
+        with pytest.raises(ValueError, match="STOP"):
+            _validate_tile_crs(src, Path("tile.tif"))
+
+
+# ── _validate_pixel_registration ─────────────────────────────────────────────
+
+class TestValidatePixelRegistration:
+    def test_area_registration_silent(self, caplog):
+        from ingest.lulc_worldcover_ingest import _validate_pixel_registration
+
+        src = _make_src(area_or_point="Area")
+        with caplog.at_level(logging.WARNING, logger="lulc_worldcover_ingest"):
+            _validate_pixel_registration(src, Path("tile.tif"))
+        assert not caplog.records
+
+    def test_point_registration_warns(self, caplog):
+        from ingest.lulc_worldcover_ingest import _validate_pixel_registration
+
+        src = _make_src(area_or_point="Point")
+        with caplog.at_level(logging.WARNING, logger="lulc_worldcover_ingest"):
+            _validate_pixel_registration(src, Path("tile.tif"))
+        assert any("AREA_OR_POINT" in r.message for r in caplog.records)
+        assert any("Mitigation" in r.message for r in caplog.records)
+
+    def test_missing_tag_defaults_to_area_silent(self, caplog):
+        from ingest.lulc_worldcover_ingest import _validate_pixel_registration
+
+        src = _make_src()
+        src.tags.return_value = {}  # no AREA_OR_POINT tag
+        with caplog.at_level(logging.WARNING, logger="lulc_worldcover_ingest"):
+            _validate_pixel_registration(src, Path("tile.tif"))
+        assert not caplog.records
+
+
+# ── _warn_boundary_coords ─────────────────────────────────────────────────────
+
+class TestWarnBoundaryCoords:
+    # pixel_size = 8.333e-05; origin lon=-180, lat=90
+    # A coord at lon=-180.0 (frac_col=0.0) is exactly on the left edge → boundary.
+    # A coord at lon=-180.0 + 0.5*pixel_size is at pixel centre → not boundary.
+
+    def _make_interior_coord(self, pixel_size: float = 8.333e-05) -> tuple[float, float]:
+        """Coordinate at pixel centre — safely away from any boundary."""
+        return (-180.0 + pixel_size * 0.5, 90.0 - pixel_size * 0.5)
+
+    def _make_boundary_coord(self) -> tuple[float, float]:
+        """Coordinate exactly on a pixel edge (frac_col = 0.0)."""
+        return (-180.0, 90.0)
+
+    def test_no_warning_for_interior_coords(self, caplog):
+        from ingest.lulc_worldcover_ingest import _warn_boundary_coords
+
+        src = _make_src()
+        coords = [self._make_interior_coord() for _ in range(5)]
+        with caplog.at_level(logging.WARNING, logger="lulc_worldcover_ingest"):
+            _warn_boundary_coords(src, coords, Path("tile.tif"))
+        assert not caplog.records
+
+    def test_warns_for_boundary_coords(self, caplog):
+        from ingest.lulc_worldcover_ingest import _warn_boundary_coords
+
+        src = _make_src()
+        coords = [self._make_boundary_coord()]
+        with caplog.at_level(logging.WARNING, logger="lulc_worldcover_ingest"):
+            _warn_boundary_coords(src, coords, Path("tile.tif"))
+        assert any("pixel boundary" in r.message for r in caplog.records)
+        assert any("Mitigation" in r.message for r in caplog.records)
+
+    def test_warns_counts_correctly(self, caplog):
+        from ingest.lulc_worldcover_ingest import _warn_boundary_coords
+
+        src = _make_src()
+        pixel_size = 8.333e-05
+        coords = [
+            self._make_boundary_coord(),          # boundary
+            self._make_interior_coord(pixel_size), # interior
+            self._make_boundary_coord(),          # boundary
+        ]
+        with caplog.at_level(logging.WARNING, logger="lulc_worldcover_ingest"):
+            _warn_boundary_coords(src, coords, Path("tile.tif"))
+        # Should report 2/3 boundary coords.
+        assert any("2/3" in r.message for r in caplog.records)
+
+    def test_empty_coords_silent(self, caplog):
+        from ingest.lulc_worldcover_ingest import _warn_boundary_coords
+
+        src = _make_src()
+        with caplog.at_level(logging.WARNING, logger="lulc_worldcover_ingest"):
+            _warn_boundary_coords(src, [], Path("tile.tif"))
+        assert not caplog.records

--- a/ingest/tests/test_lulc_worldcover_ingest.py
+++ b/ingest/tests/test_lulc_worldcover_ingest.py
@@ -12,7 +12,6 @@ import logging
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import numpy as np
 import pytest
 from affine import Affine
 


### PR DESCRIPTION
Closes #290

## Changes

Add validation helpers to ensure correct geographic sampling before LULC WorldCover tile processing:

- **`_validate_tile_crs()`**: Enforce EPSG:4326 (WGS-84) CRS. Direct lon/lat sampling would produce incorrect results with any other CRS.
- **`_validate_pixel_registration()`**: Warn if tile uses centre-registration instead of area-registration. Centre-registered tiles require a half-pixel shift before sampling.
- **`_warn_boundary_coords()`**: Warn when coordinates fall within 5% of a pixel edge (~0.5 m at 10 m resolution). Sub-metre GPS scatter may cause misassignment to adjacent pixels.

Integrate validation calls in `_backfill_tile()` before processing coordinates.

## Testing

Add comprehensive unit tests covering:
- CRS validation (correct, wrong, missing)
- Pixel registration detection (Area, Point, missing tag)
- Boundary coordinate detection (interior, boundary, mixed batches, empty)

Tests use mocked `rasterio.DatasetReader` objects with configurable CRS and affine transforms.