### PR TITLE
fix(archive): correct off-by-one in FIRMS lookback validation (#312)

### DIFF
--- a/api/routes/archive.py
+++ b/api/routes/archive.py
@@ -263,7 +263,7 @@ async def trigger_archive_ingest(body: ArchiveIngestRequest) -> ArchiveIngestRes
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Cannot ingest future dates.",
         )
-    if days_ago >= MAX_FIRMS_LOOKBACK_DAYS:
+    if days_ago > MAX_FIRMS_LOOKBACK_DAYS:
         raise ArchiveRangeError(
             f"Date {body.date} is {days_ago} days ago. "
             f"FIRMS NRT API only supports up to {MAX_FIRMS_LOOKBACK_DAYS} days back. "
@@ -346,7 +346,7 @@ async def trigger_archive_ingest_range(body: ArchiveRangeIngestRequest) -> Archi
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=f"{label} {d} is in the future. Cannot ingest future dates.",
             )
-        if days_ago >= MAX_FIRMS_LOOKBACK_DAYS:
+        if days_ago > MAX_FIRMS_LOOKBACK_DAYS:
             raise ArchiveRangeError(
                 f"{label} {d} is {days_ago} days ago. "
                 f"FIRMS NRT API only supports up to {MAX_FIRMS_LOOKBACK_DAYS} days back."

--- a/api/tests/test_archive_ingest.py
+++ b/api/tests/test_archive_ingest.py
@@ -106,12 +106,27 @@ class TestTriggerArchiveIngest:
         assert resp.status_code == 422
         assert "future" in _error_text(resp)
 
-    def test_rejects_date_at_lookback_boundary(self, client):
-        too_old = (date.today() - timedelta(days=MAX_FIRMS_LOOKBACK_DAYS)).isoformat()
+    def test_rejects_date_beyond_lookback(self, client):
+        # 11 days ago is one beyond the 10-day FIRMS NRT limit → must be rejected
+        too_old = (date.today() - timedelta(days=MAX_FIRMS_LOOKBACK_DAYS + 1)).isoformat()
         resp = client.post("/fires/archive/ingest", json={"date": too_old, "timeframe": "morning"})
         assert resp.status_code == 400
         assert resp.json()["error"] == "ArchiveRangeError"
         assert str(MAX_FIRMS_LOOKBACK_DAYS) in _error_text(resp)
+
+    @patch("rq.Queue")
+    @patch("api.routes.archive.get_redis")
+    def test_accepts_date_exactly_at_lookback_boundary(self, mock_get_redis, mock_queue_cls, client):
+        # Exactly MAX_FIRMS_LOOKBACK_DAYS days ago is still within the FIRMS NRT window → accepted
+        boundary = (date.today() - timedelta(days=MAX_FIRMS_LOOKBACK_DAYS)).isoformat()
+        mock_job = MagicMock()
+        mock_job.id = "boundary-job-id"
+        mock_queue_cls.return_value.enqueue.return_value = mock_job
+        mock_get_redis.return_value = MagicMock()
+
+        resp = client.post("/fires/archive/ingest", json={"date": boundary, "timeframe": "morning"})
+        assert resp.status_code == 202
+        assert resp.json()["job_id"] == "boundary-job-id"
 
     def test_rejects_invalid_date_format(self, client):
         resp = client.post("/fires/archive/ingest", json={"date": "not-a-date", "timeframe": "morning"})

--- a/api/tests/test_archive_range.py
+++ b/api/tests/test_archive_range.py
@@ -92,7 +92,8 @@ class TestTriggerArchiveIngestRange:
         assert "future" in _error_text(resp)
 
     def test_rejects_start_beyond_lookback(self, client):
-        too_old = (date.today() - timedelta(days=MAX_FIRMS_LOOKBACK_DAYS)).isoformat()
+        # 11 days ago exceeds the 10-day FIRMS NRT limit → must be rejected
+        too_old = (date.today() - timedelta(days=MAX_FIRMS_LOOKBACK_DAYS + 1)).isoformat()
         yesterday = _recent_date(1)
         resp = client.post(
             "/fires/archive/ingest-range",
@@ -103,17 +104,30 @@ class TestTriggerArchiveIngestRange:
         assert str(MAX_FIRMS_LOOKBACK_DAYS) in _error_text(resp)
 
     def test_rejects_end_beyond_lookback(self, client):
-        # end_date is within lookback but start is even older — still rejected by end check
-        # Actually both are validated. Use a case where start is valid but end is too old.
-        # With MAX_FIRMS_LOOKBACK_DAYS=10: start=9 days ago (ok), end=10 days ago < start → rejected first.
-        # Let's test: start=10 days ago directly.
-        too_old = (date.today() - timedelta(days=MAX_FIRMS_LOOKBACK_DAYS)).isoformat()
+        # 11 days ago exceeds the 10-day FIRMS NRT limit → must be rejected
+        too_old = (date.today() - timedelta(days=MAX_FIRMS_LOOKBACK_DAYS + 1)).isoformat()
         resp = client.post(
             "/fires/archive/ingest-range",
             json={"start_date": too_old, "end_date": too_old},
         )
         assert resp.status_code == 400
         assert resp.json()["error"] == "ArchiveRangeError"
+
+    @patch("rq.Queue")
+    @patch("api.routes.archive.get_redis")
+    def test_accepts_start_date_exactly_at_lookback_boundary(self, mock_get_redis, mock_queue_cls, client):
+        # Exactly MAX_FIRMS_LOOKBACK_DAYS days ago is still within the FIRMS NRT window → accepted.
+        # The range must also fit within MAX_ARCHIVE_RANGE_DAYS, so use a 1-day range.
+        boundary = (date.today() - timedelta(days=MAX_FIRMS_LOOKBACK_DAYS)).isoformat()
+        mock_get_redis.return_value = MagicMock()
+        mock_queue_cls.return_value.enqueue.return_value = MagicMock()
+
+        resp = client.post(
+            "/fires/archive/ingest-range",
+            json={"start_date": boundary, "end_date": boundary},
+        )
+        assert resp.status_code == 202
+        assert resp.json()["dates"] == [boundary]
 
     def test_rejects_range_too_large(self, client):
         # MAX_ARCHIVE_RANGE_DAYS+1 days — but must stay within FIRMS lookback.

--- a/api/tests/test_domain_exceptions.py
+++ b/api/tests/test_domain_exceptions.py
@@ -147,7 +147,9 @@ def test_archive_ingest_lookback_exceeded_returns_archive_range_error():
     """Date older than FIRMS lookback → ArchiveRangeError with HTTP 400."""
     from api.routes.archive import MAX_FIRMS_LOOKBACK_DAYS
 
-    too_old = (date.today() - timedelta(days=MAX_FIRMS_LOOKBACK_DAYS)).isoformat()
+    # MAX_FIRMS_LOOKBACK_DAYS itself is still within the window (> check, not >=).
+    # Use +1 so this date is genuinely beyond the limit.
+    too_old = (date.today() - timedelta(days=MAX_FIRMS_LOOKBACK_DAYS + 1)).isoformat()
 
     response = client.post(
         "/fires/archive/ingest",


### PR DESCRIPTION
## Summary

- Fixes #312
- Changes `>=` to `>` in both `_validate_firms_lookback` guards in `api/routes/archive.py` (lines 266 and 349) so that a date exactly `MAX_FIRMS_LOOKBACK_DAYS` (10) days ago is correctly accepted
- Updates existing boundary tests in `test_archive_ingest.py` and `test_archive_range.py` to use `+1` offset (genuinely outside the window)
- Adds acceptance tests asserting `days_ago == 10` returns HTTP 202
- Fixes a stale test in `test_domain_exceptions.py` that was also using the wrong boundary offset

## Test plan

- [ ] `cd api && uv run pytest -m "not integration" -q` — 554 passed, 1 skipped
- [ ] Boundary day (10 days ago) now returns 202 instead of 400
- [ ] Day 11+ still returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)