### PR TITLE
[Issue #299] Add restart policy and healthcheck to RQ worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,7 @@ services:
     build:
       context: ./api
     command: uv run rq worker
+    restart: unless-stopped
     volumes:
       - ./api:/app/api:delegated
       - ./data:/app/data
@@ -173,7 +174,10 @@ services:
       migrate:
         condition: service_completed_successfully
     healthcheck:
-      disable: true
+      test: ["CMD", "redis-cli", "-h", "redis", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   ingest_scheduler:
     build:


### PR DESCRIPTION
## Summary
- Add `restart: unless-stopped` to the worker service so it auto-recovers from crashes (OOM, signal 9, deadlocks)
- Replace `healthcheck: disable: true` with a real `redis-cli -h redis ping` liveness probe (10s interval, 5s timeout, 5 retries)
- Matches existing patterns from db, redis, and ingest_scheduler services

Closes #299

## Test plan
- [x] YAML syntax validated
- [x] Pattern consistency verified against all other services
- [ ] Verify worker recovers from `docker kill` in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)