### PR TITLE
[Issue #376] Fix ApiError lost in slow-path retry catch

### DIFF
--- a/ui/src/api/http.ts
+++ b/ui/src/api/http.ts
@@ -101,6 +101,7 @@ export async function getJson<T>(
           return data as T;
         } catch (innerErr) {
           secondAttempt.cancel();
+          if (innerErr instanceof ApiError) throw innerErr;
           const message = innerErr instanceof Error ? innerErr.message : "API unavailable";
           lastUnavailable = new ApiUnavailableError(message, { url });
           continue;


### PR DESCRIPTION
## Summary
- Adds `if (innerErr instanceof ApiError) throw innerErr;` guard in the second-attempt catch block of `getJson` in `ui/src/api/http.ts`
- Prevents `ApiError` (with status code and response body) from being reclassified as `ApiUnavailableError`
- Mirrors the identical guard already present in the first-attempt catch, `postJson`, and `deleteRequest`

Closes #376

## Test plan
- [x] One-line addition following established pattern used in 3 other catch blocks in the same file
- [x] No behavioral change for non-`ApiError` exceptions (network failures, timeouts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>