### PR TITLE
[Issue #357] Fix GRIB temporal validation for NumPy 2.0.x

### DIFF
--- a/ingest/weather_ingest.py
+++ b/ingest/weather_ingest.py
@@ -196,7 +196,7 @@ def _validate_temporal_metadata(
 
         # Convert to datetime if it's a numpy datetime64
         if isinstance(valid_time_scalar, np.datetime64):
-            valid_time = valid_time_scalar.astype("datetime64[ns]").astype(datetime)
+            valid_time = valid_time_scalar.astype("datetime64[us]").item()
         else:
             valid_time = valid_time_scalar
     elif "time" in ds and "step" in ds:
@@ -211,13 +211,13 @@ def _validate_temporal_metadata(
 
         # Convert time to datetime
         if isinstance(time_val, np.datetime64):
-            time_dt = time_val.astype("datetime64[ns]").astype(datetime)
+            time_dt = time_val.astype("datetime64[us]").item()
         else:
             time_dt = time_val
 
         # Convert step to timedelta
         if isinstance(step_val, np.timedelta64):
-            step_td = step_val.astype("timedelta64[ns]").astype(timedelta)
+            step_td = step_val.astype("timedelta64[us]").item()
         else:
             step_td = step_val
 


### PR DESCRIPTION
## Summary

Fixes #357

- Replaced `.astype("datetime64[ns]").astype(datetime)` with `.astype("datetime64[us]").item()` in `_validate_temporal_metadata`
- Same fix applied to all 3 conversion sites: `valid_time`, `time_dt`, and `step_td`
- Uses `[us]` (microsecond) precision to match Python `datetime` resolution and avoid nanosecond overflow
- `.item()` is the correct cross-version idiom, working on both NumPy 1.x and 2.x

Previously on NumPy 2.0.x, all GRIB temporal validation was silently skipped (caught by broad `except Exception`), allowing malformed weather data through unchecked.

## Test plan
- [ ] Verify all 17 existing weather ingest tests pass
- [ ] Confirm `_validate_temporal_metadata` correctly converts `np.datetime64` and `np.timedelta64` on both NumPy 1.x and 2.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>