### PR TITLE
[Issue #356] Fix archive rate-limit Redis key bypass

### DIFF
--- a/api/routes/archive.py
+++ b/api/routes/archive.py
@@ -71,8 +71,10 @@ def _check_archive_rate_limit(request: Request, is_large_range: bool = False) ->
         limit = ARCHIVE_INGEST_RATE_LIMIT_SHORT
         window = ARCHIVE_INGEST_RATE_WINDOW_SHORT_SECONDS
 
-    # Redis sliding window counter key
-    key = f"archive_ingest_rate_limit:{client_ip}"
+    # Redis sliding window counter key — separate keys per tier so that
+    # small-range and large-range counters are tracked independently.
+    tier = "large" if is_large_range else "small"
+    key = f"archive_ingest_rate_limit:{client_ip}:{tier}"
 
     try:
         # Increment counter

--- a/api/tests/test_archive_range.py
+++ b/api/tests/test_archive_range.py
@@ -404,7 +404,7 @@ class TestArchiveIngestRangeRateLimiting:
     @patch("rq.Queue")
     @patch("api.routes.archive.get_redis")
     def test_rate_limit_uses_client_ip(self, mock_get_redis, mock_queue_cls, client):
-        """Rate limiting should use the client IP as the key."""
+        """Rate limiting should use the client IP and tier as the key."""
         mock_redis = MagicMock()
         mock_redis.incr.return_value = 1
         mock_get_redis.return_value = mock_redis
@@ -416,11 +416,42 @@ class TestArchiveIngestRangeRateLimiting:
         )
         assert resp.status_code == 202
 
-        # Verify that incr was called with a key containing an IP
+        # Verify that incr was called with a key containing an IP and tier
         mock_redis.incr.assert_called_once()
         call_args = mock_redis.incr.call_args
         key = call_args[0][0]
         assert key.startswith("archive_ingest_rate_limit:")
+        assert key.endswith(":small")
+
+    @patch("rq.Queue")
+    @patch("api.routes.archive.get_redis")
+    def test_small_and_large_ranges_use_separate_redis_keys(self, mock_get_redis, mock_queue_cls, client):
+        """Small-range and large-range requests must use different Redis keys."""
+        mock_redis = MagicMock()
+        mock_redis.incr.return_value = 1
+        mock_get_redis.return_value = mock_redis
+        mock_queue_cls.return_value.enqueue.return_value = MagicMock()
+
+        # Small range (1 day)
+        client.post(
+            "/fires/archive/ingest-range",
+            json={"start_date": _recent_date(1), "end_date": _recent_date(1)},
+        )
+        small_key = mock_redis.incr.call_args[0][0]
+
+        mock_redis.reset_mock()
+        mock_redis.incr.return_value = 1
+
+        # Large range (6 days)
+        client.post(
+            "/fires/archive/ingest-range",
+            json={"start_date": _recent_date(6), "end_date": _recent_date(1)},
+        )
+        large_key = mock_redis.incr.call_args[0][0]
+
+        assert small_key != large_key
+        assert small_key.endswith(":small")
+        assert large_key.endswith(":large")
 
     @patch("api.routes.archive.get_redis")
     def test_rate_limit_gracefully_handles_redis_error(self, mock_get_redis, client):


### PR DESCRIPTION
## Summary

Fixes #356

- Split the shared Redis rate-limit key into separate keys per tier: `archive_ingest_rate_limit:{ip}:small` and `archive_ingest_rate_limit:{ip}:large`
- This prevents small-range requests from setting a 60s TTL that large-range requests then inherit, bypassing the intended 300s window
- Added test verifying small and large ranges produce different Redis keys
- Updated existing test to assert tier suffix

## Test plan
- [ ] Verify all 11 rate-limiting tests pass
- [ ] Confirm small-range requests (≤3 days) use `:small` key with 60s/3-request limit
- [ ] Confirm large-range requests (>3 days) use `:large` key with 300s/1-request limit
- [ ] Verify interleaving small and large requests no longer allows large-range bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>