### PR TITLE
Atomically finalize batch and advance watermark

### DIFF
--- a/ingest/firms_ingest.py
+++ b/ingest/firms_ingest.py
@@ -510,20 +510,27 @@ def run_firms_ingest(
             if denoiser_ran or config.denoiser_required:
                 _assert_batch_denoiser_complete(batch_id, config=config)
 
-            repository.finalize_ingest_batch(
-                batch_id,
-                status="succeeded",
-                fetched=fetched_count,
-                inserted=inserted,
-                skipped=max(skipped_duplicates, 0),
-            )
-            if watermark_advanced_to is not None and not is_archive_mode:
-                repository.advance_ingest_watermark(
-                    source=source,
-                    area_key=area_key,
-                    last_acq_time_utc=watermark_advanced_to,
-                    last_batch_id=batch_id,
+            # Finalize the batch and advance the watermark atomically so a crash
+            # between the two writes cannot leave the watermark un-advanced while
+            # detections are already persisted (which would cause the next run to
+            # re-fetch the same window and produce temporal continuity gaps).
+            with repository.get_engine().execution_options(isolation_level="SERIALIZABLE").begin() as commit_conn:
+                repository.finalize_ingest_batch(
+                    batch_id,
+                    status="succeeded",
+                    fetched=fetched_count,
+                    inserted=inserted,
+                    skipped=max(skipped_duplicates, 0),
+                    conn=commit_conn,
                 )
+                if watermark_advanced_to is not None and not is_archive_mode:
+                    repository.advance_ingest_watermark(
+                        source=source,
+                        area_key=area_key,
+                        last_acq_time_utc=watermark_advanced_to,
+                        last_batch_id=batch_id,
+                        conn=commit_conn,
+                    )
             log_event(
                 LOGGER,
                 "firms.watermark",

--- a/ingest/repository.py
+++ b/ingest/repository.py
@@ -113,6 +113,7 @@ def finalize_ingest_batch(
     fetched: int,
     inserted: int,
     skipped: int,
+    conn: Connection | None = None,
 ) -> None:
     """Update ingest batch metrics and mark completion."""
     stmt = text(
@@ -128,17 +129,18 @@ def finalize_ingest_batch(
         WHERE id = :batch_id
         """
     )
-    with get_engine().begin() as conn:
-        conn.execute(
-            stmt,
-            {
-                "batch_id": batch_id,
-                "status": status,
-                "fetched": fetched,
-                "inserted": inserted,
-                "skipped": skipped,
-            },
-        )
+    params = {
+        "batch_id": batch_id,
+        "status": status,
+        "fetched": fetched,
+        "inserted": inserted,
+        "skipped": skipped,
+    }
+    if conn is not None:
+        conn.execute(stmt, params)
+    else:
+        with get_engine().begin() as new_conn:
+            new_conn.execute(stmt, params)
 
 
 def get_ingest_watermark(source: str, area_key: str) -> dict | None:
@@ -180,6 +182,7 @@ def advance_ingest_watermark(
     area_key: str,
     last_acq_time_utc: datetime,
     last_batch_id: int,
+    conn: Connection | None = None,
 ) -> None:
     """Advance the source+area ingestion watermark after successful batch completion."""
     stmt = text(
@@ -208,17 +211,17 @@ def advance_ingest_watermark(
             updated_at = NOW()
         """
     )
-
-    with get_engine().begin() as conn:
-        conn.execute(
-            stmt,
-            {
-                "source": source,
-                "area_key": area_key,
-                "last_acq_time_utc": _as_utc(last_acq_time_utc),
-                "last_batch_id": int(last_batch_id),
-            },
-        )
+    params = {
+        "source": source,
+        "area_key": area_key,
+        "last_acq_time_utc": _as_utc(last_acq_time_utc),
+        "last_batch_id": int(last_batch_id),
+    }
+    if conn is not None:
+        conn.execute(stmt, params)
+    else:
+        with get_engine().begin() as new_conn:
+            new_conn.execute(stmt, params)
 
 
 def insert_detections(

--- a/ingest/tests/test_firms_ingest_incremental.py
+++ b/ingest/tests/test_firms_ingest_incremental.py
@@ -2,7 +2,7 @@ import unittest
 from contextlib import nullcontext
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from ingest.firms_client import FirmsValidationSummary
 from ingest.firms_ingest import _filter_detections_by_watermark, run_firms_ingest
@@ -117,6 +117,7 @@ class TestFirmsIncrementalWatermark(unittest.TestCase):
             area_key="20.000000,40.000000,21.000000,41.000000",
             last_acq_time_utc=datetime(2026, 2, 15, 11, 10, tzinfo=timezone.utc),
             last_batch_id=321,
+            conn=ANY,
         )
 
     @patch("ingest.firms_ingest._utc_now", return_value=datetime(2026, 3, 12, 15, 16, tzinfo=timezone.utc))
@@ -183,6 +184,7 @@ class TestFirmsIncrementalWatermark(unittest.TestCase):
             area_key="20.000000,40.000000,21.000000,41.000000",
             last_acq_time_utc=datetime(2026, 3, 12, 13, 10, tzinfo=timezone.utc),
             last_batch_id=654,
+            conn=ANY,
         )
 
     @patch("ingest.firms_ingest._utc_now", return_value=datetime(2026, 3, 12, 15, 16, tzinfo=timezone.utc))
@@ -256,6 +258,7 @@ class TestFirmsIncrementalWatermark(unittest.TestCase):
             area_key="20.000000,40.000000,21.000000,41.000000",
             last_acq_time_utc=datetime(2026, 3, 12, 13, 10, tzinfo=timezone.utc),
             last_batch_id=655,
+            conn=ANY,
         )
 
     @patch("ingest.firms_ingest.repository.advance_ingest_watermark")


### PR DESCRIPTION
Closes #284

## Changes

- **firms_ingest.py**: Wrap batch finalization and watermark advancement in a single SERIALIZABLE transaction to prevent data loss scenarios where a crash between the two operations could leave the watermark un-advanced while detections are persisted.

- **repository.py**: Update `finalize_ingest_batch()` and `advance_ingest_watermark()` to accept optional `conn` parameter, allowing these operations to be executed within an existing transaction instead of creating their own.

- **test_firms_ingest_incremental.py**: Update test expectations to verify that watermark advancement is called with the transaction connection.

## Rationale

This change ensures atomic consistency: if a crash occurs between finalizing the batch and advancing the watermark, the next run will not re-fetch the same data window and produce temporal continuity gaps in the ingested data.