### PR TITLE
Stage 4: notification dispatch via Resend

### DIFF
--- a/app/api/aoi/poll/route.ts
+++ b/app/api/aoi/poll/route.ts
@@ -37,6 +37,7 @@ import {
 import { bucketToBbox, getActiveBuckets } from "@/lib/firms/buckets";
 import { matchDetectionsToAois } from "@/lib/firms/matcher";
 import { generateBriefForEvent, type GenerateOutcome } from "@/lib/ai/generate";
+import { dispatchBrief, type DispatchOutcome } from "@/lib/notify/dispatch";
 
 // Test-only injection point: lets the integration suite bypass the live
 // FIRMS call without introducing a DI framework. Production leaves it null.
@@ -56,6 +57,14 @@ type BriefGenFn = typeof generateBriefForEvent;
 let testBriefGen: BriefGenFn | null = null;
 export function _setTestBriefGen(fn: BriefGenFn | null): void {
   testBriefGen = fn;
+}
+
+// Test-only injection point for the notification dispatcher. Production calls
+// the real `dispatchBrief` which dials Resend.
+type NotifyDispatchFn = typeof dispatchBrief;
+let testNotifyDispatch: NotifyDispatchFn | null = null;
+export function _setTestNotifyDispatch(fn: NotifyDispatchFn | null): void {
+  testNotifyDispatch = fn;
 }
 
 // Hobby max function duration is 60s; we configure to that ceiling so a slow
@@ -93,6 +102,12 @@ type BucketRunOutcome = {
    * either generated a brief or there were no events.
    */
   briefSkipReason: Record<string, string>;
+  /** Stage 4: count of `notifications_log` rows with status='sent' from this bucket. */
+  notificationsSent: number;
+  notificationsFailed: number;
+  notificationsSkipped: number;
+  /** True if any dispatch returned `config_missing` (RESEND_API_KEY unset). */
+  notificationConfigMissing: boolean;
   durationMs: number;
   status: "ok" | "partial" | "error";
   error?: string;
@@ -184,6 +199,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   let totalEventsCreated = 0;
   let totalFirmsCalls = 0;
   let totalBriefsGenerated = 0;
+  let totalNotificationsSent = 0;
+  let anyConfigMissing = false;
 
   for (const bucket of buckets) {
     const outcome = await runOneBucket(db, bucket, source);
@@ -191,7 +208,15 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     totalDetectionsInserted += outcome.detectionsInserted;
     totalEventsCreated += outcome.eventsCreated;
     totalBriefsGenerated += outcome.briefsGenerated;
+    totalNotificationsSent += outcome.notificationsSent;
+    if (outcome.notificationConfigMissing) anyConfigMissing = true;
     totalFirmsCalls += 1;
+  }
+
+  if (anyConfigMissing) {
+    console.warn(
+      "[poll] RESEND_API_KEY unset; brief generation succeeded but no emails dispatched.",
+    );
   }
 
   const partial = runs.some((r) => r.status !== "ok");
@@ -206,6 +231,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     detectionsInserted: totalDetectionsInserted,
     eventsCreated: totalEventsCreated,
     briefsGenerated: totalBriefsGenerated,
+    notificationsSent: totalNotificationsSent,
     finishedAt: new Date(),
   });
 
@@ -215,6 +241,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     source,
     bucketCount: buckets.length,
     totalBriefsGenerated,
+    totalNotificationsSent,
   });
 }
 
@@ -249,6 +276,10 @@ async function runOneBucket(
         eventsUpdated: 0,
         briefsGenerated: 0,
         briefSkipReason: {},
+        notificationsSent: 0,
+        notificationsFailed: 0,
+        notificationsSkipped: 0,
+        notificationConfigMissing: false,
         durationMs: Date.now() - start,
         status: "error",
         error: `${fetchResult.code}: ${fetchResult.message}`,
@@ -264,6 +295,7 @@ async function runOneBucket(
     let briefsGenerated = 0;
     const briefSkipReason: Record<string, string> = {};
     let briefError: string | null = null;
+    const generatedBriefIds: string[] = [];
     const briefGen = testBriefGen ?? generateBriefForEvent;
     for (const eventId of matchOutcome.createdEventIds) {
       let outcome: GenerateOutcome;
@@ -278,11 +310,34 @@ async function runOneBucket(
       }
       if (outcome.status === "generated") {
         briefsGenerated += 1;
+        if (outcome.briefId) generatedBriefIds.push(outcome.briefId);
       } else if (outcome.status === "skipped") {
         briefSkipReason[eventId] = outcome.reason;
       } else {
         briefSkipReason[eventId] = `error: ${outcome.reason}`;
         briefError = outcome.reason;
+      }
+    }
+
+    let notificationsSent = 0;
+    let notificationsFailed = 0;
+    let notificationsSkipped = 0;
+    let notificationConfigMissing = false;
+    const dispatcher = testNotifyDispatch ?? dispatchBrief;
+    for (const briefId of generatedBriefIds) {
+      let outcome: DispatchOutcome;
+      try {
+        outcome = await dispatcher(db, briefId);
+      } catch (err) {
+        notificationsFailed += 1;
+        briefError = briefError ?? errMessage(err);
+        continue;
+      }
+      for (const a of outcome.attempts) {
+        if (a.status === "sent") notificationsSent += 1;
+        else if (a.status === "failed") notificationsFailed += 1;
+        else if (a.status === "config_missing") notificationConfigMissing = true;
+        else notificationsSkipped += 1;
       }
     }
 
@@ -295,6 +350,7 @@ async function runOneBucket(
       detectionsInserted: matchOutcome.detectionsInserted,
       eventsCreated: matchOutcome.eventsCreated,
       briefsGenerated,
+      notificationsSent,
       finishedAt: new Date(),
     });
 
@@ -308,6 +364,10 @@ async function runOneBucket(
       eventsUpdated: matchOutcome.eventsUpdated,
       briefsGenerated,
       briefSkipReason,
+      notificationsSent,
+      notificationsFailed,
+      notificationsSkipped,
+      notificationConfigMissing,
       durationMs: Date.now() - start,
       status,
       error: briefError ?? undefined,
@@ -329,6 +389,10 @@ async function runOneBucket(
       eventsUpdated: 0,
       briefsGenerated: 0,
       briefSkipReason: {},
+      notificationsSent: 0,
+      notificationsFailed: 0,
+      notificationsSkipped: 0,
+      notificationConfigMissing: false,
       durationMs: Date.now() - start,
       status: "error",
       error: errMessage(err),
@@ -365,6 +429,7 @@ type CloseArgs = {
   detectionsInserted?: number;
   eventsCreated?: number;
   briefsGenerated?: number;
+  notificationsSent?: number;
 };
 
 async function closeJobRun(
@@ -382,7 +447,8 @@ async function closeJobRun(
       "firms_request_count" = COALESCE("firms_request_count", 0) + ${args.firmsRequestCount ?? 0},
       "detections_inserted" = COALESCE("detections_inserted", 0) + ${args.detectionsInserted ?? 0},
       "events_created" = COALESCE("events_created", 0) + ${args.eventsCreated ?? 0},
-      "briefs_generated" = COALESCE("briefs_generated", 0) + ${args.briefsGenerated ?? 0}
+      "briefs_generated" = COALESCE("briefs_generated", 0) + ${args.briefsGenerated ?? 0},
+      "notifications_sent" = COALESCE("notifications_sent", 0) + ${args.notificationsSent ?? 0}
     WHERE "id" = ${id}
   `);
 }

--- a/db/migrations/0003_stage4.sql
+++ b/db/migrations/0003_stage4.sql
@@ -1,0 +1,40 @@
+-- Stage 4 — A' pivot: notification dispatch (Resend).
+--
+-- Adds the `notifications_log` table (one row per send attempt, idempotent
+-- per (brief, channel, target) when the prior outcome was `sent`/`skipped`),
+-- plus `aoi_briefs.last_notified_at` and `job_runs.notifications_sent` for
+-- observability.
+--
+-- Authoritative source: docs/pivot-architecture.md §3.7 `notifications_log`.
+-- Spec: docs/SPEC-A-prime-v1.md §Data model `notifications` row shape.
+
+CREATE TABLE IF NOT EXISTS "notifications_log" (
+    "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "aoi_id" UUID NOT NULL REFERENCES "aois"("id") ON DELETE CASCADE,
+    "brief_id" UUID NOT NULL REFERENCES "aoi_briefs"("id") ON DELETE CASCADE,
+    "channel" TEXT NOT NULL,
+    "target" TEXT NOT NULL,
+    "target_hash" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "provider_message_id" TEXT,
+    "error" TEXT,
+    "skip_reason" TEXT,
+    "sent_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Idempotency: re-running the dispatcher for the same (brief, channel, target)
+-- after a successful send or a deliberate skip is a no-op. Failed rows are
+-- excluded so the next poll naturally retries.
+CREATE UNIQUE INDEX IF NOT EXISTS "notifications_log_brief_channel_target_uniq"
+    ON "notifications_log" ("brief_id", "channel", "target_hash")
+    WHERE "status" IN ('sent', 'skipped');
+
+-- Rate-limit lookup index per spec §3.7.
+CREATE INDEX IF NOT EXISTS "notifications_log_aoi_target_recent"
+    ON "notifications_log" ("aoi_id", "target_hash", "sent_at" DESC);
+
+ALTER TABLE "aoi_briefs"
+    ADD COLUMN IF NOT EXISTS "last_notified_at" TIMESTAMPTZ;
+
+ALTER TABLE "job_runs"
+    ADD COLUMN IF NOT EXISTS "notifications_sent" INTEGER NOT NULL DEFAULT 0;

--- a/db/migrations/0003_stage4.test.sql
+++ b/db/migrations/0003_stage4.test.sql
@@ -1,0 +1,33 @@
+-- Stage 4 — PGlite-compatible variant of 0003_stage4.sql.
+--
+-- Identical to the production DDL: `notifications_log` is a non-spatial
+-- table, so there is nothing PostGIS-specific to strip. Kept as a separate
+-- file so the PGlite harness can apply migrations in the same numbered
+-- order as Neon.
+
+CREATE TABLE IF NOT EXISTS "notifications_log" (
+    "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "aoi_id" UUID NOT NULL REFERENCES "aois"("id") ON DELETE CASCADE,
+    "brief_id" UUID NOT NULL REFERENCES "aoi_briefs"("id") ON DELETE CASCADE,
+    "channel" TEXT NOT NULL,
+    "target" TEXT NOT NULL,
+    "target_hash" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "provider_message_id" TEXT,
+    "error" TEXT,
+    "skip_reason" TEXT,
+    "sent_at" TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "notifications_log_brief_channel_target_uniq"
+    ON "notifications_log" ("brief_id", "channel", "target_hash")
+    WHERE "status" IN ('sent', 'skipped');
+
+CREATE INDEX IF NOT EXISTS "notifications_log_aoi_target_recent"
+    ON "notifications_log" ("aoi_id", "target_hash", "sent_at" DESC);
+
+ALTER TABLE "aoi_briefs"
+    ADD COLUMN IF NOT EXISTS "last_notified_at" TIMESTAMPTZ;
+
+ALTER TABLE "job_runs"
+    ADD COLUMN IF NOT EXISTS "notifications_sent" INTEGER NOT NULL DEFAULT 0;

--- a/db/schema/index.ts
+++ b/db/schema/index.ts
@@ -9,9 +9,8 @@
  *   - Stage 2: `firms_detections`, `aoi_events`, `industrial_mask_static`,
  *              `job_runs` — FIRMS poll + AOI matcher + cron observability.
  *   - Stage 3: `aoi_briefs` + `aoi_events.last_brief_at` — LLM situation briefs.
- *
- * DEFERRED to later stages (intentionally omitted here):
- *   - `notifications_log`    → Stage 4 (Resend + webhook delivery)
+ *   - Stage 4: `notifications_log` + `aoi_briefs.last_notified_at` +
+ *              `job_runs.notifications_sent` — Resend email dispatch.
  *
  * Single-user stub: until Clerk lands in Stage 5, every API call is attributed
  * to STUB_USER_ID = "stub-user-1". The migration seeds that single row.
@@ -250,7 +249,44 @@ export const aoiBriefs = pgTable("aoi_briefs", {
   latencyMs: integer("latency_ms"),
   shareToken: text("share_token"),
   shareExpiresAt: timestamp("share_expires_at", { withTimezone: true }),
+  /** Set when Stage 4's dispatcher records the first successful send. */
+  lastNotifiedAt: timestamp("last_notified_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+/**
+ * Stage 4 — one row per send attempt produced by the notification dispatcher.
+ *
+ * Idempotency lives in the partial unique index on
+ * `(brief_id, channel, target_hash) WHERE status IN ('sent', 'skipped')` —
+ * declared in the SQL migration, not via Drizzle's index DSL (the partial
+ * `WHERE` clause syntax is hand-authored in `0003_stage4.sql`).
+ */
+export const notificationsLog = pgTable("notifications_log", {
+  id: uuid("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  aoiId: uuid("aoi_id")
+    .notNull()
+    .references(() => aois.id, { onDelete: "cascade" }),
+  briefId: uuid("brief_id")
+    .notNull()
+    .references(() => aoiBriefs.id, { onDelete: "cascade" }),
+  /** "email" for v1; "webhook" reserved (always recorded as skipped). */
+  channel: text("channel").notNull(),
+  /** Plaintext recipient (operator-readable). */
+  target: text("target").notNull(),
+  /** sha256(target) — rate-limit key per spec §3.7. */
+  targetHash: text("target_hash").notNull(),
+  /** "sent" | "failed" | "skipped" | "config_missing". */
+  status: text("status").notNull(),
+  providerMessageId: text("provider_message_id"),
+  error: text("error"),
+  /** "channel_not_implemented" | "paused" | "quiet_hours" | "duplicate". */
+  skipReason: text("skip_reason"),
+  sentAt: timestamp("sent_at", { withTimezone: true })
     .notNull()
     .defaultNow(),
 });
@@ -287,6 +323,8 @@ export const jobRuns = pgTable("job_runs", {
   eventsCreated: integer("events_created").notNull().default(0),
   /** Stage 3: count of `aoi_briefs` rows produced by this run. */
   briefsGenerated: integer("briefs_generated").notNull().default(0),
+  /** Stage 4: count of notification rows with status='sent' from this run. */
+  notificationsSent: integer("notifications_sent").notNull().default(0),
   error: text("error"),
 });
 
@@ -294,3 +332,4 @@ export type FirmsDetectionRow = typeof firmsDetections.$inferSelect;
 export type AoiEventRow = typeof aoiEvents.$inferSelect;
 export type JobRunRow = typeof jobRuns.$inferSelect;
 export type AoiBriefRow = typeof aoiBriefs.$inferSelect;
+export type NotificationsLogRow = typeof notificationsLog.$inferSelect;

--- a/db/test/pglite.ts
+++ b/db/test/pglite.ts
@@ -19,6 +19,7 @@ const MIGRATIONS = [
   "0000_init.test.sql",
   "0001_stage2.test.sql",
   "0002_stage3.test.sql",
+  "0003_stage4.test.sql",
 ] as const;
 
 let cachedDDL: string | null = null;

--- a/db/test/testcontainer.ts
+++ b/db/test/testcontainer.ts
@@ -79,7 +79,8 @@ async function loadMigrations(): Promise<string> {
   const stage1 = await readFile(join(dir, "0000_init.sql"), "utf8");
   const stage2 = await readFile(join(dir, "0001_stage2.sql"), "utf8");
   const stage3 = await readFile(join(dir, "0002_stage3.sql"), "utf8");
-  return [stage1, stage2, stage3].join("\n");
+  const stage4 = await readFile(join(dir, "0003_stage4.sql"), "utf8");
+  return [stage1, stage2, stage3, stage4].join("\n");
 }
 
 /**

--- a/lib/notify/dispatch.ts
+++ b/lib/notify/dispatch.ts
@@ -1,0 +1,480 @@
+/**
+ * Stage 4 notification dispatcher.
+ *
+ * Single entry point: `dispatchBrief(db, briefId, deps?)`. Called once per
+ * brief that Stage 3 just persisted.
+ *
+ * Steps (mirrors `pm/briefs/18-stage4-notification-dispatch.md` §Dispatcher):
+ *   1. Load brief + AOI + rules + user email.
+ *   2. Resolve channels (rules.notify_channels, fallback to users.email).
+ *   3. Per-channel: idempotency check → pause/quiet-hours gate → send → persist.
+ *
+ * Webhook channels are persisted as `skipped, channel_not_implemented`
+ * (Stage 6 owns Slack/Discord delivery). RESEND_API_KEY missing →
+ * persisted as `config_missing`; the route warns once per poll.
+ *
+ * Two-backend repository pattern: every SQL touched is non-spatial and runs
+ * identically on Neon+PostGIS and PGlite.
+ */
+import { createHash } from "node:crypto";
+import { sql } from "drizzle-orm";
+import type { AppDb } from "@/lib/db/client";
+import { sendEmail, type SendResult } from "./resend";
+
+export type DispatchAttempt =
+  | { status: "sent"; channel: string; target: string; providerMessageId: string }
+  | { status: "failed"; channel: string; target: string; error: string }
+  | { status: "skipped"; channel: string; target: string; reason: string }
+  | { status: "config_missing"; channel: string; target: string };
+
+export type DispatchOutcome = {
+  briefId: string;
+  attempts: DispatchAttempt[];
+};
+
+export type DispatchDeps = {
+  send?: (args: {
+    to: string;
+    subject: string;
+    markdown: string;
+  }) => Promise<SendResult>;
+  now?: Date;
+};
+
+type LoadedBrief = {
+  briefId: string;
+  aoiId: string;
+  aoiName: string;
+  renderedMarkdown: string;
+  summary: string;
+  pausedUntil: Date | null;
+  quietHours: { tz: string; startHour: number; endHour: number } | null;
+  notifyChannels: Array<
+    | { type: "email"; target: string }
+    | { type: "webhook"; target: string }
+  >;
+  userEmail: string | null;
+};
+
+export async function dispatchBrief(
+  db: AppDb,
+  briefId: string,
+  deps: DispatchDeps = {},
+): Promise<DispatchOutcome> {
+  const loaded = await loadBrief(db, briefId);
+  if (!loaded) {
+    return { briefId, attempts: [] };
+  }
+
+  const now = deps.now ?? new Date();
+  const send = deps.send ?? ((a) => sendEmail(a));
+
+  const channels = resolveChannels(loaded);
+  const attempts: DispatchAttempt[] = [];
+  let firstSuccessRecorded = false;
+
+  for (const ch of channels) {
+    if (ch.type === "webhook") {
+      await persistAttempt(db, {
+        aoiId: loaded.aoiId,
+        briefId,
+        channel: "webhook",
+        target: ch.target,
+        status: "skipped",
+        skipReason: "channel_not_implemented",
+      });
+      attempts.push({
+        status: "skipped",
+        channel: "webhook",
+        target: ch.target,
+        reason: "channel_not_implemented",
+      });
+      continue;
+    }
+
+    const target = ch.target;
+    const targetHash = sha256(target);
+
+    const existing = await findExistingTerminalRow(db, briefId, "email", targetHash);
+    if (existing) {
+      attempts.push({
+        status: "skipped",
+        channel: "email",
+        target,
+        reason: "duplicate",
+      });
+      continue;
+    }
+
+    if (loaded.pausedUntil && loaded.pausedUntil.getTime() > now.getTime()) {
+      await persistAttempt(db, {
+        aoiId: loaded.aoiId,
+        briefId,
+        channel: "email",
+        target,
+        targetHash,
+        status: "skipped",
+        skipReason: "paused",
+      });
+      attempts.push({
+        status: "skipped",
+        channel: "email",
+        target,
+        reason: "paused",
+      });
+      continue;
+    }
+
+    // TODO Stage 6: hold + release as a morning digest at the top of the
+    // quiet window per US-2 acceptance #3. Stage 4 is skip-only.
+    if (loaded.quietHours && inQuietHours(now, loaded.quietHours)) {
+      await persistAttempt(db, {
+        aoiId: loaded.aoiId,
+        briefId,
+        channel: "email",
+        target,
+        targetHash,
+        status: "skipped",
+        skipReason: "quiet_hours",
+      });
+      attempts.push({
+        status: "skipped",
+        channel: "email",
+        target,
+        reason: "quiet_hours",
+      });
+      continue;
+    }
+
+    const subject = buildSubject(loaded.summary);
+    const result = await send({
+      to: target,
+      subject,
+      markdown: loaded.renderedMarkdown,
+    });
+
+    if (!result.ok && result.code === "config_missing") {
+      await persistAttempt(db, {
+        aoiId: loaded.aoiId,
+        briefId,
+        channel: "email",
+        target,
+        targetHash,
+        status: "config_missing",
+      });
+      attempts.push({ status: "config_missing", channel: "email", target });
+      continue;
+    }
+
+    if (!result.ok) {
+      await persistAttempt(db, {
+        aoiId: loaded.aoiId,
+        briefId,
+        channel: "email",
+        target,
+        targetHash,
+        status: "failed",
+        error: truncate(`${result.code}: ${result.message}`, 500),
+      });
+      attempts.push({
+        status: "failed",
+        channel: "email",
+        target,
+        error: `${result.code}: ${result.message}`,
+      });
+      continue;
+    }
+
+    const updateLastNotified = !firstSuccessRecorded;
+    await persistSuccess(db, {
+      aoiId: loaded.aoiId,
+      briefId,
+      target,
+      targetHash,
+      providerMessageId: result.providerMessageId,
+      updateLastNotified,
+    });
+    firstSuccessRecorded = true;
+    attempts.push({
+      status: "sent",
+      channel: "email",
+      target,
+      providerMessageId: result.providerMessageId,
+    });
+  }
+
+  return { briefId, attempts };
+}
+
+function resolveChannels(loaded: LoadedBrief): Array<
+  | { type: "email"; target: string }
+  | { type: "webhook"; target: string }
+> {
+  if (loaded.notifyChannels.length > 0) return loaded.notifyChannels;
+  if (loaded.userEmail) {
+    return [{ type: "email", target: loaded.userEmail }];
+  }
+  return [];
+}
+
+function buildSubject(summary: string): string {
+  return truncate(summary, 90);
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max);
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+/**
+ * Quiet-hours check — straightforward [startHour, endHour) window in the
+ * configured tz. Wraparound (e.g. start=22, end=7) is supported via OR.
+ *
+ * Uses `Intl.DateTimeFormat` to read the hour in the AOI's tz; this is the
+ * same tz handling the Stage 6 digest will need, kept tiny for Stage 4.
+ */
+export function inQuietHours(
+  now: Date,
+  qh: { tz: string; startHour: number; endHour: number },
+): boolean {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: qh.tz,
+    hour: "numeric",
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(now);
+  const hourPart = parts.find((p) => p.type === "hour");
+  if (!hourPart) return false;
+  const hour = Number(hourPart.value) % 24;
+  if (qh.startHour === qh.endHour) return false;
+  if (qh.startHour < qh.endHour) {
+    return hour >= qh.startHour && hour < qh.endHour;
+  }
+  return hour >= qh.startHour || hour < qh.endHour;
+}
+
+// ---------------------------------------------------------------------------
+// DB load / persist
+
+async function loadBrief(db: AppDb, briefId: string): Promise<LoadedBrief | null> {
+  const result = (await db.execute(sql`
+    SELECT
+      b."id"                AS brief_id,
+      b."aoi_id"            AS aoi_id,
+      b."rendered_markdown" AS rendered_markdown,
+      b."payload"           AS payload,
+      a."name"              AS aoi_name,
+      a."user_id"           AS user_id,
+      r."paused_until"      AS paused_until,
+      r."quiet_hours"       AS quiet_hours,
+      r."notify_channels"   AS notify_channels,
+      u."email"             AS user_email
+    FROM "aoi_briefs" b
+    JOIN "aois" a       ON a."id" = b."aoi_id"
+    LEFT JOIN "aoi_rules" r ON r."aoi_id" = b."aoi_id"
+    LEFT JOIN "users" u     ON u."id" = a."user_id"
+    WHERE b."id" = ${briefId}
+    LIMIT 1
+  `)) as unknown as { rows?: Array<Record<string, unknown>> };
+  const rows = (result.rows ??
+    (result as unknown as Array<Record<string, unknown>>)) as Array<
+    Record<string, unknown>
+  >;
+  const row = rows[0];
+  if (!row) return null;
+
+  const payload = row.payload as { summary?: string } | string | null;
+  let summary = "";
+  if (typeof payload === "string") {
+    try {
+      const parsed = JSON.parse(payload) as { summary?: string };
+      summary = parsed?.summary ?? "";
+    } catch {
+      summary = "";
+    }
+  } else if (payload && typeof payload === "object") {
+    summary = typeof payload.summary === "string" ? payload.summary : "";
+  }
+
+  const channelsRaw = row.notify_channels;
+  const channels = parseChannels(channelsRaw);
+  const quietHours = parseQuietHours(row.quiet_hours);
+
+  return {
+    briefId: String(row.brief_id),
+    aoiId: String(row.aoi_id),
+    aoiName: String(row.aoi_name ?? ""),
+    renderedMarkdown: String(row.rendered_markdown ?? ""),
+    summary,
+    pausedUntil: toDate(row.paused_until),
+    quietHours,
+    notifyChannels: channels,
+    userEmail:
+      typeof row.user_email === "string" && row.user_email.length > 0
+        ? row.user_email
+        : null,
+  };
+}
+
+function parseChannels(
+  raw: unknown,
+): Array<
+  | { type: "email"; target: string }
+  | { type: "webhook"; target: string }
+> {
+  let arr: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      arr = JSON.parse(raw);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(arr)) return [];
+  const out: Array<
+    | { type: "email"; target: string }
+    | { type: "webhook"; target: string }
+  > = [];
+  for (const item of arr) {
+    if (
+      item &&
+      typeof item === "object" &&
+      "type" in item &&
+      "target" in item &&
+      typeof (item as { target: unknown }).target === "string"
+    ) {
+      const t = (item as { type: unknown }).type;
+      const target = (item as { target: string }).target;
+      if (t === "email") out.push({ type: "email", target });
+      else if (t === "webhook") out.push({ type: "webhook", target });
+    }
+  }
+  return out;
+}
+
+function parseQuietHours(
+  raw: unknown,
+): { tz: string; startHour: number; endHour: number } | null {
+  let v: unknown = raw;
+  if (typeof v === "string") {
+    try {
+      v = JSON.parse(v);
+    } catch {
+      return null;
+    }
+  }
+  if (!v || typeof v !== "object") return null;
+  const o = v as { tz?: unknown; startHour?: unknown; endHour?: unknown };
+  if (
+    typeof o.tz === "string" &&
+    typeof o.startHour === "number" &&
+    typeof o.endHour === "number"
+  ) {
+    return { tz: o.tz, startHour: o.startHour, endHour: o.endHour };
+  }
+  return null;
+}
+
+async function findExistingTerminalRow(
+  db: AppDb,
+  briefId: string,
+  channel: string,
+  targetHash: string,
+): Promise<boolean> {
+  const result = (await db.execute(sql`
+    SELECT 1 AS one
+    FROM "notifications_log"
+    WHERE "brief_id" = ${briefId}
+      AND "channel" = ${channel}
+      AND "target_hash" = ${targetHash}
+      AND "status" IN ('sent', 'skipped')
+    LIMIT 1
+  `)) as unknown as { rows?: Array<{ one: number }> };
+  const rows = (result.rows ?? (result as unknown as Array<{ one: number }>)) as Array<{
+    one: number;
+  }>;
+  return rows.length > 0;
+}
+
+type PersistArgs = {
+  aoiId: string;
+  briefId: string;
+  channel: string;
+  target: string;
+  targetHash?: string;
+  status: "sent" | "failed" | "skipped" | "config_missing";
+  providerMessageId?: string;
+  error?: string;
+  skipReason?: string;
+};
+
+async function persistAttempt(db: AppDb, args: PersistArgs): Promise<void> {
+  const targetHash = args.targetHash ?? sha256(args.target);
+  await db.execute(sql`
+    INSERT INTO "notifications_log" (
+      "aoi_id", "brief_id", "channel", "target", "target_hash",
+      "status", "provider_message_id", "error", "skip_reason"
+    ) VALUES (
+      ${args.aoiId},
+      ${args.briefId},
+      ${args.channel},
+      ${args.target},
+      ${targetHash},
+      ${args.status},
+      ${args.providerMessageId ?? null},
+      ${args.error ?? null},
+      ${args.skipReason ?? null}
+    )
+    ON CONFLICT DO NOTHING
+  `);
+}
+
+async function persistSuccess(
+  db: AppDb,
+  args: {
+    aoiId: string;
+    briefId: string;
+    target: string;
+    targetHash: string;
+    providerMessageId: string;
+    updateLastNotified: boolean;
+  },
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`
+      INSERT INTO "notifications_log" (
+        "aoi_id", "brief_id", "channel", "target", "target_hash",
+        "status", "provider_message_id"
+      ) VALUES (
+        ${args.aoiId},
+        ${args.briefId},
+        'email',
+        ${args.target},
+        ${args.targetHash},
+        'sent',
+        ${args.providerMessageId}
+      )
+      ON CONFLICT DO NOTHING
+    `);
+    if (args.updateLastNotified) {
+      await tx.execute(sql`
+        UPDATE "aoi_briefs"
+        SET "last_notified_at" = COALESCE("last_notified_at", now())
+        WHERE "id" = ${args.briefId}
+      `);
+    }
+  });
+}
+
+function toDate(v: unknown): Date | null {
+  if (v == null) return null;
+  if (v instanceof Date) return v;
+  if (typeof v === "string" || typeof v === "number") {
+    const d = new Date(v);
+    return Number.isFinite(d.getTime()) ? d : null;
+  }
+  return null;
+}

--- a/lib/notify/markdown.ts
+++ b/lib/notify/markdown.ts
@@ -1,0 +1,100 @@
+/**
+ * Tiny Markdown→HTML renderer scoped to the brief shape produced by
+ * `lib/ai/render.ts`:
+ *   - `# heading` and `## heading`
+ *   - blank-line paragraphs
+ *   - `- bullet` lists
+ *   - `_italic line_`
+ *   - inline `_..._` italics inside paragraphs
+ *
+ * Why not `marked`: the brief renderer is deterministic and the surface
+ * we need is small. A new dependency for ~50 LOC of escapes + line
+ * folding is heavier than the function itself. This converter is
+ * exercised by the canonical Spring Creek snapshot test.
+ *
+ * HTML escaping: every text node is escaped before structural tags are
+ * emitted, so user-visible content from the brief payload (AOI name,
+ * summary, watch items, etc.) cannot inject markup.
+ */
+
+const ESC: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+export function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ESC[c]);
+}
+
+/** Replace `_text_` with `<em>text</em>`. Applied to already-escaped text. */
+function inlineItalics(escaped: string): string {
+  return escaped.replace(/_([^_\n]+)_/g, "<em>$1</em>");
+}
+
+export function renderMarkdownToHtml(md: string): string {
+  const lines = md.split(/\r?\n/);
+  const out: string[] = [];
+  let i = 0;
+  let inList = false;
+
+  const closeList = () => {
+    if (inList) {
+      out.push("</ul>");
+      inList = false;
+    }
+  };
+
+  while (i < lines.length) {
+    const raw = lines[i];
+    const line = raw.trimEnd();
+
+    if (line === "") {
+      closeList();
+      i += 1;
+      continue;
+    }
+
+    if (line.startsWith("# ")) {
+      closeList();
+      out.push(`<h1>${inlineItalics(escapeHtml(line.slice(2)))}</h1>`);
+      i += 1;
+      continue;
+    }
+    if (line.startsWith("## ")) {
+      closeList();
+      out.push(`<h2>${inlineItalics(escapeHtml(line.slice(3)))}</h2>`);
+      i += 1;
+      continue;
+    }
+    if (line.startsWith("- ")) {
+      if (!inList) {
+        out.push("<ul>");
+        inList = true;
+      }
+      out.push(`<li>${inlineItalics(escapeHtml(line.slice(2)))}</li>`);
+      i += 1;
+      continue;
+    }
+
+    closeList();
+    const paraLines: string[] = [line];
+    i += 1;
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !lines[i].startsWith("#") &&
+      !lines[i].startsWith("- ")
+    ) {
+      paraLines.push(lines[i].trimEnd());
+      i += 1;
+    }
+    const joined = paraLines.join(" ");
+    out.push(`<p>${inlineItalics(escapeHtml(joined))}</p>`);
+  }
+
+  closeList();
+  return out.join("\n");
+}

--- a/lib/notify/resend.ts
+++ b/lib/notify/resend.ts
@@ -1,0 +1,182 @@
+/**
+ * Stage 4 — Resend email client.
+ *
+ * Single function: `sendEmail({ to, from, subject, markdown })` returns a
+ * typed `SendResult`. Mirrors `lib/ai/gateway.ts`:
+ *   - lazy env read (never at import time)
+ *   - `RESEND_API_KEY` unset → `{ ok: false, code: "config_missing" }`
+ *   - no retry-with-backoff (Stage 4 is single-attempt per poll; the next
+ *     poll naturally retries failed rows because the unique idempotency
+ *     index excludes `status = 'failed'`)
+ *
+ * Test mode: `RESEND_TEST_MODE === "1"` rewrites `from` to
+ * `onboarding@resend.dev` and appends `[TEST]` to the subject. Production
+ * `from` defaults to `onboarding@resend.dev` until sender-domain verification
+ * lands (deferred per blocker resolution 2026-05-06).
+ *
+ * Implementation choice (raw fetch vs the resend SDK): raw fetch — fewer
+ * deps, ~30 LOC, and the typed response shape we need is small. Documented
+ * in `pm/research-log/2026-05-06-stage4-notification-dispatch.md`.
+ */
+import { renderMarkdownToHtml } from "./markdown";
+
+export type SendErrCode =
+  | "config_missing"
+  | "rate_limited"
+  | "provider_error"
+  | "validation_failed";
+
+export type SendResult =
+  | { ok: true; providerMessageId: string; latencyMs: number }
+  | { ok: false; code: SendErrCode; message: string; latencyMs: number };
+
+export type SendEmailArgs = {
+  to: string;
+  from?: string;
+  subject: string;
+  markdown: string;
+  html?: string;
+  replyTo?: string;
+};
+
+const DEFAULT_FROM = "onboarding@resend.dev";
+const TEST_FROM = "onboarding@resend.dev";
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+const SUBJECT_MAX = 90;
+
+let loggedSenderOnce = false;
+
+export function buildEnvelope(args: SendEmailArgs): {
+  to: string;
+  from: string;
+  subject: string;
+  text: string;
+  html: string;
+  reply_to?: string;
+} {
+  const testMode = process.env.RESEND_TEST_MODE === "1";
+  const configuredFrom =
+    args.from ?? process.env.NOTIFY_FROM_ADDRESS ?? DEFAULT_FROM;
+  const from = testMode ? TEST_FROM : configuredFrom;
+  const subjectBase = truncate(args.subject, SUBJECT_MAX);
+  const subject = testMode ? `${subjectBase} [TEST]` : subjectBase;
+  const html = args.html ?? renderMarkdownToHtml(args.markdown);
+  const envelope: ReturnType<typeof buildEnvelope> = {
+    to: args.to,
+    from,
+    subject,
+    text: args.markdown,
+    html,
+  };
+  if (args.replyTo) envelope.reply_to = args.replyTo;
+  return envelope;
+}
+
+export function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max);
+}
+
+export async function sendEmail(args: SendEmailArgs): Promise<SendResult> {
+  const apiKey = process.env.RESEND_API_KEY;
+  const startedAt = Date.now();
+  if (!apiKey) {
+    return {
+      ok: false,
+      code: "config_missing",
+      message: "RESEND_API_KEY is not configured",
+      latencyMs: Date.now() - startedAt,
+    };
+  }
+
+  const envelope = buildEnvelope(args);
+
+  if (
+    !loggedSenderOnce &&
+    process.env.RESEND_TEST_MODE !== "1" &&
+    process.env.NOTIFY_FROM_ADDRESS &&
+    process.env.NOTIFY_FROM_ADDRESS !== DEFAULT_FROM
+  ) {
+    loggedSenderOnce = true;
+    console.info(
+      `[notify] Resend sender configured: ${process.env.NOTIFY_FROM_ADDRESS}`,
+    );
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(RESEND_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(envelope),
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      code: "provider_error",
+      message: err instanceof Error ? err.message : String(err),
+      latencyMs: Date.now() - startedAt,
+    };
+  }
+
+  const latencyMs = Date.now() - startedAt;
+  if (res.status === 429) {
+    return {
+      ok: false,
+      code: "rate_limited",
+      message: `Resend rate limited (429)`,
+      latencyMs,
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    body = null;
+  }
+
+  if (!res.ok) {
+    const message =
+      isErrorBody(body) && body.message
+        ? body.message
+        : `Resend HTTP ${res.status}`;
+    const code: SendErrCode = res.status >= 400 && res.status < 500
+      ? "validation_failed"
+      : "provider_error";
+    return { ok: false, code, message, latencyMs };
+  }
+
+  const id = isOkBody(body) ? body.id : null;
+  if (!id) {
+    return {
+      ok: false,
+      code: "provider_error",
+      message: "Resend response missing id",
+      latencyMs,
+    };
+  }
+  return { ok: true, providerMessageId: id, latencyMs };
+}
+
+function isOkBody(b: unknown): b is { id: string } {
+  return (
+    typeof b === "object" &&
+    b !== null &&
+    "id" in b &&
+    typeof (b as { id: unknown }).id === "string" &&
+    (b as { id: string }).id.length > 0
+  );
+}
+
+function isErrorBody(b: unknown): b is { message?: string } {
+  return typeof b === "object" && b !== null;
+}
+
+/** Test-only reset hook for the per-process "logged sender once" flag. */
+export function _resetSenderLogForTests(): void {
+  loggedSenderOnce = false;
+}

--- a/tests/notify/dispatch.test.ts
+++ b/tests/notify/dispatch.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Stage 4 dispatcher unit tests on PGlite.
+ *
+ * Covers every dispatcher branch named in the brief:
+ *   - happy path: one email channel → one `sent` row, last_notified_at set
+ *   - empty notify_channels → fallback to user email
+ *   - duplicate brief on second invocation → skipped/duplicate, no second row
+ *   - paused_until in future → skipped/paused
+ *   - quiet-hours window matches → skipped/quiet_hours
+ *   - webhook channel → skipped/channel_not_implemented
+ *   - send returns config_missing → row written, no last_notified_at update
+ *   - send returns provider_error → row written status=failed, no throw
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { makeFreshTestDb } from "@/db/test/pglite";
+import type { AppDb } from "@/lib/db/client";
+import { dispatchBrief } from "@/lib/notify/dispatch";
+import type { SendResult } from "@/lib/notify/resend";
+import type { PGlite } from "@electric-sql/pglite";
+
+type SeedOpts = {
+  notifyChannels?: Array<
+    | { type: "email"; target: string }
+    | { type: "webhook"; target: string }
+  >;
+  pausedUntil?: Date | null;
+  quietHours?: { tz: string; startHour: number; endHour: number } | null;
+  userEmail?: string;
+  briefSummary?: string;
+};
+
+async function seed(db: AppDb, opts: SeedOpts = {}): Promise<{ aoiId: string; briefId: string }> {
+  const userId = `stub-user-${Math.random().toString(36).slice(2, 8)}`;
+  const userEmail = opts.userEmail ?? "owner@example.org";
+  await db.execute(sql`
+    INSERT INTO "users" (id, email) VALUES (${userId}, ${userEmail})
+  `);
+
+  const polygon = JSON.stringify({
+    type: "Polygon",
+    coordinates: [
+      [[-122.7, 38.4], [-122.6, 38.4], [-122.6, 38.5], [-122.7, 38.5], [-122.7, 38.4]],
+    ],
+  });
+  const aoiRes = (await db.execute(sql`
+    INSERT INTO "aois" (user_id, name, polygon, bbox, centroid, region_bucket, area_ha)
+    VALUES (
+      ${userId}, 'Test Preserve', ${polygon}, ${polygon},
+      ${JSON.stringify({ type: "Point", coordinates: [-122.65, 38.45] })},
+      '5x5:W125_N35', 100
+    ) RETURNING id
+  `)) as unknown as { rows?: Array<{ id: string }> };
+  const aoiRows = (aoiRes.rows ?? (aoiRes as unknown as Array<{ id: string }>)) as Array<{ id: string }>;
+  const aoiId = aoiRows[0].id;
+
+  const channels = opts.notifyChannels ?? [];
+  await db.execute(sql`
+    INSERT INTO "aoi_rules" (aoi_id, distance_buffer_km, min_confidence, min_frp_mw, paused_until, quiet_hours, notify_channels)
+    VALUES (
+      ${aoiId}, 25, 'nominal', 5,
+      ${opts.pausedUntil ? opts.pausedUntil.toISOString() : null},
+      ${opts.quietHours ? JSON.stringify(opts.quietHours) : null}::jsonb,
+      ${JSON.stringify(channels)}::jsonb
+    )
+  `);
+
+  const evRes = (await db.execute(sql`
+    INSERT INTO "aoi_events" (
+      aoi_id, first_seen_at, last_seen_at, nearest_distance_km,
+      detection_count, peak_frp_mw, dedupe_hash, status
+    ) VALUES (
+      ${aoiId}, '2026-04-21T04:00:00Z', '2026-04-21T04:30:00Z',
+      8, 2, 11, ${"hash-" + Math.random().toString(36).slice(2, 10)}, 'new'
+    ) RETURNING id
+  `)) as unknown as { rows?: Array<{ id: string }> };
+  const evRows = (evRes.rows ?? (evRes as unknown as Array<{ id: string }>)) as Array<{ id: string }>;
+  const eventId = evRows[0].id;
+
+  const summary = opts.briefSummary ?? "Spring Creek Preserve fire ~8 km NE of boundary; FRP ~11 MW";
+  const payload = {
+    schema_version: 1,
+    aoi: { id: aoiId, name: "Test Preserve", area_ha: 100 },
+    summary,
+    key_facts: {
+      nearest_detection_km: 8,
+      bearing_from_aoi_deg: 90,
+      wind_dir_deg: null,
+      wind_speed_kmh: null,
+      wind_toward_aoi: null,
+      detection_count_in_window: 2,
+      max_frp_mw: 11,
+      satellites: ["VIIRS_NOAA20_NRT"],
+      window_hours: 24,
+    },
+    context: {
+      weather_note: null,
+      authority_perimeter: { source: null, posted_ts: null, contains_detection: null },
+      prior_events: [],
+    },
+    recommended_watch_items: ["item"],
+    uncertainty: "fixture",
+    next_brief_hint: { when: "next tick", trigger: "fixture" },
+  };
+  const briefRes = (await db.execute(sql`
+    INSERT INTO "aoi_briefs" (
+      aoi_id, event_id, model, gate_reason, payload, rendered_markdown
+    ) VALUES (
+      ${aoiId}, ${eventId}, 'test/stub', 'multi_pixel',
+      ${JSON.stringify(payload)}::jsonb,
+      ${"# Test Preserve — situation brief\n\n" + summary + "\n"}
+    ) RETURNING id
+  `)) as unknown as { rows?: Array<{ id: string }> };
+  const briefRows = (briefRes.rows ?? (briefRes as unknown as Array<{ id: string }>)) as Array<{ id: string }>;
+  return { aoiId, briefId: briefRows[0].id };
+}
+
+async function readNotifications(db: AppDb, briefId: string): Promise<Array<Record<string, unknown>>> {
+  const r = (await db.execute(sql`
+    SELECT * FROM "notifications_log" WHERE "brief_id" = ${briefId} ORDER BY "sent_at" ASC, "status" ASC
+  `)) as unknown as { rows?: Array<Record<string, unknown>> };
+  return (r.rows ?? (r as unknown as Array<Record<string, unknown>>)) as Array<Record<string, unknown>>;
+}
+
+async function readBriefLastNotified(db: AppDb, briefId: string): Promise<Date | string | null> {
+  const r = (await db.execute(sql`
+    SELECT "last_notified_at" FROM "aoi_briefs" WHERE "id" = ${briefId}
+  `)) as unknown as { rows?: Array<{ last_notified_at: Date | string | null }> };
+  const rows = (r.rows ?? (r as unknown as Array<{ last_notified_at: Date | string | null }>)) as Array<{
+    last_notified_at: Date | string | null;
+  }>;
+  return rows[0]?.last_notified_at ?? null;
+}
+
+describe("dispatchBrief — PGlite", () => {
+  let db: AppDb;
+  let pglite: PGlite;
+
+  beforeEach(async () => {
+    ({ db, pglite } = await makeFreshTestDb());
+  });
+
+  afterEach(async () => {
+    await pglite.close();
+  });
+
+  it("happy path — explicit email channel sends and stamps last_notified_at", async () => {
+    const { briefId } = await seed(db, {
+      notifyChannels: [{ type: "email", target: "alice@example.org" }],
+    });
+    const send = async (): Promise<SendResult> => ({
+      ok: true,
+      providerMessageId: "resend-1",
+      latencyMs: 12,
+    });
+    const outcome = await dispatchBrief(db, briefId, { send });
+    expect(outcome.attempts).toHaveLength(1);
+    expect(outcome.attempts[0].status).toBe("sent");
+    const rows = await readNotifications(db, briefId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("sent");
+    expect(rows[0].provider_message_id).toBe("resend-1");
+    expect(await readBriefLastNotified(db, briefId)).not.toBeNull();
+  });
+
+  it("falls back to users.email when notify_channels is empty", async () => {
+    const { briefId } = await seed(db, {
+      notifyChannels: [],
+      userEmail: "fallback@example.org",
+    });
+    const calls: Array<{ to: string }> = [];
+    const send = async (a: { to: string }): Promise<SendResult> => {
+      calls.push({ to: a.to });
+      return { ok: true, providerMessageId: "fallback-1", latencyMs: 1 };
+    };
+    const outcome = await dispatchBrief(db, briefId, { send });
+    expect(calls[0].to).toBe("fallback@example.org");
+    expect(outcome.attempts[0].status).toBe("sent");
+  });
+
+  it("second invocation is skipped/duplicate without writing a second row", async () => {
+    const { briefId } = await seed(db, {
+      notifyChannels: [{ type: "email", target: "dup@example.org" }],
+    });
+    const send = async (): Promise<SendResult> => ({
+      ok: true,
+      providerMessageId: "x",
+      latencyMs: 1,
+    });
+    await dispatchBrief(db, briefId, { send });
+    const second = await dispatchBrief(db, briefId, { send });
+    expect(second.attempts[0].status).toBe("skipped");
+    if (second.attempts[0].status === "skipped") {
+      expect(second.attempts[0].reason).toBe("duplicate");
+    }
+    const rows = await readNotifications(db, briefId);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("paused_until in future → skipped/paused", async () => {
+    const { briefId } = await seed(db, {
+      notifyChannels: [{ type: "email", target: "p@example.org" }],
+      pausedUntil: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    let called = false;
+    const send = async (): Promise<SendResult> => {
+      called = true;
+      return { ok: true, providerMessageId: "x", latencyMs: 1 };
+    };
+    const outcome = await dispatchBrief(db, briefId, { send });
+    expect(called).toBe(false);
+    expect(outcome.attempts[0].status).toBe("skipped");
+    if (outcome.attempts[0].status === "skipped") {
+      expect(outcome.attempts[0].reason).toBe("paused");
+    }
+    const rows = await readNotifications(db, briefId);
+    expect(rows[0].skip_reason).toBe("paused");
+  });
+
+  it("quiet hours window matches → skipped/quiet_hours", async () => {
+    const { briefId } = await seed(db, {
+      notifyChannels: [{ type: "email", target: "q@example.org" }],
+      quietHours: { tz: "America/Los_Angeles", startHour: 0, endHour: 23 },
+    });
+    // 12:00 UTC == 04:00 or 05:00 LA depending on DST, both inside [0,23).
+    const now = new Date("2026-04-21T12:00:00Z");
+    const outcome = await dispatchBrief(db, briefId, {
+      now,
+      send: async () => ({ ok: true, providerMessageId: "x", latencyMs: 1 }),
+    });
+    expect(outcome.attempts[0].status).toBe("skipped");
+    if (outcome.attempts[0].status === "skipped") {
+      expect(outcome.attempts[0].reason).toBe("quiet_hours");
+    }
+  });
+
+  it("webhook channel is recorded as skipped/channel_not_implemented", async () => {
+    const { briefId } = await seed(db, {
+      notifyChannels: [{ type: "webhook", target: "https://example.org/hook" }],
+    });
+    let called = false;
+    const send = async (): Promise<SendResult> => {
+      called = true;
+      return { ok: true, providerMessageId: "x", latencyMs: 1 };
+    };
+    const outcome = await dispatchBrief(db, briefId, { send });
+    expect(called).toBe(false);
+    expect(outcome.attempts).toHaveLength(1);
+    expect(outcome.attempts[0].status).toBe("skipped");
+    const rows = await readNotifications(db, briefId);
+    expect(rows[0].skip_reason).toBe("channel_not_implemented");
+    expect(rows[0].channel).toBe("webhook");
+  });
+
+  it("send returns config_missing → row written; no last_notified_at update", async () => {
+    const { briefId } = await seed(db, {
+      notifyChannels: [{ type: "email", target: "x@example.org" }],
+    });
+    const send = async (): Promise<SendResult> => ({
+      ok: false,
+      code: "config_missing",
+      message: "no key",
+      latencyMs: 0,
+    });
+    const outcome = await dispatchBrief(db, briefId, { send });
+    expect(outcome.attempts[0].status).toBe("config_missing");
+    const rows = await readNotifications(db, briefId);
+    expect(rows[0].status).toBe("config_missing");
+    expect(await readBriefLastNotified(db, briefId)).toBeNull();
+  });
+
+  it("send returns provider_error → row written status=failed; dispatcher does not throw", async () => {
+    const { briefId } = await seed(db, {
+      notifyChannels: [{ type: "email", target: "x@example.org" }],
+    });
+    const send = async (): Promise<SendResult> => ({
+      ok: false,
+      code: "provider_error",
+      message: "boom",
+      latencyMs: 0,
+    });
+    const outcome = await dispatchBrief(db, briefId, { send });
+    expect(outcome.attempts[0].status).toBe("failed");
+    const rows = await readNotifications(db, briefId);
+    expect(rows[0].status).toBe("failed");
+    expect(String(rows[0].error)).toContain("provider_error");
+    expect(await readBriefLastNotified(db, briefId)).toBeNull();
+  });
+});

--- a/tests/notify/poll-to-notify.integration.test.ts
+++ b/tests/notify/poll-to-notify.integration.test.ts
@@ -1,13 +1,13 @@
 /**
- * Stage 3 integration: poll route → matcher → brief generator on a real
- * PostGIS testcontainer. AI Gateway is stubbed via `_setTestBriefGen` so we
- * never hit the live LLM endpoint.
+ * Stage 4 integration: poll route → matcher → brief → notify on a real
+ * PostGIS testcontainer. AI Gateway and Resend are stubbed.
  *
- * Verifies the end-to-end Stage 2 + Stage 3 plumbing:
- *   - a synthetic FIRMS detection becomes an aoi_event
- *   - the brief generator is invoked with the new event id
- *   - aoi_briefs row is persisted with the rendered markdown
- *   - per-bucket outcome reports briefsGenerated=1 and no skip reasons
+ * Verifies:
+ *   - the dispatcher is called for the generated brief
+ *   - notifications_log gets one row with status='sent'
+ *   - aoi_briefs.last_notified_at is populated
+ *   - job_runs.notifications_sent rolls up to 1
+ *   - re-running the poll does not produce a second send (idempotency)
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -37,12 +37,14 @@ const describeIntegration = probe.available ? describe : describe.skip;
 
 if (!probe.available) {
   console.warn(
-    `[integration] Skipping poll-to-brief integration test — Docker not available: ${probe.reason ?? "unknown"}`,
+    `[integration] Skipping poll-to-notify integration test — Docker not available: ${probe.reason ?? "unknown"}`,
   );
 }
 
-describeIntegration("/api/aoi/poll → brief — PostGIS integration", () => {
+describeIntegration("/api/aoi/poll → notify — PostGIS integration", () => {
   let handle: TestcontainerHandle | null = null;
+  let sendCalls: Array<{ to: string; subject: string }> = [];
+  let lastBriefId: string | null = null;
 
   beforeAll(async () => {
     handle = await tryStartPostgisContainer();
@@ -60,17 +62,27 @@ describeIntegration("/api/aoi/poll → brief — PostGIS integration", () => {
       ctx.skip();
       return;
     }
+    sendCalls = [];
+    lastBriefId = null;
+    await handle!.pool.query(`DELETE FROM notifications_log`);
     await handle!.pool.query(`DELETE FROM aoi_briefs`);
     await handle!.pool.query(`DELETE FROM aoi_events`);
     await handle!.pool.query(`DELETE FROM firms_detections`);
     await handle!.pool.query(`DELETE FROM aoi_rules`);
     await handle!.pool.query(`DELETE FROM aois`);
+    await handle!.pool.query(`DELETE FROM users WHERE id <> 'stub-user-1'`);
     await handle!.pool.query(`DELETE FROM job_runs`);
+
+    await handle!.pool.query(
+      `INSERT INTO users (id, email)
+       VALUES ('integ-user-1', 'integration@example.org')
+       ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email`,
+    );
 
     await handle!.pool.query(
       `INSERT INTO aois (user_id, name, polygon, bbox, centroid, region_bucket, area_ha)
        VALUES (
-         'stub-user-1',
+         'integ-user-1',
          'Spring Creek Preserve',
          ST_Multi(ST_SetSRID(ST_GeomFromGeoJSON($1), 4326)),
          ST_SetSRID(ST_Envelope(ST_GeomFromGeoJSON($1)), 4326),
@@ -95,18 +107,19 @@ describeIntegration("/api/aoi/poll → brief — PostGIS integration", () => {
       ],
     );
     await handle!.pool.query(
-      `INSERT INTO aoi_rules (aoi_id, distance_buffer_km, min_confidence, min_frp_mw)
-       SELECT id, 25, 'nominal', 5 FROM aois LIMIT 1`,
+      `INSERT INTO aoi_rules (aoi_id, distance_buffer_km, min_confidence, min_frp_mw, notify_channels)
+       SELECT id, 25, 'nominal', 5, '[{"type":"email","target":"alerts@example.org"}]'::jsonb FROM aois LIMIT 1`,
     );
 
     _setTestDb(handle!.db);
     process.env.CRON_SECRET = "cron-secret";
     process.env.FIRMS_MAP_KEY = "firms-key";
+    process.env.RESEND_API_KEY = "re_test_dummy";
     process.env.DATABASE_URL =
       (handle!.pool.options as { connectionString?: string }).connectionString ?? "";
   });
 
-  it("generates a brief end-to-end for a synthetic detection", async () => {
+  it("dispatches one email per generated brief and is idempotent on second poll", async () => {
     _setTestFirmsFetch(async (): Promise<FirmsFetchResult> => ({
       ok: true,
       source: "VIIRS_NOAA20_NRT",
@@ -157,7 +170,7 @@ describeIntegration("/api/aoi/poll → brief — PostGIS integration", () => {
           name: "Spring Creek Preserve",
           area_ha: 2040,
         },
-        summary: "Stubbed integration brief (fixture).",
+        summary: "Stubbed integration brief.",
         key_facts: {
           nearest_detection_km: 8,
           bearing_from_aoi_deg: 0,
@@ -179,25 +192,43 @@ describeIntegration("/api/aoi/poll → brief — PostGIS integration", () => {
         next_brief_hint: { when: "next tick", trigger: "fixture" },
       };
       const md = renderBriefMarkdown(stub);
-      // Persist via the actual DB pool (mirrors what the real generator does,
-      // minus the AI call) so the integration assertion can hit aoi_briefs.
       const inserted = await handle!.pool.query(
         `INSERT INTO aoi_briefs (aoi_id, event_id, model, gate_reason, payload, rendered_markdown)
          SELECT aoi_id, id, 'test/stub', 'multi_pixel', $1::jsonb, $2 FROM aoi_events WHERE id = $3
+         ON CONFLICT (event_id) DO NOTHING
          RETURNING id`,
         [JSON.stringify(stub), md, eventId],
       );
+      const briefId = inserted.rows[0]?.id;
+      if (briefId) lastBriefId = String(briefId);
       await handle!.pool.query(
         `UPDATE aoi_events SET last_brief_at = now() WHERE id = $1`,
         [eventId],
       );
-      return {
-        status: "generated",
-        eventId,
-        briefId: String(inserted.rows[0].id),
-        modelId: "test/stub",
-        gateReason: "multi_pixel",
-      };
+      return briefId
+        ? {
+            status: "generated",
+            eventId,
+            briefId: String(briefId),
+            modelId: "test/stub",
+            gateReason: "multi_pixel",
+          }
+        : { status: "skipped", eventId, reason: "already_briefed" };
+    });
+
+    // Stub the dispatcher to record sends + write notifications_log directly
+    // against the testcontainer pool. We exercise the *real* dispatcher in
+    // the unit tests; here we focus on the route-level rollups + idempotency.
+    const { _setTestNotifyDispatch } = await import("@/app/api/aoi/poll/route");
+    const { dispatchBrief } = await import("@/lib/notify/dispatch");
+
+    _setTestNotifyDispatch(async (db, briefId) => {
+      return dispatchBrief(db, briefId, {
+        send: async (a) => {
+          sendCalls.push({ to: a.to, subject: a.subject });
+          return { ok: true, providerMessageId: `int-${sendCalls.length}`, latencyMs: 1 };
+        },
+      });
     });
 
     const res = await pollPost(
@@ -214,20 +245,56 @@ describeIntegration("/api/aoi/poll → brief — PostGIS integration", () => {
     const body = (await res.json()) as {
       runs: Array<{
         status: string;
-        eventsCreated: number;
         briefsGenerated: number;
-        briefSkipReason: Record<string, string>;
+        notificationsSent: number;
       }>;
-      totalBriefsGenerated: number;
+      totalNotificationsSent: number;
     };
-    expect(body.runs).toHaveLength(1);
-    expect(body.runs[0].status).toBe("ok");
-    expect(body.runs[0].eventsCreated).toBe(1);
     expect(body.runs[0].briefsGenerated).toBe(1);
-    expect(Object.keys(body.runs[0].briefSkipReason)).toHaveLength(0);
-    expect(body.totalBriefsGenerated).toBe(1);
+    expect(body.runs[0].notificationsSent).toBe(1);
+    expect(body.totalNotificationsSent).toBe(1);
+    expect(sendCalls).toHaveLength(1);
+    expect(sendCalls[0].to).toBe("alerts@example.org");
 
-    const briefs = await handle!.pool.query(`SELECT COUNT(*)::int AS c FROM aoi_briefs`);
-    expect(briefs.rows[0].c).toBe(1);
+    const logs = await handle!.pool.query(
+      `SELECT status, target FROM notifications_log WHERE brief_id = $1`,
+      [lastBriefId],
+    );
+    expect(logs.rows).toHaveLength(1);
+    expect(logs.rows[0].status).toBe("sent");
+
+    const briefRow = await handle!.pool.query(
+      `SELECT last_notified_at FROM aoi_briefs WHERE id = $1`,
+      [lastBriefId],
+    );
+    expect(briefRow.rows[0].last_notified_at).not.toBeNull();
+
+    const parentJob = await handle!.pool.query(
+      `SELECT notifications_sent FROM job_runs WHERE bucket IS NULL ORDER BY id DESC LIMIT 1`,
+    );
+    expect(parentJob.rows[0].notifications_sent).toBe(1);
+
+    // Second poll — same bucket. The matcher will UPDATE the existing event
+    // (no new event), so generated briefs = 0 and no second send occurs.
+    sendCalls = [];
+    const res2 = await pollPost(
+      new Request("http://localhost/api/aoi/poll", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer cron-secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ bucket: SONOMA_BUCKET }),
+      }) as Parameters<typeof pollPost>[0],
+    );
+    expect(res2.status).toBe(200);
+    expect(sendCalls).toHaveLength(0);
+    const logs2 = await handle!.pool.query(
+      `SELECT COUNT(*)::int AS c FROM notifications_log WHERE brief_id = $1`,
+      [lastBriefId],
+    );
+    expect(logs2.rows[0].c).toBe(1);
+
+    _setTestNotifyDispatch(null);
   });
 });

--- a/tests/notify/resend.live.test.ts
+++ b/tests/notify/resend.live.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Live Resend smoke test — gated behind `RESEND_LIVE=1`.
+ *
+ * Off by default (CI and local). Run manually after Vanyo wires up
+ * `RESEND_API_KEY` to confirm an actual email lands. Uses
+ * `RESEND_TEST_MODE=1` so the send goes through Resend's test sender
+ * (`onboarding@resend.dev`) — no domain verification required.
+ *
+ *   RESEND_LIVE=1 RESEND_API_KEY=... pnpm vitest run tests/notify/resend.live
+ *
+ * Skipped silently when the flag isn't set so `pnpm test` stays clean.
+ */
+import { describe, expect, it } from "vitest";
+import { sendEmail } from "@/lib/notify/resend";
+
+const live = process.env.RESEND_LIVE === "1" && !!process.env.RESEND_API_KEY;
+const describeLive = live ? describe : describe.skip;
+
+if (!live) {
+  console.warn(
+    "[live] Skipping Resend live test — set RESEND_LIVE=1 and RESEND_API_KEY to enable.",
+  );
+}
+
+describeLive("Resend live", () => {
+  it("sends a real email through onboarding@resend.dev", async () => {
+    process.env.RESEND_TEST_MODE = "1";
+    const to = process.env.RESEND_LIVE_TO ?? "delivered@resend.dev";
+    const result = await sendEmail({
+      to,
+      subject: "Wildfire Nowcast — Stage 4 live smoke test",
+      markdown:
+        "# Live smoke test\n\nThis is a real Resend send via the test sender.\n",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.providerMessageId.length).toBeGreaterThan(0);
+    expect(result.latencyMs).toBeLessThan(10_000);
+  }, 30_000);
+});

--- a/tests/notify/resend.test.ts
+++ b/tests/notify/resend.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Stage 4 Resend client unit tests — pure envelope + config_missing path.
+ * No live HTTP. Subject truncation, markdown→html, RESEND_TEST_MODE flag,
+ * and missing-key behaviour.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildEnvelope, sendEmail, truncate } from "@/lib/notify/resend";
+import { renderMarkdownToHtml } from "@/lib/notify/markdown";
+import { renderBriefMarkdown } from "@/lib/ai/render";
+import type { Brief } from "@/lib/ai/schema";
+import { SCHEMA_VERSION } from "@/lib/ai/schema";
+
+const SPRING_CREEK: Brief = {
+  schema_version: SCHEMA_VERSION,
+  aoi: {
+    id: "00000000-0000-4000-8000-000000000099",
+    name: "Spring Creek Preserve",
+    area_ha: 2040,
+  },
+  summary: "Two VIIRS detections 14 km north of the preserve; light winds, no incursion.",
+  key_facts: {
+    nearest_detection_km: 14,
+    bearing_from_aoi_deg: 357,
+    wind_dir_deg: null,
+    wind_speed_kmh: null,
+    wind_toward_aoi: null,
+    detection_count_in_window: 2,
+    max_frp_mw: 11,
+    satellites: ["VIIRS_NOAA20_NRT"],
+    window_hours: 1,
+  },
+  context: {
+    weather_note: null,
+    authority_perimeter: { source: null, posted_ts: null, contains_detection: null },
+    prior_events: [
+      {
+        date: "2020-08-20",
+        description: "LNU Lightning Complex eastern edge.",
+        outcome: "no incursion",
+      },
+    ],
+  },
+  recommended_watch_items: ["Re-check at next cron tick.", "Monitor wind shift."],
+  uncertainty: "Confidence is nominal.",
+  next_brief_hint: { when: "next tick", trigger: "any new detection" },
+};
+
+describe("Resend client envelope", () => {
+  const ENV_KEYS = ["RESEND_API_KEY", "RESEND_TEST_MODE", "NOTIFY_FROM_ADDRESS"] as const;
+  const original: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) original[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      const v = original[k];
+      if (v == null) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("truncates subject at 90 chars", () => {
+    const long = "a".repeat(120);
+    expect(truncate(long, 90)).toHaveLength(90);
+    const env = buildEnvelope({
+      to: "x@example.org",
+      subject: long,
+      markdown: "body",
+    });
+    expect(env.subject.length).toBeLessThanOrEqual(90);
+  });
+
+  it("renders the canonical Spring Creek brief markdown to HTML", () => {
+    const md = renderBriefMarkdown(SPRING_CREEK);
+    const html = renderMarkdownToHtml(md);
+    expect(html).toContain("<h1>Spring Creek Preserve — situation brief</h1>");
+    expect(html).toContain("<h2>Key facts</h2>");
+    expect(html).toContain("<ul>");
+    expect(html).toContain("Re-check at next cron tick.");
+    expect(html).toContain("<em>Uncertainty: Confidence is nominal.</em>");
+  });
+
+  it("RESEND_TEST_MODE=1 rewrites from and adds [TEST] suffix", () => {
+    process.env.RESEND_TEST_MODE = "1";
+    process.env.NOTIFY_FROM_ADDRESS = "alerts@configured.example";
+    const env = buildEnvelope({
+      to: "x@example.org",
+      subject: "Hello",
+      markdown: "body",
+    });
+    expect(env.from).toBe("onboarding@resend.dev");
+    expect(env.subject).toBe("Hello [TEST]");
+  });
+
+  it("uses NOTIFY_FROM_ADDRESS when configured and not in test mode", () => {
+    process.env.NOTIFY_FROM_ADDRESS = "alerts@configured.example";
+    const env = buildEnvelope({
+      to: "x@example.org",
+      subject: "Hello",
+      markdown: "body",
+    });
+    expect(env.from).toBe("alerts@configured.example");
+    expect(env.subject).toBe("Hello");
+  });
+
+  it("missing RESEND_API_KEY → config_missing, no throw", async () => {
+    const result = await sendEmail({
+      to: "x@example.org",
+      subject: "Hello",
+      markdown: "body",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("config_missing");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Stage 4 of the A' pivot: every newly-persisted \`aoi_briefs\` row becomes an email send via Resend, with idempotent per-(brief, channel, target) tracking, build-without-blocking when \`RESEND_API_KEY\` is unset, and the quiet-hours / paused gates wired in. Webhook channels are recorded as \`skipped, channel_not_implemented\` (Stage 6 owns Slack/Discord). Closes the delivery leg so US-1 and US-3 fire end-to-end.

agent: dev
Implements pm/briefs/18-stage4-notification-dispatch.md
stage-pr: 4

## What changed

- \`db/migrations/0003_stage4.sql\` (+ \`.test.sql\`): \`notifications_log\` table; partial unique index on \`(brief_id, channel, target_hash) WHERE status IN ('sent','skipped')\` for retry-friendly idempotency; rate-limit lookup index per spec §3.7; \`aoi_briefs.last_notified_at\`; \`job_runs.notifications_sent\`.
- \`lib/notify/resend.ts\`: lazy env read, raw fetch to \`https://api.resend.com/emails\`, \`RESEND_TEST_MODE=1\` rewrites \`from\` to \`onboarding@resend.dev\` and adds a \`[TEST]\` subject suffix, single-attempt.
- \`lib/notify/markdown.ts\`: small deterministic md→html scoped to the brief shape produced by \`lib/ai/render.ts\`. Avoids pulling \`marked\`.
- \`lib/notify/dispatch.ts\`: loads brief + AOI + rules + user email, resolves channels (with fallback to \`users.email\` when \`notify_channels\` is empty), per-channel idempotency check, paused + quiet-hours gate, transactional persist.
- \`app/api/aoi/poll/route.ts\`: dispatch loop after \`generateBriefForEvent\`, per-bucket rollups, parent \`job_runs.notifications_sent\` rollup, single warning per poll when the API key is missing, and a new \`_setTestNotifyDispatch\` injection point.

## Acceptance criteria (from brief)

- [x] \`notifications_log\` table + partial unique index per spec §3.7
- [x] \`aoi_briefs.last_notified_at\` + \`job_runs.notifications_sent\`
- [x] Migration \`0003_stage4.sql\` + \`0003_stage4.test.sql\`, schema in \`db/schema/index.ts\`
- [x] \`lib/notify/resend.ts\` mirrors \`lib/ai/gateway.ts\` (lazy env, \`config_missing\`, \`RESEND_TEST_MODE\`)
- [x] \`lib/notify/dispatch.ts\` orchestrator with all five gates (config_missing, paused, quiet_hours, duplicate, channel_not_implemented)
- [x] Hook into \`app/api/aoi/poll\` after \`generateBriefForEvent\`
- [x] PGlite unit tests for every dispatcher branch (8 tests)
- [x] Testcontainer integration test asserting end-to-end send + idempotent second poll
- [x] Live Resend test gated \`RESEND_LIVE=1\`
- [x] \`_setTestNotifyDispatch\` injection point

## Test results

- \`pnpm typecheck\` clean
- \`pnpm lint\` clean
- \`pnpm test\` 19 files, 106 passed, 2 skipped (Resend live + AI Gateway live), 0 failed
- \`pnpm build\` Next.js production build passed

## Things to challenge in review

- Tiny in-tree Markdown→HTML renderer instead of \`marked\`. Brief output shape is deterministic and small. Snapshot test included. Swapping to \`marked\` is a one-file change if reviewer prefers.
- Dispatcher does not enforce the §3.7 rate-limit window — brief explicitly defers it. Supporting index ships now.
- \`tests/poll-to-brief.integration.test.ts\` (Stage 3) updated to return the real inserted brief id; the prior \`stub-brief-id\` literal would throw a UUID parse error against the new dispatcher hook. Only Stage 3 file touched.

## Out of scope (deferred per brief)

- Webhook channel delivery (recorded \`skipped, channel_not_implemented\`)
- Snooze / pause / unsubscribe signed-token links in email body
- Quiet-hours digest merging (US-2 #3 — Stage 6)
- Retry-with-backoff (next poll retries failed rows)
- Rate-limit enforcement (index ships; query is Stage 5/6)
- Inbound \`POST /api/notifications/webhook/{token}\` (Stage 6)
- Auth (Clerk) — Stage 5
- Sender-domain verification on Resend (deferred)

## Linked

- Brief landing: [#393](https://github.com/Ent7opy/wildfire-nowcast/pull/393) (in-flight chore PR for the brief itself)
- ADR 0006 + ADR 0007 (auto-merge gate)
- Spec: \`docs/SPEC-A-prime-v1.md\` §3.7