### PR TITLE
[Issue #303] Add structured JSON logging for API and ingest services

### DIFF
--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import logging
 import os
-import uuid
 from contextvars import ContextVar
 
 from pythonjsonlogger.json import JsonFormatter

--- a/api/logging_config.py
+++ b/api/logging_config.py
@@ -1,0 +1,65 @@
+"""Structured JSON logging configuration for the API service.
+
+Call ``setup_logging()`` once at application startup (before any log statements)
+to replace the default text formatter on the root logger with a JSON formatter.
+All existing ``logging.getLogger(__name__)`` calls continue to work unchanged.
+
+When ``LOG_FORMAT=text`` is set (e.g. local development), the original
+human-readable format is preserved.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from contextvars import ContextVar
+
+from pythonjsonlogger.json import JsonFormatter
+
+# ContextVar holding the current request_id; set by FastAPI middleware.
+request_id_ctx: ContextVar[str | None] = ContextVar("request_id", default=None)
+
+
+class _RequestIdJsonFormatter(JsonFormatter):
+    """JSON formatter that injects ``request_id`` from the context variable."""
+
+    def add_fields(
+        self,
+        log_record: dict,
+        record: logging.LogRecord,
+        message_dict: dict,
+    ) -> None:
+        super().add_fields(log_record, record, message_dict)
+        log_record.setdefault("service", "api")
+        rid = request_id_ctx.get()
+        if rid:
+            log_record["request_id"] = rid
+
+
+def setup_logging(*, level: str | None = None) -> None:
+    """Configure the root logger with a JSON (or text) formatter.
+
+    Parameters
+    ----------
+    level:
+        Override log level.  Defaults to the ``LOG_LEVEL`` env-var, then INFO.
+    """
+    effective_level = (level or os.getenv("LOG_LEVEL", "INFO")).upper()
+    log_format = os.getenv("LOG_FORMAT", "json").lower()
+
+    handler = logging.StreamHandler()
+
+    if log_format == "text":
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+        )
+    else:
+        handler.setFormatter(
+            _RequestIdJsonFormatter(
+                fmt="%(asctime)s %(levelname)s %(name)s %(message)s",
+                rename_fields={"asctime": "timestamp", "levelname": "level", "name": "logger"},
+            )
+        )
+
+    logging.basicConfig(level=effective_level, handlers=[handler], force=True)

--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,6 @@
 import logging
+import uuid
+
 from fastapi import FastAPI, Request, status, HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -9,8 +11,12 @@ from redis.asyncio import Redis
 
 from api.config import settings
 from api.errors import ErrorResponse, WildfireError, wildfire_error_handler
+from api.logging_config import setup_logging, request_id_ctx
 from api.routes import archive_router, assistant_router, internal_router, fires_router, forecast_router, aois_router, tiles_router, exports_router, risk_router, ignition_router
 from api.startup_check import StartupError, run_api_startup_checks
+
+# Configure structured JSON logging before any log statements.
+setup_logging()
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,6 +42,24 @@ app.add_middleware(
 
 # Pre-computed once at startup — settings are static.
 _CSP_HEADER = f"frame-ancestors {settings.frame_ancestors}"
+
+
+@app.middleware("http")
+async def _request_id_middleware(request: Request, call_next):
+    """Attach a request_id to every request for log correlation.
+
+    If the caller supplies an ``X-Request-ID`` header it is reused; otherwise a
+    new UUID4 is generated.  The id is stored in a contextvar so the JSON log
+    formatter can include it automatically, and echoed back in the response.
+    """
+    rid = request.headers.get("X-Request-ID") or uuid.uuid4().hex
+    token = request_id_ctx.set(rid)
+    try:
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = rid
+        return response
+    finally:
+        request_id_ctx.reset(token)
 
 
 @app.middleware("http")

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "h5py>=3.10.0",
     "matplotlib>=3.8.0,<4.0.0",
     "onnxruntime>=1.18.0,<2.0.0",
+    "python-json-logger>=3.2.0,<4.0.0",
 ]
 
 [dependency-groups]

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1030,6 +1030,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-json-logger"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/d3144a0bceede957f961e975f3752760fbe390d57fbe194baf709d8f1f7b/python_json_logger-3.3.0.tar.gz", hash = "sha256:12b7e74b17775e7d565129296105bbe3910842d9d0eb083fc83a6a617aa8df84", size = 16642, upload-time = "2025-03-07T07:08:27.301Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/20/0f2523b9e50a8052bc6a8b732dfc8568abbdc42010aef03a2d750bdab3b2/python_json_logger-3.3.0-py3-none-any.whl", hash = "sha256:dd980fae8cffb24c13caf6e158d3d61c0d6d22342f932cb6e9deedab3d35eec7", size = 15163, upload-time = "2025-03-07T07:08:25.627Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1503,6 +1512,7 @@ dependencies = [
     { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "rasterio" },
     { name = "redis" },
@@ -1546,6 +1556,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=17.0.0,<18.0.0" },
     { name = "pydantic", specifier = ">=2.8.2,<2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0,<3.0.0" },
+    { name = "python-json-logger", specifier = ">=3.2.0,<4.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0,<7.0.0" },
     { name = "rasterio", specifier = ">=1.3.9,<1.4.0" },
     { name = "redis", specifier = ">=7.1.0" },

--- a/ingest/logging_config.py
+++ b/ingest/logging_config.py
@@ -1,0 +1,57 @@
+"""Structured JSON logging configuration for the ingest service.
+
+Call ``setup_logging()`` once at process startup (before any log statements)
+to replace the default text formatter on the root logger with a JSON formatter.
+All existing ``logging.getLogger(__name__)`` calls continue to work unchanged.
+
+When ``LOG_FORMAT=text`` is set (e.g. local development), the original
+human-readable format is preserved.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from pythonjsonlogger.json import JsonFormatter
+
+
+class _ServiceJsonFormatter(JsonFormatter):
+    """JSON formatter that tags every record with ``service: ingest``."""
+
+    def add_fields(
+        self,
+        log_record: dict,
+        record: logging.LogRecord,
+        message_dict: dict,
+    ) -> None:
+        super().add_fields(log_record, record, message_dict)
+        log_record.setdefault("service", "ingest")
+
+
+def setup_logging(*, level: str | None = None) -> None:
+    """Configure the root logger with a JSON (or text) formatter.
+
+    Parameters
+    ----------
+    level:
+        Override log level.  Defaults to the ``LOG_LEVEL`` env-var, then INFO.
+    """
+    effective_level = (level or os.getenv("LOG_LEVEL", "INFO")).upper()
+    log_format = os.getenv("LOG_FORMAT", "json").lower()
+
+    handler = logging.StreamHandler()
+
+    if log_format == "text":
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+        )
+    else:
+        handler.setFormatter(
+            _ServiceJsonFormatter(
+                fmt="%(asctime)s %(levelname)s %(name)s %(message)s",
+                rename_fields={"asctime": "timestamp", "levelname": "level", "name": "logger"},
+            )
+        )
+
+    logging.basicConfig(level=effective_level, handlers=[handler], force=True)

--- a/ingest/orchestrator.py
+++ b/ingest/orchestrator.py
@@ -17,15 +17,12 @@ from typing import Any, Callable, Sequence
 
 from ingest.config import REPO_ROOT
 from ingest.dem_preprocess import DemIngestSettings, ingest_terrain_for_bbox
+from ingest.logging_config import setup_logging
 from ingest.startup_check import StartupError, run_ingest_startup_checks
 from ingest.firms_ingest import run_firms_ingest
 from ingest.industrial_sources_ingest import run_industrial_ingest
 from ingest.nifc_perimeters_ingest import fetch_nifc_perimeters, ingest_perimeters
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s %(name)s %(message)s",
-)
 LOGGER = logging.getLogger("ingest_orchestrator")
 
 JOB_FIRMS = "firms"
@@ -1348,6 +1345,7 @@ def run_scheduler(
 
 
 def main(argv: list[str] | None = None) -> None:
+    setup_logging()
     args = parse_args(argv)
 
     try:

--- a/ingest/pyproject.toml
+++ b/ingest/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "scikit-learn>=1.3.0,<2.0.0",
     "onnxruntime>=1.18.0,<2.0.0",
     "xgboost>=2.0.0,<3.0.0",
+    "python-json-logger>=3.2.0,<4.0.0",
 ]
 
 [dependency-groups]

--- a/ingest/uv.lock
+++ b/ingest/uv.lock
@@ -733,6 +733,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-json-logger"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/d3144a0bceede957f961e975f3752760fbe390d57fbe194baf709d8f1f7b/python_json_logger-3.3.0.tar.gz", hash = "sha256:12b7e74b17775e7d565129296105bbe3910842d9d0eb083fc83a6a617aa8df84", size = 16642, upload-time = "2025-03-07T07:08:27.301Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/20/0f2523b9e50a8052bc6a8b732dfc8568abbdc42010aef03a2d750bdab3b2/python_json_logger-3.3.0-py3-none-any.whl", hash = "sha256:dd980fae8cffb24c13caf6e158d3d61c0d6d22342f932cb6e9deedab3d35eec7", size = 15163, upload-time = "2025-03-07T07:08:25.627Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1074,6 +1083,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "rasterio" },
     { name = "rio-cogeo" },
@@ -1105,6 +1115,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.8.2,<2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0,<3.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0.0" },
+    { name = "python-json-logger", specifier = ">=3.2.0,<4.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0,<7.0.0" },
     { name = "rasterio", specifier = ">=1.3.9,<1.4.0" },
     { name = "rio-cogeo", specifier = ">=5.4.0,<6.0.0" },


### PR DESCRIPTION
## Summary
- Adds `python-json-logger` to API and ingest services
- Creates `logging_config.py` modules with JSON formatters and `LOG_FORMAT=text` escape hatch for local dev
- API service gets request_id correlation via contextvar middleware (reads/generates `X-Request-ID`)
- Ingest service gets `service: ingest` tag on all log records
- Uses `logging.basicConfig(force=True)` for safe, idempotent configuration that doesn't break pytest `caplog`
- Existing `logging.getLogger(__name__)` calls work unchanged

Closes #303

## Test plan
- [x] API: 632 passed, 1 skipped
- [x] Ingest: 427 passed, 4 skipped
- [x] ML dep removed (no structured logging callsite in ML)
- [x] `LOG_FORMAT=text` preserves human-readable output for local development
- [x] No `_CONFIGURED` global — uses `basicConfig(force=True)` instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>