### PR TITLE
feat(ui): ignition probability map layer and priority feed integration

### DIFF
--- a/ui/src/api/ignition.ts
+++ b/ui/src/api/ignition.ts
@@ -1,0 +1,23 @@
+import type { BBox, IgnitionGridResponse } from "../types/api";
+import type { IgnitionHorizon } from "../types/state";
+import { getJson } from "./http";
+
+const HORIZON_PARAM: Record<IgnitionHorizon, string> = {
+  'now': 'now',
+  '+24h': '24h',
+  '+48h': '48h',
+};
+
+export async function getIgnitionGrid(args: {
+  bbox: BBox;
+  horizon: IgnitionHorizon;
+}): Promise<IgnitionGridResponse> {
+  const [minLon, minLat, maxLon, maxLat] = args.bbox;
+  return getJson<IgnitionGridResponse>('/ignition', {
+    min_lon: minLon,
+    min_lat: minLat,
+    max_lon: maxLon,
+    max_lat: maxLat,
+    horizon: HORIZON_PARAM[args.horizon],
+  });
+}

--- a/ui/src/components/fire-details/FireFrontsTab.tsx
+++ b/ui/src/components/fire-details/FireFrontsTab.tsx
@@ -1,10 +1,14 @@
 import { Alert, Box, Button, Divider, Stack, Typography } from "@mui/material";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import QueryStatsIcon from "@mui/icons-material/QueryStats";
+import WhatshotIcon from "@mui/icons-material/Whatshot";
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import type { FireEvent, ReverseGeocodeResponse } from "../../types/api";
+import type { BBox, FireEvent, ReverseGeocodeResponse } from "../../types/api";
 import { getWeatherForPoint } from "../../api/fires";
-import { haversineKm } from "../../utils/geo";
+import { getIgnitionGrid } from "../../api/ignition";
+import { bboxFromPoint, haversineKm } from "../../utils/geo";
+import { highOrCriticalCellsNear } from "../../utils/ignition";
 import { forecastButtonState } from "../../utils/forecast";
 import { useAppStore } from "../../state/store";
 import {
@@ -87,6 +91,25 @@ export function FireFrontsTab({ selectedEvent, resolvedGeocodes, submitError, fo
     enabled: weatherEnabled,
     staleTime: 5 * 60 * 1000,
   });
+
+  const ignitionBbox: BBox | null = lat !== null && lon !== null
+    ? bboxFromPoint(lon, lat, 50)
+    : null;
+
+  const ignitionLayerActive = useAppStore((s) => s.layers.showIgnition);
+
+  const { data: ignitionContext } = useQuery({
+    queryKey: ["ignition-context", lat, lon],
+    queryFn: () => getIgnitionGrid({ bbox: ignitionBbox!, horizon: 'now' }),
+    enabled: ignitionLayerActive && ignitionBbox !== null,
+    staleTime: 6 * 60 * 60 * 1000,
+  });
+
+  const nearbyHighRiskCount = useMemo(() => {
+    return lat !== null && lon !== null && ignitionContext
+      ? highOrCriticalCellsNear(ignitionContext.cells, lat, lon, 50)
+      : 0;
+  }, [lat, lon, ignitionContext]);
 
   const riskTier = riskTierFromScore(score);
   const distanceToFireKm = isSafetyMode && safety.userLocation && lat !== null && lon !== null
@@ -269,6 +292,24 @@ export function FireFrontsTab({ selectedEvent, resolvedGeocodes, submitError, fo
       />
 
       <WarningsBlock warnings={weatherData?.warnings ?? null} />
+
+      {ignitionLayerActive && nearbyHighRiskCount > 0 && (
+        <Box sx={{ p: 1.5, bgcolor: "rgba(220,38,127,0.10)", border: "1px solid rgba(220,38,127,0.28)", borderRadius: 2.5, display: "flex", alignItems: "flex-start", gap: 0.9 }}>
+          <WhatshotIcon sx={{ fontSize: 15, color: "#dc2680", mt: 0.1, flexShrink: 0 }} />
+          <Box>
+            <Typography sx={{ fontSize: 11, fontWeight: 800, color: "#f9a8d4", letterSpacing: "0.08em", textTransform: "uppercase", mb: 0.3 }}>
+              Ignition Risk
+            </Typography>
+            <Typography sx={{ fontSize: 12, color: "#f9a8d4", lineHeight: 1.55 }}>
+              Conditions in this area are primed for new ignitions.{" "}
+              <Typography component="span" sx={{ fontSize: 12, fontWeight: 800, color: "#f9a8d4" }}>
+                {nearbyHighRiskCount}
+              </Typography>{" "}
+              high-risk cell{nearbyHighRiskCount !== 1 ? "s" : ""} within 50 km.
+            </Typography>
+          </Box>
+        </Box>
+      )}
 
       <Divider sx={{ borderColor: "rgba(255,255,255,0.08)" }} />
 

--- a/ui/src/components/fire-details/FireOverviewTab.tsx
+++ b/ui/src/components/fire-details/FireOverviewTab.tsx
@@ -1,5 +1,7 @@
+import { useMemo } from "react";
 import { Box, Typography } from "@mui/material";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import WhatshotIcon from "@mui/icons-material/Whatshot";
 import type { FireEvent, ReverseGeocodeResponse } from "../../types/api";
 import {
   safeNumber,
@@ -11,6 +13,7 @@ import {
   formatIntensity
 } from "./types";
 import { useAppStore } from "../../state/store";
+import { firstCriticalCellWithoutNearbyFire } from "../../utils/ignition";
 
 interface FireOverviewTabProps {
   topFires: FireEvent[];
@@ -21,6 +24,14 @@ export function FireOverviewTab({ topFires, resolvedGeocodes }: FireOverviewTabP
   const setSelectedEvent = useAppStore((s) => s.setSelectedEvent);
   const setLastClick = useAppStore((s) => s.setLastClick);
   const focusMapOnPoint = useAppStore((s) => s.focusMapOnPoint);
+  const ignitionLayerActive = useAppStore((s) => s.layers.showIgnition);
+  const ignitionData = useAppStore((s) => s.ignitionData);
+
+  const criticalWarningCell = useMemo(() => {
+    return ignitionLayerActive && ignitionData
+      ? firstCriticalCellWithoutNearbyFire(ignitionData.cells, topFires)
+      : null;
+  }, [ignitionLayerActive, ignitionData, topFires]);
 
   return (
     <>
@@ -29,6 +40,20 @@ export function FireOverviewTab({ topFires, resolvedGeocodes }: FireOverviewTabP
           {topFires.length} in view
         </Typography>
       </Box>
+
+      {criticalWarningCell && (
+        <Box sx={{ mx: 2.25, mt: 1.5, px: 1.4, py: 1, bgcolor: "rgba(220,38,127,0.12)", border: "1px solid rgba(220,38,127,0.35)", borderRadius: 2, display: "flex", alignItems: "flex-start", gap: 0.8 }}>
+          <WhatshotIcon sx={{ fontSize: 14, color: "#dc2680", mt: 0.15, flexShrink: 0 }} />
+          <Typography sx={{ fontSize: 11, color: "#f9a8d4", lineHeight: 1.55 }}>
+            No active fires detected — but conditions at{" "}
+            <Typography component="span" sx={{ fontSize: 11, fontWeight: 800, color: "#f9a8d4", fontFamily: "monospace" }}>
+              {criticalWarningCell.lat.toFixed(2)}°, {criticalWarningCell.lon.toFixed(2)}°
+            </Typography>{" "}
+            are critical for ignition right now.
+          </Typography>
+        </Box>
+      )}
+
       <Box sx={{ p: 2.25, overflowY: "auto", display: "flex", flexDirection: "column", gap: 1.2 }}>
         {topFires.map((event, index) => {
           const lat = safeNumber(event.lat);

--- a/ui/src/components/map/FireMap.tsx
+++ b/ui/src/components/map/FireMap.tsx
@@ -33,6 +33,8 @@ import type { Feature } from "geojson";
 import { apiPublicBaseUrl } from "../../config/runtime";
 import { getFireEvents, getFireFronts, getRiskGrid } from "../../api/client";
 import { getWeatherWarnings } from "../../api/fires";
+import { getIgnitionGrid } from "../../api/ignition";
+import { ApiError } from "../../api/http";
 import { useAppStore } from "../../state/store";
 import type { FireEvent } from "../../types/api";
 import {
@@ -68,6 +70,7 @@ import {
 } from "./layers/layerConfig";
 import { toFiniteNumber } from "../../utils/priorityFeed";
 import { geometryProvenanceLabel } from "../fire-details/types";
+import type { IgnitionCell } from "../../types/api";
 
 type ConfidenceFilter = "All" | "High";
 
@@ -86,6 +89,19 @@ const WARNING_SEVERITY_RGB: Record<string, [number, number, number]> = {
 function warningSeverityColor(sev: string, alpha: number): [number, number, number, number] {
   const [r, g, b] = WARNING_SEVERITY_RGB[sev] ?? WARNING_SEVERITY_RGB.yellow;
   return [r, g, b, alpha];
+}
+
+// Ignition risk colour palette — distinct hue family from the risk grid
+// (risk grid: green/gold/crimson; ignition: amber/orange-red/magenta)
+const IGNITION_LEVEL_COLOR: Record<string, [number, number, number, number]> = {
+  low:      [0, 0, 0, 0],           // invisible
+  elevated: [245, 158, 11, 110],    // amber
+  high:     [249, 115, 22, 175],    // orange-red
+  critical: [220, 38, 127, 210],    // deep magenta
+};
+
+function ignitionCellColor(cell: IgnitionCell): [number, number, number, number] {
+  return IGNITION_LEVEL_COLOR[cell.level] ?? IGNITION_LEVEL_COLOR.low;
 }
 
 function isHighConfidence(event: FireEvent): boolean {
@@ -121,6 +137,7 @@ export default function FireMap({
   const selectedEvent = useAppStore((s) => s.selectedEvent);
   const archive = useAppStore((s) => s.archive);
   const safety = useAppStore((s) => s.safety);
+  const ignitionHorizon = useAppStore((s) => s.ignitionHorizon);
   const { requestLocation } = useGeolocation();
   const setMapView = useAppStore((s) => s.setMapView);
   const setSelectedEvent = useAppStore((s) => s.setSelectedEvent);
@@ -129,6 +146,8 @@ export default function FireMap({
   const setFrontIndexByEvent = useAppStore((s) => s.setFrontIndexByEvent);
   const setLayersState = useAppStore((s) => s.setLayersState);
   const exitToLiveMode = useAppStore((s) => s.exitToLiveMode);
+  const setIgnitionHorizon = useAppStore((s) => s.setIgnitionHorizon);
+  const setIgnitionData = useAppStore((s) => s.setIgnitionData);
 
   const isArchiveMode = archive.viewMode === "archive";
 
@@ -192,6 +211,23 @@ export default function FireMap({
     staleTime: 15 * 60 * 1000,  // MeteoAlarm feed updates every ~15 min
     placeholderData: (prev) => prev
   });
+
+  const ignitionQuery = useQuery({
+    queryKey: ["ignition", bbox, ignitionHorizon],
+    queryFn: () => getIgnitionGrid({ bbox, horizon: ignitionHorizon }),
+    enabled: layersState.showIgnition,
+    staleTime: 6 * 60 * 60 * 1000,  // 6h — matches server cache cadence
+    placeholderData: (prev) => prev,
+    retry: (failureCount, error) => {
+      // Don't retry 503 — model is explicitly unavailable
+      if (error instanceof ApiError && error.statusCode === 503) return false;
+      return failureCount < 2;
+    }
+  });
+
+  useEffect(() => {
+    setIgnitionData(ignitionQuery.data ?? null);
+  }, [ignitionQuery.data, setIgnitionData]);
 
   const normalizedEvents = useMemo(() => {
     const source = eventsQuery.data?.events || [];
@@ -486,6 +522,27 @@ export default function FireMap({
       );
     }
 
+    // Ignition probability layer
+    if (layersState.showIgnition && ignitionQuery.data) {
+      const visibleCells = ignitionQuery.data.cells.filter((c) => c.level !== 'low');
+      if (visibleCells.length > 0) {
+        deckLayers.push(
+          new ScatterplotLayer<IgnitionCell>({
+            id: `ignition-${ignitionHorizon}-${visibleCells.length}`,
+            data: visibleCells,
+            pickable: false,
+            filled: true,
+            stroked: false,
+            getPosition: (c) => [c.lon, c.lat],
+            getFillColor: ignitionCellColor,
+            getRadius: 10000,  // ~10 km radius per cell; distinct at zoom 5+
+            radiusMinPixels: 3,
+            radiusMaxPixels: 20
+          })
+        );
+      }
+    }
+
     // User location layers (safety mode)
     if (safety.enabled && safety.userLocation) {
       const locationLayers = buildUserLocationLayers(safety.userLocation, safety.proximityRadiusKm);
@@ -496,9 +553,12 @@ export default function FireMap({
   }, [
     filters.clusterPoints,
     forecast.lastForecast?.run.id,
+    ignitionHorizon,
+    ignitionQuery.data,
     layersState.showFires,
     layersState.showFronts,
     layersState.showForecast,
+    layersState.showIgnition,
     layersState.showRisk,
     layersState.showWarnings,
     mapView.zoom,
@@ -584,6 +644,18 @@ export default function FireMap({
       {(eventsQuery.isError || frontsQuery.isError || riskQuery.isError) && (
         <Alert severity="warning" sx={{ position: "absolute", top: 12, left: 12, right: 12, zIndex: 20 }}>
           Live map data is partially unavailable; showing last successful snapshot where possible.
+        </Alert>
+      )}
+
+      {layersState.showIgnition && ignitionQuery.isError && (
+        <Alert severity="info" sx={{ position: "absolute", top: 12, left: 12, right: 260, zIndex: 20 }}>
+          Ignition model unavailable — layer hidden.
+        </Alert>
+      )}
+
+      {layersState.showIgnition && !ignitionQuery.isError && ignitionQuery.data?.coverage_warnings && ignitionQuery.data.coverage_warnings.length > 0 && (
+        <Alert severity="warning" icon={false} sx={{ position: "absolute", bottom: 52, left: 12, right: 12, zIndex: 20, py: 0.5, fontSize: 11 }}>
+          {ignitionQuery.data.coverage_warnings.join(' · ')}
         </Alert>
       )}
 
@@ -731,8 +803,69 @@ export default function FireMap({
         <FormControlLabel
           control={<Switch size="small" checked={layersState.showWarnings} onChange={(e) => setLayersState({ showWarnings: e.target.checked })} />}
           label={<Typography sx={{ fontSize: 13, color: "#d1d5db" }}>Weather Warnings <Typography component="span" sx={{ fontSize: 10, color: "#6b7280" }}>(Europe)</Typography></Typography>}
+          sx={{ display: "flex", mx: 0, mb: 0.25 }}
+        />
+        <FormControlLabel
+          control={<Switch size="small" checked={layersState.showIgnition} onChange={(e) => setLayersState({ showIgnition: e.target.checked })} />}
+          label={<Typography sx={{ fontSize: 13, color: "#d1d5db" }}>Ignition Risk</Typography>}
           sx={{ display: "flex", mx: 0 }}
         />
+
+        {layersState.showIgnition && (
+          <Box sx={{ mt: 1, pl: 0.5 }}>
+            <Typography sx={{ fontSize: 11, color: "#6b7280", mb: 0.5 }}>Horizon</Typography>
+            <ToggleButtonGroup
+              exclusive
+              size="small"
+              value={ignitionHorizon}
+              onChange={(_, v) => { if (v) setIgnitionHorizon(v); }}
+              sx={{ width: "100%" }}
+            >
+              {(['now', '+24h', '+48h'] as const).map((h) => (
+                <ToggleButton
+                  key={h}
+                  value={h}
+                  sx={{
+                    flex: 1,
+                    fontSize: 11,
+                    fontWeight: 600,
+                    color: "#9ca3af",
+                    borderColor: "rgba(255,255,255,0.12)",
+                    "&.Mui-selected": { bgcolor: "rgba(245,158,11,0.18)", color: "#f59e0b", borderColor: "rgba(245,158,11,0.4)" }
+                  }}
+                >
+                  {h}
+                </ToggleButton>
+              ))}
+            </ToggleButtonGroup>
+            {ignitionHorizon === '+48h' && (
+              <Typography sx={{ fontSize: 10, color: "#9ca3af", mt: 0.5, fontStyle: "italic" }}>
+                Lower confidence — 48h forecast
+              </Typography>
+            )}
+          </Box>
+        )}
+
+        {/* Ignition legend — only shown when layer is active */}
+        {layersState.showIgnition && (
+          <Box sx={{ mt: 1, p: 1, bgcolor: "rgba(0,0,0,0.2)", borderRadius: 1.5, border: "1px solid rgba(255,255,255,0.06)" }}>
+            <Typography sx={{ fontSize: 10, fontWeight: 700, color: "#6b7280", letterSpacing: "0.08em", textTransform: "uppercase", mb: 0.75 }}>
+              Ignition Risk
+            </Typography>
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+              {[
+                { label: "Critical", color: "#dc2680" },
+                { label: "High",     color: "#f97316" },
+                { label: "Elevated", color: "#f59e0b" },
+              ].map(({ label, color }) => (
+                <Box key={label} sx={{ display: "flex", alignItems: "center", gap: 0.7 }}>
+                  <Box sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: color }} />
+                  <Typography sx={{ fontSize: 10, color: "#d1d5db" }}>{label}</Typography>
+                </Box>
+              ))}
+            </Box>
+          </Box>
+        )}
 
         <Divider sx={{ my: 1.5, borderColor: "rgba(255,255,255,0.08)" }} />
 

--- a/ui/src/state/store.ts
+++ b/ui/src/state/store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-import type { FireEvent } from "../types/api";
+import type { FireEvent, IgnitionGridResponse } from "../types/api";
 import type {
   ArchiveModeState,
   ArchiveSubMode,
@@ -11,6 +11,7 @@ import type {
   ForecastNotification,
   ForecastRequestContext,
   ForecastRunMeta,
+  IgnitionHorizon,
   LayersState,
   MapViewState,
   SafetyModeState,
@@ -35,6 +36,7 @@ const DEFAULT_LAYERS: LayersState = {
   showForecast: true,
   showRisk: false,
   showWarnings: false,
+  showIgnition: false,
   basemap: 'dark'
 };
 
@@ -104,6 +106,8 @@ interface AppStoreState {
   assistantViewContext: AssistantViewContext;
   archive: ArchiveModeState;
   safety: SafetyModeState;
+  ignitionHorizon: IgnitionHorizon;
+  ignitionData: IgnitionGridResponse | null;
   setFilters: (patch: Partial<FiltersState>) => void;
   applyPreset: (preset: { name: string; hoursStart: number; hoursEnd: number; likelihood: number }) => void;
   setLayersState: (patch: Partial<LayersState>) => void;
@@ -137,6 +141,8 @@ interface AppStoreState {
   setSafetyProximityRadius: (km: number) => void;
   requestAssistantBriefing: (prompt: string) => void;
   clearAssistantBriefingPrompt: () => void;
+  setIgnitionHorizon: (horizon: IgnitionHorizon) => void;
+  setIgnitionData: (data: IgnitionGridResponse | null) => void;
 }
 
 function updatePreset(filters: FiltersState): string {
@@ -155,6 +161,8 @@ export const useAppStore = create<AppStoreState>((set) => ({
   assistantViewContext: DEFAULT_ASSISTANT_VIEW_CONTEXT,
   archive: DEFAULT_ARCHIVE_STATE,
   safety: DEFAULT_SAFETY_STATE,
+  ignitionHorizon: 'now' as IgnitionHorizon,
+  ignitionData: null,
 
   setFilters: (patch) => {
     set((state) => {
@@ -384,4 +392,8 @@ export const useAppStore = create<AppStoreState>((set) => ({
   clearAssistantBriefingPrompt: () => set((state) => ({
     safety: { ...state.safety, pendingBriefingPrompt: null }
   })),
+
+  setIgnitionHorizon: (horizon) => set({ ignitionHorizon: horizon }),
+
+  setIgnitionData: (data) => set({ ignitionData: data }),
 }));

--- a/ui/src/tests/ignition-priority-feed.test.ts
+++ b/ui/src/tests/ignition-priority-feed.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  firstCriticalCellWithoutNearbyFire,
+  highOrCriticalCellsNear,
+} from "../utils/ignition";
+import type { IgnitionCell } from "../types/api";
+import type { FireEvent } from "../types/api";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function cell(lat: number, lon: number, level: IgnitionCell["level"]): IgnitionCell {
+  return { lat, lon, probability: level === "critical" ? 0.95 : level === "high" ? 0.75 : level === "elevated" ? 0.45 : 0.1, level };
+}
+
+function fire(lat: number, lon: number): FireEvent {
+  return { event_id: `${lat},${lon}`, lat, lon, event_score: 0.9 };
+}
+
+// ── firstCriticalCellWithoutNearbyFire ────────────────────────────────────────
+
+describe("firstCriticalCellWithoutNearbyFire", () => {
+  it("returns null when there are no critical cells", () => {
+    const cells = [cell(34, -118, "elevated"), cell(35, -117, "high")];
+    expect(firstCriticalCellWithoutNearbyFire(cells, [])).toBeNull();
+  });
+
+  it("returns null when all critical cells have a fire within 50 km", () => {
+    // 34.0, -118.0  →  fire at 34.1, -118.0 is ~11 km away
+    const cells = [cell(34.0, -118.0, "critical")];
+    const fires = [fire(34.1, -118.0)];
+    expect(firstCriticalCellWithoutNearbyFire(cells, fires)).toBeNull();
+  });
+
+  it("returns the critical cell when no fire is within 50 km", () => {
+    // Cell in Los Angeles; fire >50 km away in San Diego
+    const criticalCell = cell(34.05, -118.24, "critical");
+    const fires = [fire(32.72, -117.16)]; // San Diego, ~180 km away
+    const result = firstCriticalCellWithoutNearbyFire([criticalCell], fires);
+    expect(result).toBe(criticalCell);
+  });
+
+  it("skips non-critical cells even when no fire is nearby", () => {
+    const cells = [cell(34.0, -118.0, "high"), cell(35.0, -119.0, "elevated")];
+    expect(firstCriticalCellWithoutNearbyFire(cells, [])).toBeNull();
+  });
+
+  it("returns first critical cell with no nearby fire when multiple exist", () => {
+    const c1 = cell(34.0, -118.0, "critical");
+    const c2 = cell(40.0, -105.0, "critical"); // Denver area, no fires
+    const fires = [fire(34.1, -118.0)];        // covers c1 but not c2
+    const result = firstCriticalCellWithoutNearbyFire([c1, c2], fires);
+    expect(result).toBe(c2);
+  });
+
+  it("uses the supplied radiusKm override", () => {
+    const criticalCell = cell(34.0, -118.0, "critical");
+    // Fire ~11 km away
+    const fires = [fire(34.1, -118.0)];
+    // With 5 km radius the fire is outside → should return the cell
+    expect(firstCriticalCellWithoutNearbyFire([criticalCell], fires, 5)).toBe(criticalCell);
+    // With 50 km radius the fire is inside → should return null
+    expect(firstCriticalCellWithoutNearbyFire([criticalCell], fires, 50)).toBeNull();
+  });
+
+  it("returns null when fires array is empty but there are no critical cells", () => {
+    expect(firstCriticalCellWithoutNearbyFire([], [])).toBeNull();
+  });
+
+  it("returns a critical cell when fires array is empty", () => {
+    const c = cell(50.0, 10.0, "critical");
+    expect(firstCriticalCellWithoutNearbyFire([c], [])).toBe(c);
+  });
+});
+
+// ── highOrCriticalCellsNear ───────────────────────────────────────────────────
+
+describe("highOrCriticalCellsNear", () => {
+  it("returns 0 when cells array is empty", () => {
+    expect(highOrCriticalCellsNear([], 34.0, -118.0)).toBe(0);
+  });
+
+  it("counts only high and critical cells within the radius", () => {
+    const cells = [
+      cell(34.05, -118.2, "critical"),  // very close
+      cell(34.1,  -118.2, "high"),      // close
+      cell(34.2,  -118.0, "elevated"),  // close but not high/critical
+      cell(34.15, -118.1, "low"),       // close but low
+    ];
+    expect(highOrCriticalCellsNear(cells, 34.0, -118.24, 50)).toBe(2);
+  });
+
+  it("excludes cells outside the radius", () => {
+    const cells = [
+      cell(34.0, -118.0, "critical"),  // ~within 1 km of query point
+      cell(40.0, -105.0, "high"),      // Denver — very far from LA
+    ];
+    expect(highOrCriticalCellsNear(cells, 34.0, -118.0, 50)).toBe(1);
+  });
+
+  it("counts both high and critical cells", () => {
+    const cells = [
+      cell(34.01, -118.01, "critical"),
+      cell(34.02, -118.02, "high"),
+      cell(34.03, -118.03, "high"),
+    ];
+    expect(highOrCriticalCellsNear(cells, 34.0, -118.0, 50)).toBe(3);
+  });
+
+  it("respects a custom radius", () => {
+    // Cell is ~11 km away
+    const cells = [cell(34.1, -118.0, "critical")];
+    expect(highOrCriticalCellsNear(cells, 34.0, -118.0, 5)).toBe(0);
+    expect(highOrCriticalCellsNear(cells, 34.0, -118.0, 50)).toBe(1);
+  });
+});

--- a/ui/src/tests/store.test.ts
+++ b/ui/src/tests/store.test.ts
@@ -22,6 +22,7 @@ describe("app store filters", () => {
         showForecast: true,
         showRisk: false,
         showWarnings: false,
+        showIgnition: false,
         basemap: 'dark' as const
       }
     });

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -296,3 +296,19 @@ export interface WeatherResponse {
   forecast: WeatherForecastStep[] | null;
   warnings: WeatherWarningBrief[] | null;
 }
+
+export type IgnitionLevel = 'low' | 'elevated' | 'high' | 'critical';
+
+export interface IgnitionCell {
+  lat: number;
+  lon: number;
+  probability: number;
+  level: IgnitionLevel;
+}
+
+export interface IgnitionGridResponse {
+  cells: IgnitionCell[];
+  as_of: string;
+  horizon: string;
+  coverage_warnings?: string[];
+}

--- a/ui/src/types/state.ts
+++ b/ui/src/types/state.ts
@@ -24,12 +24,15 @@ export interface FiltersState {
   clusterPoints: boolean;
 }
 
+export type IgnitionHorizon = 'now' | '+24h' | '+48h';
+
 export interface LayersState {
   showFires: boolean;
   showFronts: boolean;
   showForecast: boolean;
   showRisk: boolean;
   showWarnings: boolean;
+  showIgnition: boolean;
   basemap: 'dark' | 'light' | 'satellite';
 }
 

--- a/ui/src/utils/geo.ts
+++ b/ui/src/utils/geo.ts
@@ -31,6 +31,17 @@ export function nearestFireKm(
   return min;
 }
 
+/**
+ * Returns a [minLon, minLat, maxLon, maxLat] bounding box centred on a point,
+ * extended by radiusKm in all directions using an equirectangular approximation.
+ */
+export function bboxFromPoint(lon: number, lat: number, radiusKm: number): [number, number, number, number] {
+  const latDelta = radiusKm / 111;
+  const lonScale = Math.max(Math.cos((Math.PI / 180) * lat), 0.1);
+  const lonDelta = radiusKm / (111 * lonScale);
+  return [lon - lonDelta, lat - latDelta, lon + lonDelta, lat + latDelta];
+}
+
 /** Filters events to those within radiusKm of a user location. */
 export function eventsWithinRadius(
   userLat: number,

--- a/ui/src/utils/ignition.ts
+++ b/ui/src/utils/ignition.ts
@@ -1,0 +1,47 @@
+import type { FireEvent } from "../types/api";
+import type { IgnitionCell } from "../types/api";
+import { haversineKm } from "./geo";
+
+/**
+ * Scan critical ignition cells in the viewport to find any that have no
+ * confirmed fire within 50 km. Returns the first such cell, or null.
+ *
+ * Used to drive the priority-feed warning: "conditions critical but no
+ * active fires detected nearby".
+ */
+export function firstCriticalCellWithoutNearbyFire(
+  cells: IgnitionCell[],
+  fires: FireEvent[],
+  radiusKm = 50
+): IgnitionCell | null {
+  for (const cell of cells) {
+    if (cell.level !== 'critical') continue;
+    const hasNearbyFire = fires.some(
+      (f) =>
+        f.lat != null &&
+        f.lon != null &&
+        haversineKm(cell.lat, cell.lon, f.lat, f.lon) <= radiusKm
+    );
+    if (!hasNearbyFire) return cell;
+  }
+  return null;
+}
+
+/**
+ * Count high + critical ignition cells within radiusKm of a point.
+ *
+ * Used to drive the fire-details context block: "N high-risk cells within
+ * 50 km".
+ */
+export function highOrCriticalCellsNear(
+  cells: IgnitionCell[],
+  lat: number,
+  lon: number,
+  radiusKm = 50
+): number {
+  return cells.filter(
+    (c) =>
+      (c.level === 'high' || c.level === 'critical') &&
+      haversineKm(lat, lon, c.lat, c.lon) <= radiusKm
+  ).length;
+}


### PR DESCRIPTION
## Summary

- Adds `IgnitionProbabilityLayer` to the map using Deck.GL `ScatterplotLayer` with an amber/orange/magenta colour palette distinct from the existing risk grid, so both layers can be active simultaneously without confusion
- Adds horizon selector (Now / +24h / +48h) in the layers popover with a lower-confidence caveat at +48h, coverage warning advisory banner, and graceful 503 error state
- Surfaces a priority feed warning in the telemetry overview when `critical` ignition cells exist in the viewport with no confirmed fire within 50 km
- Appends an ignition context block to the fire details panel when `high`/`critical` cells are within 50 km of the selected fire's centroid

## What changed

| File | Change |
|------|--------|
| `api/ignition.ts` | New — `getIgnitionGrid(bbox, horizon)` calling `GET /ignition` |
| `utils/ignition.ts` | New — `firstCriticalCellWithoutNearbyFire`, `highOrCriticalCellsNear` |
| `utils/geo.ts` | `bboxFromPoint` extracted (deduplicates identical IIFE in `FireDetailsPanel`) |
| `types/api.ts` | `IgnitionLevel`, `IgnitionCell`, `IgnitionGridResponse` |
| `types/state.ts` | `IgnitionHorizon`, `showIgnition` in `LayersState` |
| `state/store.ts` | `ignitionHorizon`, `ignitionData`, `setIgnitionHorizon`, `setIgnitionData` |
| `components/map/FireMap.tsx` | Ignition layer, React Query (6 h stale time), horizon selector, legend, banners |
| `components/fire-details/FireOverviewTab.tsx` | Critical-cell priority feed warning |
| `components/fire-details/FireFrontsTab.tsx` | Lazy ignition context query + context block below weather summary |
| `tests/ignition-priority-feed.test.ts` | New — 13 unit tests |

## Test plan

- [ ] All 109 existing tests pass (`cd ui && npm run test:run`)
- [ ] TypeScript clean (`npm run typecheck`)
- [ ] Toggle "Ignition Risk" in the layers panel — layer appears; `low` cells invisible
- [ ] Switch horizon to +48h — confidence caveat appears below the selector
- [ ] If API returns `coverage_warnings` — advisory banner renders at map bottom
- [ ] If ignition API returns 503 — "Ignition model unavailable" alert appears; map and other layers unaffected
- [ ] With ignition layer active and a critical cell visible with no nearby fire — warning appears in telemetry overview
- [ ] Open a fire details panel — ignition context block appears below weather summary if high/critical cells within 50 km

🤖 Generated with [Claude Code](https://claude.com/claude-code)