### PR TITLE
chore: demote four unused lib/ exports to module-private

### DIFF
--- a/lib/api/handlers.ts
+++ b/lib/api/handlers.ts
@@ -55,7 +55,7 @@ export async function parseJson<T>(
   return { ok: true, value: parsed.data };
 }
 
-export function mapDomainError(err: unknown): NextResponse<ApiErrorBody> {
+function mapDomainError(err: unknown): NextResponse<ApiErrorBody> {
   if (err instanceof ZodError) return zodErrorResponse(err);
   if (err instanceof AoiNotFoundError) {
     return apiError("not_found", err.message);

--- a/lib/db/aoi-repository.ts
+++ b/lib/db/aoi-repository.ts
@@ -25,7 +25,7 @@ import { regionBucketFromLonLat } from "@/lib/geo/region-bucket";
 import type { PolygonalGeom } from "@/lib/validators/geojson";
 import type { RulesUpsert } from "@/lib/validators/aoi";
 
-export const MAX_AREA_HA = 100_000;
+const MAX_AREA_HA = 100_000;
 
 export class AoiAreaTooLargeError extends Error {
   constructor(public readonly areaHa: number) {

--- a/lib/validators/geojson.ts
+++ b/lib/validators/geojson.ts
@@ -30,12 +30,12 @@ const linearRing = z
 
 const polygonRings = z.array(linearRing).min(1);
 
-export const polygonSchema = z.object({
+const polygonSchema = z.object({
   type: z.literal("Polygon"),
   coordinates: polygonRings,
 });
 
-export const multiPolygonSchema = z.object({
+const multiPolygonSchema = z.object({
   type: z.literal("MultiPolygon"),
   coordinates: z.array(polygonRings).min(1),
 });


### PR DESCRIPTION
agent: scout

## What and why

Four symbols in `lib/` are declared `export` but referenced only from inside their own module. Demoting them to module-private clarifies the public surface of `lib/api`, `lib/validators`, and `lib/db` and removes false signal that external consumers exist.

| File | Symbol | Only caller |
|---|---|---|
| `lib/api/handlers.ts` | `mapDomainError` | `withDb` in same file |
| `lib/validators/geojson.ts` | `polygonSchema` | `polygonalGeomSchema` discriminated union, same file |
| `lib/validators/geojson.ts` | `multiPolygonSchema` | `polygonalGeomSchema` discriminated union, same file |
| `lib/db/aoi-repository.ts` | `MAX_AREA_HA` | `AoiAreaTooLargeError` + `createAoi`, same file |

Verified with `grep -rE "import .*\{[^}]*\b<sym>\b"` across `*.ts`/`*.tsx` — zero import sites for any of the four.

## Risk

Worst case if this ships unnoticed: a future caller in another module that wanted to import one of these symbols would see a TypeScript error and either re-export it or duplicate the value. There is no runtime behaviour change. No API contract, no schema, no migration touched.

## Verification (local, Windows + pnpm 10.30.0)

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test` — 69/69 passed across 12 files
- `pnpm build` — successful (5 routes generated)

## Diff size

3 files, +4 / -4 lines.