### PR TITLE
Fix ingest_scheduler health check to verify data freshness

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,7 +239,7 @@ services:
       migrate:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD-SHELL", "test -f /app/data/ingest/orchestrator_dashboard.json"]
+      test: ["CMD", "python", "/app/scripts/check_data_freshness.py"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/scripts/check_data_freshness.py
+++ b/scripts/check_data_freshness.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Check data freshness health endpoint and exit with appropriate code.
+
+Used by the ingest_scheduler health check to verify that source data
+(FIRMS, weather, terrain, etc.) is fresh according to the configured
+stale thresholds.
+
+Exit codes:
+  0 – overall_state == "healthy"
+  1 – overall_state != "healthy" or endpoint unreachable
+"""
+
+import sys
+import json
+import urllib.request
+import urllib.error
+
+ENDPOINT = "http://api:8000/internal/health/data-freshness"
+TIMEOUT = 10  # seconds
+
+
+def main() -> int:
+    try:
+        req = urllib.request.Request(ENDPOINT, method="GET")
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            if resp.status != 200:
+                print(f"Unexpected status: {resp.status}", file=sys.stderr)
+                return 1
+            data = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        print(f"HTTP error: {e.code} {e.reason}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Request failed: {e}", file=sys.stderr)
+        return 1
+
+    overall = data.get("overall_state")
+    if overall == "healthy":
+        print(f"Data freshness healthy: {overall}")
+        return 0
+    else:
+        print(f"Data freshness not healthy: {overall}", file=sys.stderr)
+        stale = data.get("stale_sources", [])
+        if stale:
+            print(f"Stale sources: {stale}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -107,6 +107,30 @@ class HealthChecker:
             self.results.append(("Database (via API)", False, str(e)))
             return False
 
+    def check_data_freshness(self) -> bool:
+        """Check if data freshness is healthy."""
+        try:
+            req = urllib.request.Request(f'{self.api_url}/health/data-freshness', method='GET')
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                if resp.status == 200:
+                    data = json.loads(resp.read().decode())
+                    overall = data.get('overall_state')
+                    if overall == 'healthy':
+                        self.results.append(('Data freshness', True, 'OK'))
+                        return True
+                    else:
+                        self.results.append(('Data freshness', False, f'State: {overall}'))
+                        return False
+                else:
+                    self.results.append(('Data freshness', False, f'HTTP {resp.status}'))
+                    return False
+        except urllib.error.HTTPError as e:
+            self.results.append(('Data freshness', False, f'HTTP {e.code}'))
+            return False
+        except Exception as e:
+            self.results.append(('Data freshness', False, str(e)))
+            return False
+
     def run_all_checks(self) -> bool:
         """Run all health checks and return overall status."""
         print("🔍 Checking Wildfire Nowcast stack health...\n")
@@ -114,6 +138,7 @@ class HealthChecker:
         self.check_api()
         self.check_api_version()
         self.check_database()
+        self.check_data_freshness()
         self.check_ui()
 
         return self.print_summary()


### PR DESCRIPTION
This PR replaces the file‑existence health check in the ingest_scheduler Docker service with a proper data‑freshness check.

- The health check now calls the internal `/internal/health/data‑freshness` endpoint and verifies that `overall_state` is `"healthy"`.
- The general stack health script (`scripts/health_check.py`) also includes a data‑freshness check for consistency.
- Closes #300.