### PR TITLE
fix(api): tighten CORS to explicit method and header allowlists

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -22,12 +22,15 @@ cors_allow_origins = [
     if origin.strip()
 ]
 
+# Explicit allowlists for CORS methods and headers — wildcards would permit
+# non-standard methods (TRACE, CONNECT) and arbitrary headers, broadening the
+# attack surface.  Only list what the app actually needs.  (Fixes #297)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=cors_allow_origins,
     allow_credentials=False,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "HEAD", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization", "X-Request-ID"],
 )
 
 

--- a/api/tests/test_cors_policy.py
+++ b/api/tests/test_cors_policy.py
@@ -1,0 +1,97 @@
+"""Tests for CORS policy (issue #297).
+
+Verifies that the explicit method/header allowlists are enforced and that
+non-standard methods are rejected at the CORS layer.
+"""
+
+import pytest
+from starlette.testclient import TestClient
+
+from api.main import app
+
+ORIGIN = "http://localhost:8501"
+
+
+@pytest.fixture()
+def client():
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# -- Allowed methods ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", ["GET", "POST", "HEAD", "OPTIONS"])
+def test_preflight_allowed_methods(client, method):
+    """CORS preflight returns the requested method when it is in the allowlist."""
+    resp = client.options(
+        "/fires",
+        headers={
+            "Origin": ORIGIN,
+            "Access-Control-Request-Method": method,
+        },
+    )
+    assert resp.status_code == 200
+    allowed = resp.headers.get("access-control-allow-methods", "")
+    assert method in allowed
+
+
+# -- Disallowed methods -------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", ["DELETE", "PUT", "PATCH", "TRACE"])
+def test_preflight_disallowed_methods(client, method):
+    """CORS preflight must NOT echo back methods outside the allowlist."""
+    resp = client.options(
+        "/fires",
+        headers={
+            "Origin": ORIGIN,
+            "Access-Control-Request-Method": method,
+        },
+    )
+    allowed = resp.headers.get("access-control-allow-methods", "")
+    assert method not in allowed
+
+
+# -- Allowed headers ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("header", ["Content-Type", "Authorization", "X-Request-ID"])
+def test_preflight_allowed_headers(client, header):
+    """CORS preflight returns the requested header when it is in the allowlist."""
+    resp = client.options(
+        "/fires",
+        headers={
+            "Origin": ORIGIN,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": header,
+        },
+    )
+    assert resp.status_code == 200
+    allowed = resp.headers.get("access-control-allow-headers", "")
+    assert header.lower() in allowed.lower()
+
+
+# -- Disallowed headers -------------------------------------------------------
+
+
+def test_preflight_disallowed_header(client):
+    """CORS preflight must NOT echo back headers outside the allowlist."""
+    resp = client.options(
+        "/fires",
+        headers={
+            "Origin": ORIGIN,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "X-Custom-Evil",
+        },
+    )
+    allowed = resp.headers.get("access-control-allow-headers", "")
+    assert "x-custom-evil" not in allowed.lower()
+
+
+# -- Simple request includes CORS origin header --------------------------------
+
+
+def test_simple_get_includes_cors_origin(client):
+    """A simple GET with an Origin header receives Access-Control-Allow-Origin."""
+    resp = client.get("/fires", headers={"Origin": ORIGIN})
+    assert "access-control-allow-origin" in resp.headers


### PR DESCRIPTION
## Summary

- Replace wildcard `allow_methods=["*"]` and `allow_headers=["*"]` in the FastAPI CORS middleware with explicit allowlists of only the HTTP methods and headers the frontend actually uses.
- This prevents cross-site tracing (XST) via TRACE/PATCH/DELETE and reduces the overall CORS attack surface.
- Add comprehensive test coverage for the new CORS policy (allowed and disallowed methods/headers).

Closes #297

## Test plan

- [ ] `cd api && uv run pytest tests/test_cors_policy.py` passes — verifies allowed methods return proper CORS headers and disallowed methods (TRACE, PATCH, DELETE) are rejected
- [ ] `make dev-api` and confirm browser preflight requests from the UI still succeed for GET, POST, PUT, OPTIONS
- [ ] Manual check: `curl -X OPTIONS -H "Origin: http://localhost:8501" -H "Access-Control-Request-Method: TRACE" http://localhost:8000/` returns no `Access-Control-Allow-Methods` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)