### PR TITLE
[Issue #377] Fix stale AI briefing on rapid event switch

### DIFF
--- a/ui/src/components/AIChatAssistant.tsx
+++ b/ui/src/components/AIChatAssistant.tsx
@@ -99,6 +99,7 @@ export default function AIChatAssistant(): JSX.Element {
   const lastBriefedEventId = useRef<string | null>(null);
   const lastBriefedPrompt = useRef<string | null>(null);
   const isBriefingRef = useRef(false);
+  const pendingBriefRef = useRef<{ eventId: string; prompt: string } | null>(null);
 
   const selectedEvent = useAppStore((s) => s.selectedEvent);
   const filters = useAppStore((s) => s.filters);
@@ -182,9 +183,19 @@ export default function AIChatAssistant(): JSX.Element {
     [activePreset, assistantViewContext, eventContext, filters, forecast, layers, mapView, timeRange]
   );
 
-  const triggerBriefing = useCallback(async (prompt: string): Promise<boolean> => {
-    if (!assistantConfigured || isBriefingRef.current) return false;
+  const triggerBriefing = useCallback(async (prompt: string, eventId?: string): Promise<boolean> => {
+    if (!assistantConfigured) return false;
+
+    // If a briefing is already in flight, record this event as pending so the
+    // finally block can re-trigger once the current request completes.
+    if (isBriefingRef.current) {
+      if (eventId) pendingBriefRef.current = { eventId, prompt };
+      return false;
+    }
+
     isBriefingRef.current = true;
+    const requestEventId = eventId ?? null;
+    pendingBriefRef.current = null;
     setIsBriefing(true);
     setAutoBriefing(null);
     try {
@@ -210,7 +221,12 @@ export default function AIChatAssistant(): JSX.Element {
       if (!response.ok) throw new Error(`briefing call failed with ${response.status}`);
       const payload = (await response.json()) as unknown;
       const reply = extractReply(payload);
-      if (reply) setAutoBriefing(reply);
+      // Only apply the briefing if the event hasn't changed while the request was in flight.
+      const currentEvent = useAppStore.getState().selectedEvent;
+      const currentEventId = currentEvent ? String(currentEvent.event_id ?? "") : null;
+      if (reply && requestEventId === currentEventId) {
+        setAutoBriefing(reply);
+      }
       return true;
     } catch (err: unknown) {
       console.error("[AIChatAssistant] auto-briefing failed:", err);
@@ -219,6 +235,16 @@ export default function AIChatAssistant(): JSX.Element {
     } finally {
       isBriefingRef.current = false;
       setIsBriefing(false);
+
+      // If another event was queued while this request was in flight, trigger it now.
+      // Re-read from the ref — the in-flight guard may have written a new value.
+      const pending = pendingBriefRef.current as { eventId: string; prompt: string } | null;
+      if (pending && pending.eventId !== requestEventId) {
+        pendingBriefRef.current = null;
+        void triggerBriefing(pending.prompt, pending.eventId).then((accepted) => {
+          if (accepted) lastBriefedEventId.current = pending.eventId;
+        });
+      }
     }
   }, [assistantConfigured, isSafetyMode, viewingContext]);
 
@@ -230,7 +256,7 @@ export default function AIChatAssistant(): JSX.Element {
     const prompt = isSafetyMode
       ? "Give a 2-sentence safety briefing for this fire. Plain language only: risk level and what the person should do right now."
       : "Give a 2-sentence analyst briefing: fire behavior context, intensity interpretation, and spread risk.";
-    void triggerBriefing(prompt).then((accepted) => {
+    void triggerBriefing(prompt, eventId).then((accepted) => {
       if (accepted) lastBriefedEventId.current = eventId;
     });
   }, [selectedEvent, selectedEvent?.event_id, assistantConfigured, isSafetyMode, triggerBriefing]);


### PR DESCRIPTION
## Summary
- Fixes race condition where rapidly switching fire events shows the previous event's AI briefing
- Adds a `pendingBriefRef` that queues the latest event when a briefing is already in-flight; the `finally` block re-triggers for the pending event
- Discards stale briefing responses by reading current event from `useAppStore.getState()` (not closure) before applying
- No prompt string duplication — pending ref carries both event ID and prompt

Closes #377

## Test plan
- [x] 119 tests pass across 18 test files
- [x] TypeScript type checker clean (0 errors)
- [x] Verified: `selectedEvent` NOT in `useCallback` deps (avoids dependency cycle)
- [x] Verified: `useAppStore.getState()` used for staleness check (not closure capture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>