### PR TITLE
fix: merge three unresolved Alembic heads blocking deployments

### DIFF
--- a/api/migrations/versions/20260404_merge_three_heads.py
+++ b/api/migrations/versions/20260404_merge_three_heads.py
@@ -1,0 +1,33 @@
+"""Merge three unresolved migration heads into a single lineage.
+
+Heads being merged:
+  - 20260402_add_ignition_model_family (ignition model family CHECK)
+  - 20260403_review_queue_unique_pending_event (review queue partial unique index)
+  - 20260403_add_aoi_watch_notifications_paused_until (AOI watch pause column)
+
+Revision ID: 20260404_merge_three_heads
+Revises: 20260402_add_ignition_model_family, 20260403_review_queue_unique_pending_event, 20260403_add_aoi_watch_notifications_paused_until
+Create Date: 2026-04-04 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+revision: str = "20260404_merge_three_heads"
+down_revision: Union[str, Sequence[str], None] = (
+    "20260402_add_ignition_model_family",
+    "20260403_review_queue_unique_pending_event",
+    "20260403_add_aoi_watch_notifications_paused_until",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Merge migration — no schema changes."""
+    pass
+
+
+def downgrade() -> None:
+    """Merge migration — no schema changes."""
+    pass


### PR DESCRIPTION
## Summary

Closes #335

- Adds a merge migration (`20260404_merge_three_heads`) that converges three unresolved Alembic heads into a single lineage:
  - `20260402_add_ignition_model_family`
  - `20260403_review_queue_unique_pending_event`
  - `20260403_add_aoi_watch_notifications_paused_until` (orphaned — pointed at ancient `d46889070598`)
- Prior merge migrations (#315, #330) resolved earlier branches but missed the new heads introduced by recent commits

## Verification

```
$ alembic heads
20260404_merge_three_heads (head)     # single head ✓

$ pytest -m "not integration"
552 passed, 1 skipped                 # all tests pass ✓
```

## Test plan

- [ ] `alembic heads` returns exactly one head
- [ ] `alembic upgrade head` succeeds against a fresh database
- [ ] `alembic downgrade -1` and `alembic upgrade head` round-trips cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)