### PR TITLE
Add database backup and recovery procedure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help doctor health-check install test lint lint-fix clean clean-venv migrate revision widget-build ralph-init ralph-plan ralph-run ralph-status denoiser-label denoiser-snapshot denoiser-train denoiser-eval denoiser-eventize denoiser-label-v2 denoiser-snapshot-v2 denoiser-train-v2 denoiser-eval-v2 train-denoiser train-spread ignition-snapshot ignition-train train-ignition model-register model-promote model-rollback model-update-contract hindcast-build spread-champion-challenger weather-bias seed-ne-places ingest-orchestrator ops-start
+.PHONY: help doctor health-check install test lint lint-fix clean clean-venv migrate revision widget-build ralph-init ralph-plan ralph-run ralph-status denoiser-label denoiser-snapshot denoiser-train denoiser-eval denoiser-eventize denoiser-label-v2 denoiser-snapshot-v2 denoiser-train-v2 denoiser-eval-v2 train-denoiser train-spread ignition-snapshot ignition-train train-ignition model-register model-promote model-rollback model-update-contract hindcast-build spread-champion-challenger weather-bias seed-ne-places ingest-orchestrator ops-start backup restore backup-list
 
 PYTHON ?= python3
 UV ?= uv
@@ -144,6 +144,19 @@ revision: ## Create a new migration revision (usage: make revision msg="descript
 	@echo "Creating new migration revision..."
 	$(if $(msg),,$(error Please provide a message with msg='your message'))
 	cd api && $(UV) run alembic revision -m "$(msg)"
+
+backup: ## Create a compressed database backup (stored in data/backups/)
+	@echo "Creating database backup..."
+	@scripts/backup_db.sh
+
+restore: ## Restore database from a backup file (usage: make restore BACKUP=path/to/backup.sql.gz)
+	@echo "Restoring database from $(BACKUP)..."
+	@if [ -z "$(BACKUP)" ]; then echo "Error: BACKUP variable not set"; exit 1; fi
+	@scripts/restore_db.sh "$(BACKUP)"
+
+backup-list: ## List available database backups
+	@echo "Available backups in data/backups/:"
+	@ls -1 data/backups/*.sql.gz 2>/dev/null | head -20 || echo "No backups found."
 
 # ── Ralph ──────────────────────────────────────────────────────────────────────
 

--- a/docs/backup_recovery.md
+++ b/docs/backup_recovery.md
@@ -1,0 +1,162 @@
+# Database Backup & Recovery
+
+This document outlines the backup and recovery procedures for the Wildfire Nowcast PostgreSQL database. It addresses the audit requirement (issue #301) for a documented recovery procedure.
+
+## Overview
+
+- **Backup format:** Plain SQL, compressed with gzip.
+- **Backup location:** `data/backups/` (relative to repository root).
+- **Retention:** Automatic pruning of backups older than 7 days (configurable).
+- **Tools:** `make backup`, `make restore`, manual scripts.
+
+## Quick Start
+
+### Create a backup
+
+```bash
+make backup
+```
+
+This runs `scripts/backup_db.sh`, which:
+1. Creates a timestamped backup file: `data/backups/wildfire_20260404_120000.sql.gz`
+2. Excludes high‑volatility tables (alembic_version, ingest_watermarks, RQ jobs) to keep backups small.
+3. Prunes backups older than 7 days.
+
+### List available backups
+
+```bash
+make backup-list
+```
+
+### Restore from a backup
+
+```bash
+make restore BACKUP=data/backups/wildfire_20260404_120000.sql.gz
+```
+
+The restore script will:
+1. Ask for confirmation (`yes`).
+2. Terminate existing database connections (if possible).
+3. Restore the SQL dump in a single transaction.
+
+## Manual Scripts
+
+You can also run the scripts directly:
+
+```bash
+scripts/backup_db.sh
+scripts/restore_db.sh path/to/backup.sql.gz
+```
+
+## Automated Backups (Production)
+
+For production deployments, schedule regular backups using cron (or your platform’s scheduler).
+
+### Cron Example
+
+Add to your crontab (runs daily at 2 AM):
+
+```cron
+0 2 * * * cd /path/to/wildfire-nowcast && make backup
+```
+
+### Environment Variables
+
+The scripts respect the following environment variables (set in `.env` or exported):
+
+- `POSTGRES_USER` (default: `wildfire`)
+- `POSTGRES_DB` (default: `wildfire`)
+- `BACKUP_DIR` (default: `data/backups`)
+
+## What Gets Backed Up
+
+The backup includes:
+- All tables (except excluded ones).
+- Schema (tables, indexes, constraints, sequences).
+- Data (excluding ephemeral tables).
+
+**Excluded tables (data only):**
+- `public.alembic_version` (Alembic migration tracking)
+- `public.ingest_watermarks` (ingestion progress; safe to reconstruct)
+- `public.rq_jobs`, `public.rq_job_dependents` (Redis‑backed job queue; transient)
+
+These exclusions keep backup size manageable and avoid restoring transient state.
+
+## Recovery Procedure
+
+### Scenario 1: Accidental data loss
+
+1. **Stop the ingest scheduler and API** to prevent new writes:
+   ```bash
+   docker compose stop ingest_scheduler api worker
+   ```
+2. **Restore the most recent backup**:
+   ```bash
+   make restore BACKUP=data/backups/wildfire_$(date -u +"%Y%m%d")_*.sql.gz
+   ```
+3. **Restart services**:
+   ```bash
+   docker compose start api worker ingest_scheduler
+   ```
+
+### Scenario 2: Database corruption or server failure
+
+If the PostgreSQL container is unusable:
+
+1. **Replace the database volume** (if using Docker volumes):
+   ```bash
+   docker compose down -v  # WARNING: deletes all data
+   docker compose up -d db
+   ```
+2. **Restore from backup** after the new DB is running:
+   ```bash
+   make restore BACKUP=path/to/latest-backup.sql.gz
+   ```
+3. **Run migrations** (if needed):
+   ```bash
+   make migrate
+   ```
+4. **Restart the stack**.
+
+### Scenario 3: Point‑in‑time recovery
+
+PostgreSQL’s WAL‑based point‑in‑time recovery is not configured by default. For production deployments, consider enabling continuous archiving and WAL shipping (outside the scope of this document).
+
+## Production Considerations
+
+- **Off‑site storage:** The `data/backups/` directory is local to the server. For disaster recovery, copy backups to cloud storage (S3, GCS, etc.) or a remote server.
+- **Encryption:** If backups contain sensitive data, encrypt them before off‑site transfer (e.g., with `gpg`).
+- **Monitoring:** Monitor backup success/failure (e.g., log exit codes, send alerts).
+- **Testing:** Periodically test restoration on a staging environment.
+
+## Integration with CI/CD
+
+Backup scripts can be integrated into deployment pipelines to create a snapshot before applying migrations. Example GitHub Actions step:
+
+```yaml
+- name: Backup before migration
+  run: make backup
+```
+
+## Troubleshooting
+
+### “pg_dump: error: connection to database failed”
+
+Ensure the `db` service is running:
+```bash
+docker compose ps db
+```
+
+### “Permission denied” when writing backups
+
+Ensure the `data/backups/` directory is writable by the user running the script.
+
+### Restore fails due to active connections
+
+The restore script attempts to terminate existing connections, but if other services (API, worker) are still running, they may hold locks. Stop those services before restoring.
+
+## Related Documentation
+
+- [Database Schema](../api/migrations/)
+- [Docker Compose Configuration](../docker-compose.yml)
+- [Issue #301: No database backup or documented recovery procedure](https://github.com/Ent7opy/wildfire-nowcast/issues/301)

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Backup PostgreSQL database for Wildfire Nowcast.
+# Requires Docker Compose and the 'db' service running.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+cd "${REPO_ROOT}"
+
+# Load environment variables from .env if present
+if [ -f .env ]; then
+    set -a
+    source .env
+    set +a
+fi
+
+POSTGRES_USER="${POSTGRES_USER:-wildfire}"
+POSTGRES_DB="${POSTGRES_DB:-wildfire}"
+BACKUP_DIR="${BACKUP_DIR:-data/backups}"
+TIMESTAMP=$(date -u +"%Y%m%d_%H%M%S")
+BACKUP_FILE="${BACKUP_DIR}/${POSTGRES_DB}_${TIMESTAMP}.sql.gz"
+
+# Ensure backup directory exists
+mkdir -p "${BACKUP_DIR}"
+
+echo "Backing up database '${POSTGRES_DB}' as user '${POSTGRES_USER}'..."
+
+# Run pg_dump inside the db container, compress on the fly
+docker compose exec -T db \
+    pg_dump \
+        --username="${POSTGRES_USER}" \
+        --dbname="${POSTGRES_DB}" \
+        --clean \
+        --if-exists \
+        --no-owner \
+        --no-privileges \
+        --no-comments \
+        --quote-all-identifiers \
+        --exclude-table-data='public.alembic_version' \
+        --exclude-table-data='public.ingest_watermarks' \
+        --exclude-table-data='public.rq_jobs' \
+        --exclude-table-data='public.rq_job_dependents' \
+        | gzip > "${BACKUP_FILE}"
+
+# Verify backup was created
+if [ -s "${BACKUP_FILE}" ]; then
+    BACKUP_SIZE=$(du -h "${BACKUP_FILE}" | cut -f1)
+    echo "✅ Backup created: ${BACKUP_FILE} (${BACKUP_SIZE})"
+else
+    echo "❌ Backup failed: output file is empty or missing"
+    exit 1
+fi
+
+# Optional: prune old backups (keep last 7 days)
+if command -v find &> /dev/null; then
+    find "${BACKUP_DIR}" -name "${POSTGRES_DB}_*.sql.gz" -type f -mtime +7 -delete
+    echo "🗑️  Pruned backups older than 7 days"
+fi

--- a/scripts/restore_db.sh
+++ b/scripts/restore_db.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Restore PostgreSQL database from a backup file.
+# WARNING: This will replace the current database content.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+cd "${REPO_ROOT}"
+
+# Load environment variables from .env if present
+if [ -f .env ]; then
+    set -a
+    source .env
+    set +a
+fi
+
+POSTGRES_USER="${POSTGRES_USER:-wildfire}"
+POSTGRES_DB="${POSTGRES_DB:-wildfire}"
+BACKUP_DIR="${BACKUP_DIR:-data/backups}"
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <backup_file.sql.gz>"
+    echo "Available backups:"
+    ls -1 "${BACKUP_DIR}/${POSTGRES_DB}_"*.sql.gz 2>/dev/null | head -10
+    exit 1
+fi
+
+BACKUP_FILE="$1"
+if [ ! -f "${BACKUP_FILE}" ]; then
+    echo "Error: backup file '${BACKUP_FILE}' not found"
+    exit 1
+fi
+
+echo "Restoring database '${POSTGRES_DB}' from ${BACKUP_FILE}..."
+echo "WARNING: This will overwrite existing data in the database."
+read -p "Are you sure? (type 'yes' to continue): " confirm
+if [ "${confirm}" != "yes" ]; then
+    echo "Aborted."
+    exit 1
+fi
+
+# Drop existing connections (optional, may fail if other services are running)
+echo "Terminating existing connections..."
+docker compose exec -T db \
+    psql --username="${POSTGRES_USER}" --dbname="${POSTGRES_DB}" \
+        -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid();" \
+        2>/dev/null || true
+
+# Restore the backup
+gunzip -c "${BACKUP_FILE}" | \
+    docker compose exec -T db \
+        psql --username="${POSTGRES_USER}" --dbname="${POSTGRES_DB}" \
+            --quiet --single-transaction
+
+echo "✅ Database restored successfully."


### PR DESCRIPTION
This PR implements a backup and recovery solution for the PostgreSQL database, addressing audit issue #301.

**Changes:**
- `scripts/backup_db.sh` – creates a compressed SQL dump with 7‑day retention.
- `scripts/restore_db.sh` – restores a backup with safety confirmation.
- `make backup`, `make restore`, `make backup‑list` – convenient Make targets.
- `docs/backup_recovery.md` – comprehensive documentation covering local/production scenarios.
- Excludes ephemeral tables (alembic_version, ingest_watermarks, RQ jobs) to keep backups small.

Closes #301.