### PR TITLE
[Issue #316] Fix VIIRS SNPP-NRT failure loop — zombie reaper + error logging

### DIFF
--- a/ingest/firms_ingest.py
+++ b/ingest/firms_ingest.py
@@ -600,8 +600,8 @@ def run_firms_ingest(
                 skipped=0,
             )
             return 1
-        except Exception:  # pragma: no cover - defensive logging
-            LOGGER.exception("Ingest failed for source=%s batch=%s", source, batch_id)
+        except Exception as e:  # pragma: no cover - defensive logging
+            LOGGER.exception("Ingest failed for source=%s batch=%s — exception details: %s", source, batch_id, str(e))
             persisted_after_cleanup = 0
             try:
                 persisted_before_cleanup = repository.count_detections_for_batch(batch_id)
@@ -615,12 +615,15 @@ def run_firms_ingest(
                 persisted_after_cleanup = repository.count_detections_for_batch(batch_id)
             except Exception:
                 LOGGER.exception("Failed to cleanup detections for failed batch %s", batch_id)
+            # For exception cases, we don't have accurate duplicate counts since the error
+            # occurred during processing. Set skipped to 0 since persisted_after_cleanup
+            # represents rows that survived the failure, not duplicates.
             repository.finalize_ingest_batch(
                 batch_id,
                 status="failed",
                 fetched=fetched_count,
                 inserted=persisted_after_cleanup,
-                skipped=max(rows_after_watermark_filter - persisted_after_cleanup, 0),
+                skipped=0,
             )
             return 1
 

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -238,6 +238,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Database cleanup run interval in minutes (loop mode).",
     )
     parser.add_argument(
+        "--max-batch-age-minutes",
+        type=float,
+        default=120.0,
+        help=(
+            "Maximum age (in minutes) for 'running' ingest batches before they are "
+            "considered stuck (zombie) and expired. Default 120 = 2x default 60-minute "
+            "incremental FIRMS lookback window."
+        ),
+    )
+    parser.add_argument(
         "--operator-accuracy-interval-minutes",
         type=float,
         default=10080.0,
@@ -827,16 +837,27 @@ def _run_operator_accuracy(args: argparse.Namespace) -> int:  # noqa: ARG001
 
 
 def _run_cleanup(args: argparse.Namespace) -> int:
-    """Run database cleanup.
+    """Run database cleanup and zombie batch reaper.
 
     Performs real cleanup by default. Set CLEANUP_DRY_RUN=true to count eligible
     rows without deleting (operator dry-run only; scheduled path always deletes).
+
+    Also runs the zombie batch reaper to expire 'running' batches that have
+    exceeded their timeout (default 2x incremental_lookback_minutes).
     """
     # Lazy import: avoids pulling api.db into module scope at startup.
     from scripts.db_cleanup import cleanup  # noqa: PLC0415
 
     dry_run = os.getenv("CLEANUP_DRY_RUN", "false").lower() in ("1", "true", "yes")
     cleanup(dry_run=dry_run)
+
+    # Reap zombie batches (batches stuck in 'running' state longer than 2x lookback window).
+    # Default is 120 minutes (2 * 60-minute default incremental lookback).
+    max_batch_age_minutes = getattr(args, "max_batch_age_minutes", 120)
+    reaped = _reap_zombie_batches(max_age_minutes=int(max_batch_age_minutes))
+    if reaped > 0:
+        LOGGER.info("Reaped %d zombie batch(es) during cleanup job", reaped)
+
     return 0
 
 

--- a/ingest/tests/test_orchestrator.py
+++ b/ingest/tests/test_orchestrator.py
@@ -864,6 +864,75 @@ class TestExpireStaleRunningBatches(unittest.TestCase):
         count = _reap_zombie_batches(expire_fn=lambda _: [])
         self.assertEqual(0, count)
 
+    def test_cleanup_job_calls_reaper(self):
+        """The _run_cleanup function should call the zombie reaper with configured max_age."""
+        from ingest.orchestrator import _run_cleanup
+
+        reaped_calls: list[int] = []
+
+        def _mock_reaper(max_age_minutes: int) -> int:
+            reaped_calls.append(max_age_minutes)
+            return 1
+
+        args = argparse.Namespace(
+            max_batch_age_minutes=120,
+        )
+
+        with (
+            patch("scripts.db_cleanup.cleanup"),
+            patch("ingest.orchestrator._reap_zombie_batches", side_effect=_mock_reaper),
+        ):
+            exit_code = _run_cleanup(args)
+
+        self.assertEqual(0, exit_code)
+        self.assertEqual([120], reaped_calls)
+
+    def test_cleanup_job_uses_custom_batch_age(self):
+        """The _run_cleanup function should use custom max_batch_age_minutes from args."""
+        from ingest.orchestrator import _run_cleanup
+
+        reaped_calls: list[int] = []
+
+        def _mock_reaper(max_age_minutes: int) -> int:
+            reaped_calls.append(max_age_minutes)
+            return 0
+
+        args = argparse.Namespace(
+            max_batch_age_minutes=240,
+        )
+
+        with (
+            patch("scripts.db_cleanup.cleanup"),
+            patch("ingest.orchestrator._reap_zombie_batches", side_effect=_mock_reaper),
+        ):
+            exit_code = _run_cleanup(args)
+
+        self.assertEqual(0, exit_code)
+        self.assertEqual([240], reaped_calls)
+
+    def test_cleanup_job_logs_when_zombies_reaped(self):
+        """The _run_cleanup function should log when zombies are reaped."""
+        from ingest.orchestrator import _run_cleanup
+
+        def _mock_reaper(max_age_minutes: int) -> int:
+            return 3
+
+        args = argparse.Namespace(
+            max_batch_age_minutes=120,
+        )
+
+        with (
+            patch("scripts.db_cleanup.cleanup"),
+            patch("ingest.orchestrator._reap_zombie_batches", side_effect=_mock_reaper),
+            self.assertLogs("ingest_orchestrator", level="INFO") as log_ctx,
+        ):
+            exit_code = _run_cleanup(args)
+
+        self.assertEqual(0, exit_code)
+        log_text = "\n".join(log_ctx.output)
+        self.assertIn("3", log_text)
+        self.assertIn("zombie", log_text.lower())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Fixes #316

- **Fixed mislabeled counter**: Exception handler was setting `skipped` to `rows_after_watermark_filter` — now correctly set to `0` since duplicate counts are unavailable during failures
- **Added exception details to logs**: `except Exception:` → `except Exception as e:` with full exception text in log output for diagnosing SNPP-NRT root cause
- **Added zombie-batch reaper**: `_run_cleanup()` now expires `running` batches stuck longer than `2× incremental_lookback_minutes` (default 120 min), preventing watermark lock from crashed processes
- **New CLI flag**: `--max-batch-age-minutes` to configure reaper timeout

## Test plan
- [x] 3 new tests for cleanup/reaper integration in `test_orchestrator.py`
- [ ] Verify SNPP-NRT batches process after deploying (requires production DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)