### PR TITLE
chore: pin Vercel framework to nextjs (unblocks 3 PRs)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "outputDirectory": ".next"
 }


### PR DESCRIPTION
## Summary

Vercel preview deploys on every open PR are failing with \`No Output Directory named "dist" found\` — Vercel's project Build & Development Settings still carry a Vite/\`ui\` Framework Preset from the pre-cutover stack. Auto-detection isn't overriding it despite \`next.config.ts\` at the repo root.

This minimal \`vercel.json\` (schema hint + \`"framework": "nextjs"\`) pins the framework in-code, overrides the sticky dashboard setting, and survives future mis-clicks. No new dependencies.

agent: orchestrator

## Why pinning in code instead of fixing the dashboard

- Survives if anyone re-clicks the wrong preset later.
- Doesn't require Vanyo to log into Vercel for what's a 4-line repo change.
- Recommended by Vercel's current platform docs (the longer-term form is \`vercel.ts\`, but that adds a dependency and an exclusion-list trip — the JSON form is the right minimum here).

## Currently blocking

- [#388](https://github.com/Ent7opy/wildfire-nowcast/pull/388) — Stage 3 brief generation (LGTM'd, gated on Vanyo per ADR 0006)
- [#389](https://github.com/Ent7opy/wildfire-nowcast/pull/389) — pm chore (blockers reconciliation + Stage 3 brief)
- [#390](https://github.com/Ent7opy/wildfire-nowcast/pull/390) — dead-export cleanup (LGTM'd)

All three should turn green on their next preview rebuild after this lands.

## Verification

- \`pnpm typecheck\` ✅
- \`pnpm lint\` ✅
- \`pnpm build\` ✅ (Next.js 16 build completes, route table includes existing API routes)
- \`pnpm test\` not run on this branch — diff is config-only, no test impact

## Out of scope

- Migrating to \`vercel.ts\` (per platform's preferred direction). That adds \`@vercel/config\` to deps and trips the auto-merge exclusion list. Defer to a future scout slot if Vanyo wants the upgrade.
- Fixing the upstream Vercel project dashboard preset to match. \`vercel.json\` should override it; if it doesn't, that's a follow-up.