### PR TITLE
chore: post-cutover cleanup (FIRMS cron on, Clerk var rename, blockers reconcile)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,5 +42,7 @@ FIRMS_MAP_KEY=your_firms_api_key_here
 # Stage 5 — Auth (Clerk) — pending
 # =============================================================================
 # Free tier: 10,000 MAU. https://clerk.com
-# CLERK_PUBLISHABLE_KEY=
+# The publishable key is exposed to the browser via the NEXT_PUBLIC_ prefix
+# (Next.js convention); the secret key stays server-only.
+# NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 # CLERK_SECRET_KEY=

--- a/.github/workflows/firms-poll.yml
+++ b/.github/workflows/firms-poll.yml
@@ -1,12 +1,5 @@
 name: FIRMS poll
 
-# IMPORTANT (Vanyo): the `schedule:` trigger below is intentionally commented
-# out at merge time. Per pm/blockers.md "Stage 2 — CRON_SECRET", flip the
-# toggle by un-commenting the two `cron:` lines once these are both set:
-#   1. `CRON_SECRET` on the Vercel `wildfire-nowcast` project (Preview + Prod)
-#   2. `CRON_SECRET` as a GitHub Actions repo secret
-# Until then, leaving `schedule:` active would generate a 503 (CRON_SECRET
-# unset) every 15 minutes and pollute job_runs with noise.
 on:
   workflow_dispatch:
     inputs:
@@ -14,8 +7,8 @@ on:
         description: "Optional 5x5:E### or 5x5:W### bucket key"
         required: false
         type: string
-  # schedule:
-  #   - cron: "*/15 * * * *"
+  schedule:
+    - cron: "*/15 * * * *"
 
 # Don't pre-empt a slow run with a fresh tick. If a poll genuinely takes longer
 # than 15 minutes, we want to see it finish and then let the next tick start.

--- a/pm/blockers.md
+++ b/pm/blockers.md
@@ -8,89 +8,19 @@ Update mode: PM_CLAUDE adds entries; Vanyo marks `[x]` when done; PM_CLAUDE remo
 
 ## Active
 
-### Stage 1 — Neon Postgres
-
-- [ ] **Create Neon free-tier project** at https://console.neon.tech
-  - Any region (suggest `aws-eu-central-1` for EU latency, or `aws-us-east-1` for US)
-  - Project name: `wildfire-nowcast` (or any — only the connection string matters)
-- [ ] **Add `DATABASE_URL` to Vercel `wildfire-nowcast` project** (Preview environment scope only for now; Production scope when we get to Stage 7 cutover)
-  - Connection string from Neon dashboard, the "pooled" variant (`-pooler` host) for Vercel functions
-  - Vercel dashboard → wildfire-nowcast project → Settings → Environment Variables
-
-**Why:** Stage 1 dev agent built the AOI schema + CRUD against PGlite in-memory. The Vercel preview deploy lights up the moment this env var lands.
-
-**When:** Any time. Not blocking dev.
-
----
-
-### Stage 2 — local Docker for integration tests
-
-- [ ] **Confirm Docker is running locally** — `docker ps` should return a table (empty is fine)
-  - Most likely already true: existing `docker-compose.yml` for the legacy Railway stack means Docker is installed
-  - If "Cannot connect to Docker daemon": just open Docker Desktop
-  - If not installed at all: `brew install --cask docker` (macOS)
-
-**Why:** PGlite (Stage 1's in-memory test DB) does not include PostGIS. Stage 2's FIRMS-to-AOI spatial matcher uses `ST_DWithin` / `ST_Intersects`, which need real PostGIS. Stage 2 dev agent adds `@testcontainers/postgresql` to dev deps; tests spin up a `postgis/postgis:16-3.5` container per test run (~10s startup, then fast). GitHub Actions Ubuntu runners have Docker pre-installed so CI needs no changes.
-
-**When:** Before Stage 2 PR opens. Non-blocking for the agent — it can write the testcontainer-using tests; Vanyo only needs Docker running to execute them locally.
-
----
-
-### Stage 2 — CRON_SECRET (cheap, but required)
-
-- [ ] **Generate a CRON_SECRET random string** (e.g. `openssl rand -hex 32`)
-- [ ] **Add `CRON_SECRET` to Vercel `wildfire-nowcast` project** env vars (Preview + Production scopes)
-- [ ] **Add the same `CRON_SECRET` as a GitHub Actions repository secret** at https://github.com/Ent7opy/wildfire-nowcast/settings/secrets/actions
-
-**Why:** GitHub Actions cron will POST to `/api/aoi/poll` every 15 min. The function must reject anyone else hitting that endpoint, otherwise we burn FIRMS rate limit and Neon CU-hours. Standard pattern: shared secret in an `Authorization: Bearer <CRON_SECRET>` header.
-
-**When:** Before Stage 2 PR merges. Until then the cron workflow is disabled at the YAML level (commit on/off toggle).
-
----
-
-### Stage 3 — Vercel AI Gateway
-
-- [ ] **Enable Vercel AI Gateway** on your team
-  - Vercel dashboard → AI Gateway → Get started
-  - Free tier includes $5/mo credit
-- [ ] **Add `AI_GATEWAY_API_KEY` to Vercel `wildfire-nowcast` project** (Preview + Production)
-
-**When:** Before Stage 3 dev work begins.
-
----
-
-### Stage 4 — Resend (notifications)
-
-- [ ] **Create Resend free-tier account** at https://resend.com
-  - Free: 3,000 emails/mo, 100/day
-- [ ] **Verify a sender domain** (or use Resend's `onboarding@resend.dev` for testing)
-- [ ] **Add `RESEND_API_KEY` to Vercel** (Preview + Production)
-
-**When:** Before Stage 4 dev work begins.
-
----
-
-### Stage 5 — Clerk (auth)
-
-- [ ] **Create Clerk free-tier project** at https://clerk.com
-  - Free: 10,000 MAU
-- [ ] **Add `CLERK_PUBLISHABLE_KEY` + `CLERK_SECRET_KEY` to Vercel** (Preview + Production)
-
-**When:** Before Stage 5 dev work begins. Stages 1–4 use a single-user stub (`STUB_USER_ID = "stub-user-1"`); no auth needed for those.
-
----
-
-### Convenience (non-blocking but unlocks better verification)
-
-- [ ] **Install Vercel CLI locally** — `npm i -g vercel`
-
-**Why:** Lets PM_CLAUDE verify Vercel preview deploys, pull env vars locally, run `vercel logs` against running deployments, check function execution times. Right now PM_CLAUDE trusts the git integration blindly — fine for Stage 0 but increasingly useful as functions, crons, and AI Gateway calls go live in later stages.
-
-**When:** Whenever convenient.
+_(none open at the moment — all stage 1–5 secrets and tooling are wired)_
 
 ---
 
 ## Resolved (for the record)
 
+- [x] **2026-05-06** — Stage 5 (Clerk) keys provisioned. Created Clerk free-tier project; added `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` to Vercel `wildfire-nowcast` (Preview + Production). Verified via `vercel env ls`.
+- [x] **2026-05-06** — Stage 4 (Resend) key provisioned. `RESEND_API_KEY` on Vercel (Preview + Production). Sender-domain verification deferred until Stage 4 dev work — `onboarding@resend.dev` is fine for testing.
+- [x] **2026-05-06** — Stage 3 (Vercel AI Gateway) key provisioned. `AI_GATEWAY_API_KEY` on Vercel (Preview + Production).
+- [x] **2026-05-06** — Stage 2 (`CRON_SECRET`) provisioned on both Vercel (Preview + Production) and as a GitHub Actions repository secret. Cron `schedule:` un-commented in `.github/workflows/firms-poll.yml` in the same chore PR that recorded this resolution.
+- [x] **2026-05-06** — Stage 2 (Docker) confirmed running locally for spatial-integration tests. Docker Engine 29.4.1.
+- [x] **2026-05-06** — Stage 1 (Neon Postgres) provisioned. `DATABASE_URL` on Vercel `wildfire-nowcast` (Preview + Production), pooled connection string. Verified via `vercel env ls`.
+- [x] **2026-05-06** — Vercel CLI installed locally and project linked (`vanyoivanov98-2068s-projects/wildfire-nowcast`). PM_CLAUDE can now run `vercel env ls`, `vercel logs`, `vercel env pull` to verify deploys directly instead of trusting the git integration blindly.
+- [x] **2026-05-06** — Stage 7 (cutover) PR #386 merged. Legacy stack removed; `loop.md` + `.claude/agents/` harness landed on `master`. Pivot now operates as the trunk.
 - [x] **2026-04-22** — `FIRMS_MAP_KEY` moved from Railway → Vercel env vars. Confirmed by Vanyo.
 - [x] **2026-04-21** — `.claude/pm/` → `pm/` move. Vanyo's global gitignore excluded `.claude/`; resolved by moving PM workspace to a project-native path.


### PR DESCRIPTION
Three small follow-ups after PR #386 landed and Vanyo wired the remaining secrets.

## Changes

- **`.github/workflows/firms-poll.yml`** — un-comment the `schedule:` trigger. Now that `CRON_SECRET` is provisioned on both Vercel and GitHub Actions, the every-15-min cron can run without 401-storming.
- **`.env.example`** — rename Clerk publishable key to `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` to match the Next.js convention (and the variable Vanyo actually wired on Vercel).
- **`pm/blockers.md`** — reconcile. All Stage 1–5 external dependencies are provisioned. Active section is empty; resolutions recorded with today's date.

## Verification

- `vercel env ls production` and `... preview` confirm: `DATABASE_URL`, `CRON_SECRET`, `AI_GATEWAY_API_KEY`, `RESEND_API_KEY`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `FIRMS_MAP_KEY` are all on both Preview + Production.
- `gh secret list` confirms `CRON_SECRET` is on the repo.
- `docker version` returns 29.4.1 client + server (local spatial integration tests will run).
- `vercel link` linked this repo to `vanyoivanov98-2068s-projects/wildfire-nowcast`.

## Out of scope (not in this PR)

- Strip stale `VITE_API_BASE_URL` and `VITE_API_PUBLIC_BASE_URL` from Vercel — flagged for a future scout chore.
- Strip Python entries from `.gitignore` — flagged for a future scout chore.

agent: cutover

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>