### PR TITLE
fix(ml): eliminate temporal data leakage in denoiser calibration split

### DIFF
--- a/api/aoi_utils.py
+++ b/api/aoi_utils.py
@@ -10,12 +10,19 @@ from datetime import datetime, timezone
 from typing import Any
 
 
-def _is_notifications_paused(aoi: dict[str, Any]) -> bool:
+def _is_notifications_paused(
+    aoi: dict[str, Any],
+    *,
+    _now: datetime | None = None,
+) -> bool:
     """Return True if AOI notifications are currently paused.
 
     The column ``watch_notifications_paused_until`` is NULL when active, or set
     to a future TIMESTAMPTZ when paused.  A past timestamp means the pause has
     expired and notifications are treated as active.
+
+    Args:
+        _now: Override for current UTC time (testing only).
     """
     paused_until = aoi.get("watch_notifications_paused_until")
     if paused_until is None:
@@ -25,4 +32,5 @@ def _is_notifications_paused(aoi: dict[str, Any]) -> bool:
     # Normalise to UTC-aware for safe comparison.
     if paused_until.tzinfo is None:
         paused_until = paused_until.replace(tzinfo=timezone.utc)
-    return paused_until > datetime.now(timezone.utc)
+    now = _now if _now is not None else datetime.now(timezone.utc)
+    return paused_until > now

--- a/ingest/aoi_watch.py
+++ b/ingest/aoi_watch.py
@@ -342,7 +342,7 @@ def check_new_ignition(
             else ""
         )
 
-        if _is_notifications_paused(aoi):
+        if _is_notifications_paused(aoi, _now=now):
             LOGGER.info(
                 "aoi_watch: notifications paused for AOI %s until %s — skipping alerts",
                 aoi_name,
@@ -446,7 +446,7 @@ def run_aoi_watch_cycle(api_base_url: str | None = None) -> int:
 
             if max_spread_prob is not None and _should_alert(aoi, max_spread_prob, check_time):
                 threshold = aoi["watch_alert_threshold"]
-                if _is_notifications_paused(aoi):
+                if _is_notifications_paused(aoi, _now=now):
                     LOGGER.info(
                         "aoi_watch: notifications paused for AOI %s until %s — skipping alerts",
                         aoi_name,

--- a/ingest/spread_trajectory_watch.py
+++ b/ingest/spread_trajectory_watch.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import math
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -411,19 +412,22 @@ def check_spread_trajectory(
 def run_spread_trajectory_checks(
     aois: list[dict[str, Any]],
     session: Any,
+    *,
+    _now: datetime | None = None,
 ) -> list[dict[str, Any]]:
     """Run spread trajectory checks for every watched AOI.
 
     Args:
         aois:    List of AOI dicts (same shape as produced by list_watched_aois_due).
         session: SQLAlchemy connection/session.
+        _now:    Override for current UTC time (testing only).
 
     Returns:
         Flat list of result dicts from all AOIs and all horizons that triggered.
     """
     results: list[dict[str, Any]] = []
     for aoi in aois:
-        if _is_notifications_paused(aoi):
+        if _is_notifications_paused(aoi, _now=_now):
             LOGGER.info(
                 "spread_trajectory_watch: notifications paused for AOI %s — skipping",
                 aoi.get("name"),

--- a/ingest/tests/test_aoi_pause_notifications.py
+++ b/ingest/tests/test_aoi_pause_notifications.py
@@ -77,14 +77,10 @@ def test_paused_aoi_skips_notify_in_new_ignition():
 
 def test_expired_pause_allows_notify():
     """When the pause timestamp is in the past (expired), notify IS called."""
-    from datetime import datetime, timezone
-
     from ingest.aoi_watch import check_new_ignition
 
-    # Use real now() so the expired timestamp is genuinely in the past.
-    real_now = datetime.now(timezone.utc)
     aoi = _make_aoi(
-        watch_notifications_paused_until=real_now - timedelta(hours=1),
+        watch_notifications_paused_until=_NOW - timedelta(hours=1),
     )
 
     mock_rows = [
@@ -177,7 +173,7 @@ def test_spread_trajectory_skips_paused_aoi():
     session = MagicMock()
 
     with patch("ingest.spread_trajectory_watch.check_spread_trajectory") as mock_check:
-        results = run_spread_trajectory_checks([paused_aoi], session)
+        results = run_spread_trajectory_checks([paused_aoi], session, _now=_NOW)
 
     mock_check.assert_not_called()
     assert results == []
@@ -191,7 +187,7 @@ def test_spread_trajectory_runs_for_active_aoi():
     session = MagicMock()
 
     with patch("ingest.spread_trajectory_watch.check_spread_trajectory", return_value=[]) as mock_check:
-        run_spread_trajectory_checks([active_aoi], session)
+        run_spread_trajectory_checks([active_aoi], session, _now=_NOW)
 
     mock_check.assert_called_once_with(active_aoi, session)
 
@@ -208,7 +204,7 @@ def test_weather_threshold_skips_paused_aoi():
     session = MagicMock()
 
     with patch("ingest.weather_threshold_watch.check_weather_thresholds") as mock_check:
-        results = run_weather_threshold_checks([paused_aoi], session)
+        results = run_weather_threshold_checks([paused_aoi], session, _now=_NOW)
 
     mock_check.assert_not_called()
     assert results == []
@@ -222,6 +218,6 @@ def test_weather_threshold_runs_for_active_aoi():
     session = MagicMock()
 
     with patch("ingest.weather_threshold_watch.check_weather_thresholds", return_value=None) as mock_check:
-        run_weather_threshold_checks([active_aoi], session)
+        run_weather_threshold_checks([active_aoi], session, _now=_NOW)
 
     mock_check.assert_called_once_with(active_aoi, session)

--- a/ingest/weather_threshold_watch.py
+++ b/ingest/weather_threshold_watch.py
@@ -29,6 +29,7 @@ RH Threshold Crossing (Transition Gate):
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -265,19 +266,22 @@ def check_weather_thresholds(aoi: dict[str, Any], session: Any) -> dict[str, Any
 def run_weather_threshold_checks(
     aois: list[dict[str, Any]],
     session: Any,
+    *,
+    _now: datetime | None = None,
 ) -> list[dict[str, Any]]:
     """Run weather threshold checks for every watched AOI.
 
     Args:
         aois:    List of AOI dicts.
         session: SQLAlchemy connection/session.
+        _now:    Override for current UTC time (testing only).
 
     Returns:
         List of non-None results from check_weather_thresholds.
     """
     results: list[dict[str, Any]] = []
     for aoi in aois:
-        if _is_notifications_paused(aoi):
+        if _is_notifications_paused(aoi, _now=_now):
             LOGGER.info(
                 "weather_threshold_watch: notifications paused for AOI %s — skipping",
                 aoi.get("name"),

--- a/ml/train_denoiser_v2.py
+++ b/ml/train_denoiser_v2.py
@@ -61,7 +61,19 @@ def _maybe_git_sha() -> Optional[str]:
         return None
 
 
-def _load_snapshot(path: str, *, columns: list[str]) -> tuple[pd.DataFrame, pd.DataFrame]:
+def _load_snapshot(
+    path: str,
+    *,
+    columns: list[str],
+    train_fraction: float = 0.6,
+    calibration_fraction: float = 0.8,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Load snapshot and split into train / calibration / eval using temporal ordering.
+
+    Default fractions: training=first 60%, calibration=middle 20%, eval=final 20%.
+    For directory snapshots (``train.parquet`` + ``eval.parquet``), both files are
+    concatenated before re-splitting so the temporal boundaries are re-established.
+    """
     read_columns = list(dict.fromkeys(columns))
 
     def _read_with_fallback(parquet_path: str) -> pd.DataFrame:
@@ -72,27 +84,25 @@ def _load_snapshot(path: str, *, columns: list[str]) -> tuple[pd.DataFrame, pd.D
             keep = [c for c in read_columns if c in full.columns]
             return full[keep]
 
+    full_columns = list(dict.fromkeys(read_columns + ["start_time"]))
+
     if os.path.isdir(path):
         train_path = os.path.join(path, "train.parquet")
         eval_path = os.path.join(path, "eval.parquet")
-        train = _read_with_fallback(train_path)
-        eval_df = _read_with_fallback(eval_path)
-        return train, eval_df
-    full_columns = list(dict.fromkeys(read_columns + ["start_time"]))
-    try:
-        full = read_parquet_with_fallback(path, columns=full_columns)
-    except Exception:
-        full = read_parquet_with_fallback(path)
-        keep = [c for c in full_columns if c in full.columns]
-        full = full[keep]
-    if "start_time" in full.columns:
-        full = full.sort_values("start_time")
-    split_dt = full["start_time"].quantile(0.8) if "start_time" in full.columns else None
-    if split_dt is not None:
-        return full[full["start_time"] < split_dt].copy(), full[full["start_time"] >= split_dt].copy()
-    n = len(full)
-    cut = int(n * 0.8)
-    return full.iloc[:cut].copy(), full.iloc[cut:].copy()
+        full = pd.concat(
+            [_read_with_fallback(train_path), _read_with_fallback(eval_path)],
+            ignore_index=True,
+            sort=False,
+        )
+    else:
+        try:
+            full = read_parquet_with_fallback(path, columns=full_columns)
+        except Exception:
+            full = read_parquet_with_fallback(path)
+            keep = [c for c in full_columns if c in full.columns]
+            full = full[keep]
+
+    return _temporal_3way_split(full, train_fraction=train_fraction, calibration_fraction=calibration_fraction)
 
 
 def _map_labels(df: pd.DataFrame, label_col: str = "event_label") -> np.ndarray:
@@ -162,21 +172,60 @@ def _stratified_downsample(
     return work.loc[sampled_unique].copy()
 
 
+def _temporal_3way_split(
+    df: pd.DataFrame,
+    *,
+    train_fraction: float = 0.6,
+    calibration_fraction: float = 0.8,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Split *df* into (train, calibration, eval) in chronological order.
+
+    Splits at ``start_time`` quantiles when the column is present and quantile
+    boundaries produce non-empty partitions; falls back to positional slicing.
+    The caller is responsible for checking that no returned partition is empty.
+    """
+    if "start_time" in df.columns:
+        ordered = df.sort_values("start_time").reset_index(drop=True)
+        split_train_dt = ordered["start_time"].quantile(train_fraction)
+        split_cal_dt = ordered["start_time"].quantile(calibration_fraction)
+        train = ordered[ordered["start_time"] < split_train_dt].copy()
+        cal = ordered[
+            (ordered["start_time"] >= split_train_dt) & (ordered["start_time"] < split_cal_dt)
+        ].copy()
+        eval_df = ordered[ordered["start_time"] >= split_cal_dt].copy()
+        if not train.empty and not cal.empty and not eval_df.empty:
+            return train, cal, eval_df
+        # Fall through to positional when quantile boundaries collapse (e.g. many duplicate timestamps)
+    else:
+        ordered = df
+
+    n = len(ordered)
+    cut_train = int(n * train_fraction)
+    cut_cal = int(n * calibration_fraction)
+    return (
+        ordered.iloc[:cut_train].copy(),
+        ordered.iloc[cut_train:cut_cal].copy(),
+        ordered.iloc[cut_cal:].copy(),
+    )
+
+
 def _apply_micro_batch(
     *,
     train_df: pd.DataFrame,
+    calibration_df: pd.DataFrame,
     eval_df: pd.DataFrame,
     config: Dict[str, Any],
     label_col: str,
     default_strat_cols: list[str],
     rng: np.random.Generator,
-) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, Any]]:
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, dict[str, Any]]:
     micro_cfg = dict(config.get("micro_batch", {}))
     if not bool(micro_cfg.get("enabled", False)):
-        return train_df, eval_df, {"enabled": False}
+        return train_df, calibration_df, eval_df, {"enabled": False}
 
-    if "start_time" not in train_df.columns or "start_time" not in eval_df.columns:
-        raise ValueError("micro_batch requires start_time in snapshot.")
+    for name, df in [("train_df", train_df), ("calibration_df", calibration_df), ("eval_df", eval_df)]:
+        if "start_time" not in df.columns:
+            raise ValueError(f"micro_batch requires start_time in {name}.")
 
     start_raw = micro_cfg.get("start")
     end_raw = micro_cfg.get("end")
@@ -187,7 +236,9 @@ def _apply_micro_batch(
     if end <= start:
         raise ValueError(f"Invalid micro_batch window: start={start} end={end}")
 
-    combined = pd.concat([train_df.copy(), eval_df.copy()], ignore_index=True, sort=False)
+    combined = pd.concat(
+        [train_df, calibration_df, eval_df], ignore_index=True, sort=False
+    )
     combined["start_time"] = pd.to_datetime(combined["start_time"], utc=True, errors="coerce")
     micro = combined[(combined["start_time"] >= start) & (combined["start_time"] < end)].copy()
     if micro.empty:
@@ -212,15 +263,13 @@ def _apply_micro_batch(
             f"positive_rows={pos_count}, min_positive_rows={min_pos}."
         )
 
-    split_dt = micro["start_time"].quantile(0.8)
-    micro_train = micro[micro["start_time"] < split_dt].copy()
-    micro_eval = micro[micro["start_time"] >= split_dt].copy()
-    if micro_train.empty or micro_eval.empty:
-        cut = max(1, int(np.floor(len(micro) * 0.8)))
-        micro_train = micro.iloc[:cut].copy()
-        micro_eval = micro.iloc[cut:].copy()
-        if micro_eval.empty:
-            micro_eval = micro_train.tail(min(1000, len(micro_train))).copy()
+    micro_train, micro_cal, micro_eval = _temporal_3way_split(micro)
+    if micro_train.empty or micro_cal.empty or micro_eval.empty:
+        raise ValueError(
+            f"micro_batch 60/20/20 temporal split produced an empty partition "
+            f"(rows={len(micro)}). "
+            "Widen the micro_batch window or reduce min_positive_rows."
+        )
 
     stats = {
         "enabled": True,
@@ -228,6 +277,7 @@ def _apply_micro_batch(
         "end": end.isoformat(),
         "rows_total": int(len(micro)),
         "rows_train": int(len(micro_train)),
+        "rows_calibration": int(len(micro_cal)),
         "rows_eval": int(len(micro_eval)),
         "positive_rows_total": int((micro[label_col] == "POSITIVE").sum()),
         "negative_rows_total": int((micro[label_col] == "NEGATIVE").sum()),
@@ -235,7 +285,7 @@ def _apply_micro_batch(
         "max_rows": int(max_rows),
         "stratify_columns": strat_cols,
     }
-    return micro_train, micro_eval, stats
+    return micro_train, micro_cal, micro_eval, stats
 
 
 def _compute_shap_top_features(
@@ -1348,11 +1398,15 @@ def train_denoiser_v2(config: Dict[str, Any]) -> str:
     required_columns = list(dict.fromkeys(features + [label_col] + slice_cols + ["start_time"]))
     if coverage_scope == "covered":
         required_columns.append("truth_covered_mask")
-    train_df, eval_df = _load_snapshot(config["snapshot_path"], columns=required_columns)
+    train_df, calibration_df, eval_df = _load_snapshot(
+        config["snapshot_path"], columns=required_columns
+    )
     train_df = _ensure_slice_columns(train_df, slice_cols)
+    calibration_df = _ensure_slice_columns(calibration_df, slice_cols)
     eval_df = _ensure_slice_columns(eval_df, slice_cols)
-    train_df, eval_df, micro_batch_stats = _apply_micro_batch(
+    train_df, calibration_df, eval_df, micro_batch_stats = _apply_micro_batch(
         train_df=train_df,
+        calibration_df=calibration_df,
         eval_df=eval_df,
         config=config,
         label_col=label_col,
@@ -1363,12 +1417,16 @@ def train_denoiser_v2(config: Dict[str, Any]) -> str:
     for col in features:
         if col not in train_df.columns:
             train_df[col] = np.nan
+        if col not in calibration_df.columns:
+            calibration_df[col] = np.nan
         if col not in eval_df.columns:
             eval_df[col] = np.nan
     train_df = _ensure_slice_columns(train_df, slice_cols)
+    calibration_df = _ensure_slice_columns(calibration_df, slice_cols)
     eval_df = _ensure_slice_columns(eval_df, slice_cols)
 
     train_scope = _select_scope(train_df, coverage_scope)
+    calibration_scope = _select_scope(calibration_df, coverage_scope)
     eval_scope = _select_scope(eval_df, coverage_scope)
 
     y_train = _map_labels(train_scope, label_col)
@@ -1417,34 +1475,39 @@ def train_denoiser_v2(config: Dict[str, Any]) -> str:
         rng=rng,
     )
 
-    eval_known_mask = _map_labels(eval_scope, label_col) >= 0
-    eval_known_df = eval_scope.loc[eval_known_mask].copy()
-    if eval_known_df.empty:
-        raise ValueError("No known labels in eval scope; cannot calibrate or compute promotion gates.")
+    cal_known_mask = _map_labels(calibration_scope, label_col) >= 0
+    calibration_known_df = calibration_scope.loc[cal_known_mask].copy()
+    if calibration_known_df.empty:
+        raise ValueError("No known labels in calibration scope; cannot calibrate.")
 
-    calibration_fraction = float(config.get("calibration_holdout_fraction", 0.5))
-    calibration_df, eval_holdout_df = _split_calibration_eval_holdout(
-        eval_known_df,
-        calibration_fraction=calibration_fraction,
-    )
-    if eval_holdout_df.empty:
-        eval_holdout_df = calibration_df.copy()
+    eval_known_mask = _map_labels(eval_scope, label_col) >= 0
+    eval_known_holdout = eval_scope.loc[eval_known_mask].copy()
+    if eval_known_holdout.empty:
+        raise ValueError("No known labels in eval scope; cannot compute promotion gates.")
+
+    # Temporal non-overlap assertion: every calibration timestamp must precede every eval timestamp.
+    if "start_time" in calibration_known_df.columns and "start_time" in eval_known_holdout.columns:
+        cal_max = calibration_known_df["start_time"].max()
+        eval_min = eval_known_holdout["start_time"].min()
+        if cal_max >= eval_min:
+            raise ValueError(
+                f"Temporal leakage detected: calibration max timestamp ({cal_max}) "
+                f">= eval min timestamp ({eval_min}). "
+                "Ensure the snapshot covers a wide enough time range for a 60/20/20 split."
+            )
 
     global_calibrator, slice_calibrators, y_cal, raw_cal = _calibrate(
         config=config,
         model=model,
-        calibration_df=calibration_df,
+        calibration_df=calibration_known_df,
         features=features,
         slice_cols=slice_cols,
         label_col=label_col,
     )
 
-    y_eval = _map_labels(eval_holdout_df, label_col)
-    known_eval_mask = y_eval >= 0
-    eval_known_holdout = eval_holdout_df.loc[known_eval_mask].copy()
-    y_eval_known = y_eval[known_eval_mask]
+    y_eval_known = _map_labels(eval_known_holdout, label_col)
     if len(eval_known_holdout) == 0:
-        raise ValueError("No known labels in eval holdout after split.")
+        raise ValueError("No known labels in eval holdout.")
 
     raw_eval = _predict_raw(model, _feature_matrix(eval_known_holdout, features))
     calibrated_scores = _apply_slice_calibration(
@@ -1606,6 +1669,8 @@ def train_denoiser_v2(config: Dict[str, Any]) -> str:
         "train_rows": int(len(train_df)),
         "train_scope_rows": int(len(train_scope)),
         "train_fit_rows": int(len(fit_train_df)),
+        "calibration_rows": int(len(calibration_df)),
+        "calibration_scope_rows": int(len(calibration_scope)),
         "eval_rows": int(len(eval_df)),
         "eval_scope_rows": int(len(eval_scope)),
         "train_known_rows": int(known_train.sum()),


### PR DESCRIPTION
## Summary
Refactors the denoiser training pipeline to use a proper 3-way temporal split (train/calibration/eval) instead of the previous 2-way split, eliminating data leakage where calibration and evaluation sets could overlap in time.

## Changes

### New `_temporal_3way_split()` function
- Splits data into train (60%) / calibration (20%) / eval (20%) using chronological ordering
- Uses `start_time` quantiles when available, falls back to positional slicing
- Handles edge cases like duplicate timestamps gracefully

### Updated `_load_snapshot()` function
- Now returns 3 dataframes instead of 2
- Accepts `train_fraction` and `calibration_fraction` parameters
- Concatenates pre-split train/eval files before re-splitting to establish proper temporal boundaries
- Refactored directory handling to use temporal splits consistently

### Updated `_apply_micro_batch()` function
- Now accepts and processes `calibration_df` alongside train/eval
- Uses `_temporal_3way_split()` for micro-batch window re-splitting
- Returns 4 values (adds calibration dataframe)
- Adds `rows_calibration` to stats output

### Updated `train_denoiser_v2()` function
- Handles three separate dataframes through the pipeline
- Adds temporal leakage detection: validates that calibration max timestamp ≤ eval min timestamp
- Removes the previous `calibration_holdout_fraction` split logic
- Updates logging/stats to track calibration rows separately

### CI fix: injectable clock in `_is_notifications_paused`
- `_is_notifications_paused` previously hard-coded `datetime.now()`, causing tests to fail once wall time caught up to the test's hardcoded sentinel date
- Added `_now` kwarg and threaded it through `check_new_ignition`, `run_spread_trajectory_checks`, and `run_weather_threshold_checks`

## Impact
- Prevents temporal data leakage in calibration metrics
- Ensures consistent 60/20/20 temporal split across all code paths

Closes #280