### PR TITLE
[Issue #375] Fix date.today() to use UTC in archive.py

### DIFF
--- a/api/routes/archive.py
+++ b/api/routes/archive.py
@@ -316,7 +316,7 @@ async def trigger_archive_ingest(body: ArchiveIngestRequest) -> ArchiveIngestRes
             detail=f"Invalid date '{body.date}'. Expected YYYY-MM-DD.",
         )
 
-    days_ago = (date.today() - requested_date).days
+    days_ago = (datetime.now(timezone.utc).date() - requested_date).days
     if days_ago < 0:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -412,7 +412,7 @@ async def trigger_archive_ingest_range(request: Request, body: ArchiveRangeInges
             detail="end_date must be on or after start_date.",
         )
 
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
     for d, label in [(start_d, "start_date"), (end_d, "end_date")]:
         days_ago = (today - d).days
         if days_ago < 0:


### PR DESCRIPTION
## Summary
- Replaces `date.today()` with `datetime.now(timezone.utc).date()` in two locations in `api/routes/archive.py`
- Fixes incorrect date boundary checks on non-UTC servers: valid UTC dates near midnight could be rejected, or future dates accepted
- Aligns with the rest of the codebase which consistently uses `datetime.now(timezone.utc)`

Closes #375

## Test plan
- [x] All 52 archive-related tests pass (`test_archive_range.py` + `test_archive_ingest.py`)
- [x] No new imports needed — `datetime` and `timezone` already imported

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>