### PR TITLE
feat(api): add dead-letter queue depth monitoring to health endpoint

### DIFF
--- a/api/dead_letter.py
+++ b/api/dead_letter.py
@@ -1,0 +1,97 @@
+"""Dead-letter queue depth and age monitoring.
+
+Provides metrics for RQ dead-letter queues so external monitors and the
+health endpoint can alert on accumulating failed jobs.
+
+Also provides a generic ``move_to_dead_letter_ingest`` failure callback
+for ingest/archive RQ jobs that lack their own dead-letter handling.
+"""
+
+import logging
+import time
+from typing import Any
+
+from rq import Queue
+from rq.job import Job
+
+from api.cache import get_redis
+
+logger = logging.getLogger(__name__)
+
+# Canonical dead-letter queue names.  Forecast has one today; ingest gets one
+# via this module so that failed archive/ingest jobs are observable too.
+DEAD_LETTER_QUEUES = ("failed_forecast", "failed_ingest")
+
+
+def get_dead_letter_queue(name: str) -> Queue:
+    """Return an RQ Queue instance for the named dead-letter queue."""
+    return Queue(name, connection=get_redis())
+
+
+def dead_letter_metrics(queue_name: str) -> dict[str, Any]:
+    """Return depth and oldest-job age for a single dead-letter queue.
+
+    Returns a dict with:
+      - ``depth``: number of jobs currently in the queue
+      - ``oldest_job_age_seconds``: age in seconds of the oldest job, or None
+        if the queue is empty
+    """
+    q = get_dead_letter_queue(queue_name)
+    job_ids = q.job_ids  # lightweight: reads list from Redis, no job fetch
+
+    depth = len(job_ids)
+    oldest_age: float | None = None
+
+    if depth > 0:
+        # Only fetch the oldest job (first in the list) to compute age.
+        try:
+            oldest_job = Job.fetch(job_ids[0], connection=q.connection)
+            enqueued_at = oldest_job.enqueued_at
+            if enqueued_at is not None:
+                oldest_age = time.time() - enqueued_at.timestamp()
+        except Exception:
+            # Job may have expired from Redis between listing and fetch.
+            logger.debug("Could not fetch oldest job %s from %s", job_ids[0], queue_name)
+
+    return {
+        "depth": depth,
+        "oldest_job_age_seconds": round(oldest_age, 1) if oldest_age is not None else None,
+    }
+
+
+def move_to_dead_letter_ingest(job, connection, type, value, traceback):
+    """RQ on_failure callback: park failed ingest/archive jobs in the ``failed_ingest`` DLQ.
+
+    Mirrors :func:`api.forecast.worker.move_to_dead_letter` but for
+    ingest-family jobs.  Logging only — no DB status update because archive
+    jobs track status via Redis keys, not a DB table.
+    """
+    error_name = type.__name__ if type else "Unknown"
+    error_msg = str(value) if value else ""
+    logger.error(
+        "Ingest job %s failed: %s: %s — parking in failed_ingest dead-letter queue",
+        job.id,
+        error_name,
+        error_msg,
+    )
+    try:
+        dlq = get_dead_letter_queue("failed_ingest")
+        dlq.enqueue_job(job)
+    except Exception as e:
+        logger.error("Failed to move ingest job %s to dead-letter queue: %s", job.id, e)
+
+
+def all_dead_letter_metrics() -> dict[str, dict[str, Any]]:
+    """Return metrics for every canonical dead-letter queue.
+
+    Keyed by queue name, each value is the dict returned by
+    :func:`dead_letter_metrics`.
+    """
+    result: dict[str, dict[str, Any]] = {}
+    for name in DEAD_LETTER_QUEUES:
+        try:
+            result[name] = dead_letter_metrics(name)
+        except Exception:
+            logger.exception("Error reading dead-letter metrics for %s", name)
+            result[name] = {"depth": None, "oldest_job_age_seconds": None, "error": "unavailable"}
+    return result

--- a/api/routes/archive.py
+++ b/api/routes/archive.py
@@ -18,6 +18,7 @@ from sqlalchemy import text
 
 from api.cache import get_redis
 from api.db import get_engine
+from api.dead_letter import move_to_dead_letter_ingest
 from api.errors import ArchiveRangeError
 
 # Add repo root to path so the RQ worker can import ingest module
@@ -274,7 +275,7 @@ async def trigger_archive_ingest(body: ArchiveIngestRequest) -> ArchiveIngestRes
         from rq import Queue
 
         q = Queue(connection=get_redis(), default_timeout=600)
-        job = q.enqueue(_run_archive_ingest, body.date, body.timeframe)
+        job = q.enqueue(_run_archive_ingest, body.date, body.timeframe, on_failure=move_to_dead_letter_ingest)
         job_id = str(job.id)
     except Exception as exc:
         logger.error("Failed to enqueue archive ingest job: %s", exc)
@@ -388,7 +389,7 @@ async def trigger_archive_ingest_range(body: ArchiveRangeIngestRequest) -> Archi
         )
 
         q = Queue(connection=redis_conn, default_timeout=num_days * 600)  # 10 min per day
-        q.enqueue(_run_archive_ingest_range, range_job_id, dates)
+        q.enqueue(_run_archive_ingest_range, range_job_id, dates, on_failure=move_to_dead_letter_ingest)
 
     except Exception as exc:
         logger.error("Failed to enqueue archive range ingest: %s", exc)

--- a/api/routes/internal.py
+++ b/api/routes/internal.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from api.config import settings
 from api.data_status import build_data_status_snapshot
 from api.db_health import build_db_size_snapshot, read_orchestrator_dashboard
+from api.dead_letter import all_dead_letter_metrics
 from api.model_registry import (
     list_active_models,
     promote_model,
@@ -50,6 +51,21 @@ class RollbackModelRequest(BaseModel):
 async def healthcheck() -> dict:
     """Simple health endpoint used for local dev and readiness checks."""
     return {"status": "ok"}
+
+
+@internal_router.get("/internal/health/dead-letter-queues")
+async def dead_letter_queue_health() -> dict:
+    """Return depth and oldest-job age for each dead-letter queue.
+
+    External monitors can poll this endpoint to alert when failed jobs
+    accumulate (depth > 0) or age beyond an acceptable threshold.
+    """
+    as_of = datetime.now(timezone.utc).isoformat()
+    try:
+        queues = all_dead_letter_metrics()
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        return {"as_of": as_of, "queues": {}, "error": str(exc)}
+    return {"as_of": as_of, "queues": queues}
 
 
 @internal_router.get("/health/data-freshness")
@@ -436,6 +452,12 @@ async def ingest_health_dashboard() -> dict:
         db_section = {"database": {"size_bytes": None, "size_pretty": None}, "tables": {}, "retention_policy": {}, "error": str(exc)}
         cleanup_section = {"last_run_at": None, "last_outcome": None, "next_run_at": None, "interval_minutes": None, "source": "error"}
 
+    # --- dead-letter queue depth ---
+    try:
+        dlq_section = all_dead_letter_metrics()
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        dlq_section = {"error": str(exc)}
+
     return {
         "as_of": as_of,
         "orchestrator": {
@@ -445,6 +467,7 @@ async def ingest_health_dashboard() -> dict:
         "data_freshness": freshness_section,
         "db_size": db_section,
         "cleanup": cleanup_section,
+        "dead_letter_queues": dlq_section,
     }
 
 

--- a/api/tests/test_dead_letter.py
+++ b/api/tests/test_dead_letter.py
@@ -1,0 +1,189 @@
+"""Tests for dead-letter queue metrics and the health endpoint."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from api.dead_letter import (
+    DEAD_LETTER_QUEUES,
+    all_dead_letter_metrics,
+    dead_letter_metrics,
+    move_to_dead_letter_ingest,
+)
+from api.main import app
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: dead_letter_metrics
+# ---------------------------------------------------------------------------
+
+
+def test_dead_letter_metrics_empty_queue():
+    mock_queue = MagicMock()
+    mock_queue.job_ids = []
+    mock_queue.connection = MagicMock()
+
+    with patch("api.dead_letter.get_dead_letter_queue", return_value=mock_queue):
+        result = dead_letter_metrics("failed_forecast")
+
+    assert result["depth"] == 0
+    assert result["oldest_job_age_seconds"] is None
+
+
+def test_dead_letter_metrics_with_jobs():
+    enqueued_at = datetime(2026, 4, 4, 10, 0, 0, tzinfo=timezone.utc)
+    mock_job = MagicMock()
+    mock_job.enqueued_at = enqueued_at
+
+    mock_queue = MagicMock()
+    mock_queue.job_ids = ["job-1", "job-2", "job-3"]
+    mock_queue.connection = MagicMock()
+
+    with (
+        patch("api.dead_letter.get_dead_letter_queue", return_value=mock_queue),
+        patch("api.dead_letter.Job.fetch", return_value=mock_job),
+    ):
+        result = dead_letter_metrics("failed_forecast")
+
+    assert result["depth"] == 3
+    assert result["oldest_job_age_seconds"] is not None
+    assert result["oldest_job_age_seconds"] > 0
+
+
+def test_dead_letter_metrics_handles_fetch_error():
+    """If the oldest job vanished from Redis, depth is still reported."""
+    mock_queue = MagicMock()
+    mock_queue.job_ids = ["gone-job"]
+    mock_queue.connection = MagicMock()
+
+    with (
+        patch("api.dead_letter.get_dead_letter_queue", return_value=mock_queue),
+        patch("api.dead_letter.Job.fetch", side_effect=Exception("no such job")),
+    ):
+        result = dead_letter_metrics("failed_forecast")
+
+    assert result["depth"] == 1
+    assert result["oldest_job_age_seconds"] is None
+
+
+def test_all_dead_letter_metrics_covers_all_queues():
+    mock_queue = MagicMock()
+    mock_queue.job_ids = []
+    mock_queue.connection = MagicMock()
+
+    with patch("api.dead_letter.get_dead_letter_queue", return_value=mock_queue):
+        result = all_dead_letter_metrics()
+
+    for name in DEAD_LETTER_QUEUES:
+        assert name in result
+        assert result[name]["depth"] == 0
+
+
+def test_all_dead_letter_metrics_handles_per_queue_error():
+    """One queue erroring does not block the others."""
+
+    def _fail_on_forecast(queue_name):
+        if queue_name == "failed_forecast":
+            raise RuntimeError("Redis down")
+        q = MagicMock()
+        q.job_ids = []
+        q.connection = MagicMock()
+        return q
+
+    with patch("api.dead_letter.get_dead_letter_queue", side_effect=_fail_on_forecast):
+        result = all_dead_letter_metrics()
+
+    assert "error" in result["failed_forecast"]
+    assert result["failed_ingest"]["depth"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit test: move_to_dead_letter_ingest callback
+# ---------------------------------------------------------------------------
+
+
+def test_move_to_dead_letter_ingest_parks_job():
+    job = SimpleNamespace(id="rq-ingest-job-1")
+    mock_dlq = MagicMock()
+
+    with patch("api.dead_letter.get_dead_letter_queue", return_value=mock_dlq):
+        move_to_dead_letter_ingest(job, MagicMock(), RuntimeError, RuntimeError("boom"), None)
+
+    mock_dlq.enqueue_job.assert_called_once_with(job)
+
+
+def test_move_to_dead_letter_ingest_handles_enqueue_failure():
+    """If the DLQ itself is unavailable, the callback must not raise."""
+    job = SimpleNamespace(id="rq-ingest-job-2")
+    mock_dlq = MagicMock()
+    mock_dlq.enqueue_job.side_effect = Exception("Redis gone")
+
+    with patch("api.dead_letter.get_dead_letter_queue", return_value=mock_dlq):
+        # Should not raise
+        move_to_dead_letter_ingest(job, MagicMock(), RuntimeError, RuntimeError("boom"), None)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: health endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_dead_letter_health_endpoint_returns_queue_metrics(monkeypatch):
+    metrics = {
+        "failed_forecast": {"depth": 2, "oldest_job_age_seconds": 3600.0},
+        "failed_ingest": {"depth": 0, "oldest_job_age_seconds": None},
+    }
+    monkeypatch.setattr("api.routes.internal.all_dead_letter_metrics", lambda: metrics)
+
+    response = client.get("/internal/health/dead-letter-queues")
+    assert response.status_code == 200
+    body = response.json()
+    assert "as_of" in body
+    assert body["queues"] == metrics
+
+
+def test_dead_letter_health_endpoint_empty_queues(monkeypatch):
+    metrics = {
+        "failed_forecast": {"depth": 0, "oldest_job_age_seconds": None},
+        "failed_ingest": {"depth": 0, "oldest_job_age_seconds": None},
+    }
+    monkeypatch.setattr("api.routes.internal.all_dead_letter_metrics", lambda: metrics)
+
+    response = client.get("/internal/health/dead-letter-queues")
+    assert response.status_code == 200
+    body = response.json()
+    assert all(q["depth"] == 0 for q in body["queues"].values())
+
+
+def test_consolidated_dashboard_includes_dead_letter_section(monkeypatch):
+    """The /internal/health/dashboard response must include dead_letter_queues."""
+    dlq_metrics = {
+        "failed_forecast": {"depth": 1, "oldest_job_age_seconds": 120.0},
+        "failed_ingest": {"depth": 0, "oldest_job_age_seconds": None},
+    }
+    monkeypatch.setattr("api.routes.internal.all_dead_letter_metrics", lambda: dlq_metrics)
+    monkeypatch.setattr("api.routes.internal.read_orchestrator_dashboard", lambda: None)
+    monkeypatch.setattr(
+        "api.routes.internal.build_data_status_snapshot",
+        lambda include_internal=False: {"overall_state": "healthy", "forecast_inputs_ready": True, "sources": {}},
+    )
+    monkeypatch.setattr(
+        "api.routes.internal.build_db_size_snapshot",
+        lambda **_: {
+            "as_of": "2026-04-04T00:00:00+00:00",
+            "database": {"size_bytes": 100, "size_pretty": "100 B"},
+            "tables": {},
+            "retention_policy": {},
+            "cleanup": {"last_run_at": None, "last_outcome": None, "next_run_at": None, "interval_minutes": None, "source": "error"},
+        },
+    )
+
+    response = client.get("/internal/health/dashboard")
+    assert response.status_code == 200
+    body = response.json()
+    assert "dead_letter_queues" in body
+    assert body["dead_letter_queues"] == dlq_metrics


### PR DESCRIPTION
## Summary

- Add `api/dead_letter.py` with per-queue depth metrics (`depth`, `oldest_job_age_seconds`) and an `move_to_dead_letter_ingest` RQ failure callback so ingest jobs now land in a dedicated DLQ
- Expose `GET /internal/health/dead-letter-queues` endpoint returning depth and oldest-job age for each dead-letter queue (forecast and ingest), enabling external monitors/alerting
- Include `dead_letter_queues` section in the consolidated `/internal/health/dashboard` response for single-pane observability
- Wire the ingest DLQ failure callback into archive single-day and range RQ jobs in `routes/archive.py`

What is now observable: queue depth per DLQ, oldest failed job age per DLQ, and per-queue isolation between forecast and ingest failure domains.

## Test plan

- [x] 10 unit tests in `api/tests/test_dead_letter.py` covering:
  - Metrics collection (empty queue, populated queue, oldest job age)
  - Failure callback moves jobs to the ingest DLQ
  - `/internal/health/dead-letter-queues` endpoint returns correct shape
  - Dashboard includes `dead_letter_queues` key
- [ ] Verify `make test` passes (API suite, `pytest -m "not integration"`)
- [ ] Manual: enqueue a failing job, confirm it appears in DLQ endpoint response

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)