### PR TITLE
chore(stage-5.5): dispatcher behavioral fixes (3)

### DIFF
--- a/lib/notify/dispatch.ts
+++ b/lib/notify/dispatch.ts
@@ -73,13 +73,52 @@ export async function dispatchBrief(
   const attempts: DispatchAttempt[] = [];
   let firstSuccessRecorded = false;
 
+  if (channels.length === 0) {
+    const reason = isPendingPlaceholder(loaded.userEmail)
+      ? "no_recipient_pending"
+      : "no_recipient";
+    const target = loaded.userEmail ?? "";
+    await persistAttempt(db, {
+      aoiId: loaded.aoiId,
+      briefId,
+      channel: "email",
+      target,
+      status: "skipped",
+      skipReason: reason,
+    });
+    attempts.push({
+      status: "skipped",
+      channel: "email",
+      target,
+      reason,
+    });
+    return { briefId, attempts };
+  }
+
   for (const ch of channels) {
     if (ch.type === "webhook") {
+      const webhookHash = sha256(ch.target);
+      const existingWebhook = await findExistingTerminalRow(
+        db,
+        briefId,
+        "webhook",
+        webhookHash,
+      );
+      if (existingWebhook) {
+        attempts.push({
+          status: "skipped",
+          channel: "webhook",
+          target: ch.target,
+          reason: "duplicate",
+        });
+        continue;
+      }
       await persistAttempt(db, {
         aoiId: loaded.aoiId,
         briefId,
         channel: "webhook",
         target: ch.target,
+        targetHash: webhookHash,
         status: "skipped",
         skipReason: "channel_not_implemented",
       });
@@ -210,11 +249,19 @@ function resolveChannels(loaded: LoadedBrief): Array<
   | { type: "email"; target: string }
   | { type: "webhook"; target: string }
 > {
-  if (loaded.notifyChannels.length > 0) return loaded.notifyChannels;
-  if (loaded.userEmail) {
+  if (loaded.notifyChannels.length > 0) {
+    return loaded.notifyChannels.filter(
+      (c) => c.type !== "email" || !isPendingPlaceholder(c.target),
+    );
+  }
+  if (loaded.userEmail && !isPendingPlaceholder(loaded.userEmail)) {
     return [{ type: "email", target: loaded.userEmail }];
   }
   return [];
+}
+
+function isPendingPlaceholder(email: string | null | undefined): boolean {
+  return typeof email === "string" && /@pending\.invalid$/.test(email);
 }
 
 function buildSubject(summary: string): string {

--- a/tests/notify/dispatch.test.ts
+++ b/tests/notify/dispatch.test.ts
@@ -269,6 +269,91 @@ describe("dispatchBrief — PGlite", () => {
     expect(await readBriefLastNotified(db, briefId)).toBeNull();
   });
 
+  it("user email is @pending.invalid placeholder → skipped/no_recipient_pending, send not called", async () => {
+    const { briefId } = await seed(db, {
+      notifyChannels: [],
+      userEmail: "clerk_user_xyz@pending.invalid",
+    });
+    let called = false;
+    const send = async (): Promise<SendResult> => {
+      called = true;
+      return { ok: true, providerMessageId: "x", latencyMs: 1 };
+    };
+    const outcome = await dispatchBrief(db, briefId, { send });
+    expect(called).toBe(false);
+    expect(outcome.attempts).toHaveLength(1);
+    expect(outcome.attempts[0].status).toBe("skipped");
+    if (outcome.attempts[0].status === "skipped") {
+      expect(outcome.attempts[0].reason).toBe("no_recipient_pending");
+    }
+    const rows = await readNotifications(db, briefId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("skipped");
+    expect(rows[0].skip_reason).toBe("no_recipient_pending");
+  });
+
+  it("missing user (deleted) → skipped/no_recipient row persisted", async () => {
+    const { briefId, aoiId } = await seed(db, {
+      notifyChannels: [],
+      userEmail: "owner@example.org",
+    });
+    // Detach the user so the LEFT JOIN yields null user_email. The aois.user_id
+    // FK has ON DELETE CASCADE; drop whichever auto-named FK is in place so we
+    // can dangle the reference without cascading away the AOI.
+    const fk = (await db.execute(sql`
+      SELECT conname FROM pg_constraint
+      WHERE conrelid = 'aois'::regclass AND contype = 'f'
+        AND pg_get_constraintdef(oid) LIKE '%REFERENCES%users%'
+    `)) as unknown as { rows?: Array<{ conname: string }> };
+    const fkRows = (fk.rows ?? (fk as unknown as Array<{ conname: string }>)) as Array<{
+      conname: string;
+    }>;
+    for (const r of fkRows) {
+      await db.execute(sql.raw(`ALTER TABLE "aois" DROP CONSTRAINT "${r.conname}"`));
+    }
+    await db.execute(sql`UPDATE "aois" SET "user_id" = ${"missing-user-" + Math.random().toString(36).slice(2, 8)} WHERE "id" = ${aoiId}`);
+    let called = false;
+    const send = async (): Promise<SendResult> => {
+      called = true;
+      return { ok: true, providerMessageId: "x", latencyMs: 1 };
+    };
+    const outcome = await dispatchBrief(db, briefId, { send });
+    expect(called).toBe(false);
+    expect(outcome.attempts).toHaveLength(1);
+    expect(outcome.attempts[0].status).toBe("skipped");
+    if (outcome.attempts[0].status === "skipped") {
+      expect(outcome.attempts[0].reason).toBe("no_recipient");
+    }
+    const rows = await readNotifications(db, briefId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("skipped");
+    expect(rows[0].skip_reason).toBe("no_recipient");
+  });
+
+  it("webhook channel re-dispatch → second call returns skipped/duplicate", async () => {
+    const { briefId } = await seed(db, {
+      notifyChannels: [{ type: "webhook", target: "https://example.org/hook" }],
+    });
+    const send = async (): Promise<SendResult> => ({
+      ok: true,
+      providerMessageId: "x",
+      latencyMs: 1,
+    });
+    const first = await dispatchBrief(db, briefId, { send });
+    expect(first.attempts[0].status).toBe("skipped");
+    if (first.attempts[0].status === "skipped") {
+      expect(first.attempts[0].reason).toBe("channel_not_implemented");
+    }
+    const second = await dispatchBrief(db, briefId, { send });
+    expect(second.attempts[0].status).toBe("skipped");
+    if (second.attempts[0].status === "skipped") {
+      expect(second.attempts[0].reason).toBe("duplicate");
+    }
+    const rows = await readNotifications(db, briefId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].skip_reason).toBe("channel_not_implemented");
+  });
+
   it("send returns provider_error → row written status=failed; dispatcher does not throw", async () => {
     const { briefId } = await seed(db, {
       notifyChannels: [{ type: "email", target: "x@example.org" }],


### PR DESCRIPTION
agent: dev

Three small dispatcher behavioral fixes flagged by reviewers across Stages 4 and 5.

## Changes

### Fix 1 — \`@pending.invalid\` placeholder skip
The Stage 5 JIT user-provisioning path inserts \`users.email = '<userId>@pending.invalid'\` until the Clerk webhook fills the real address. The dispatcher now treats any email matching \`/@pending\.invalid\$/\` as no recipient, persists a \`notifications_log\` row with \`status='skipped'\` and \`skip_reason='no_recipient_pending'\`, and does not call Resend.

### Fix 2 — Missing user → \`no_recipient\` row
When the \`users\` LEFT JOIN yields null (deleted user / dangling reference), the dispatcher now persists a \`notifications_log\` row with \`status='skipped'\` and \`skip_reason='no_recipient'\` instead of silently returning \`{ attempts: [] }\`.

### Fix 3 — Webhook re-run idempotency reason
The webhook branch now runs the same \`findExistingTerminalRow\` precheck the email path uses. On a duplicate dispatch it returns \`skipped/duplicate\` instead of the cosmetically-divergent \`skipped/channel_not_implemented\`.

## Acceptance criteria

- [x] \`@pending.invalid\` placeholder: row persisted, \`skip_reason='no_recipient_pending'\`, Resend not called
- [x] Missing user / null email: row persisted, \`skip_reason='no_recipient'\`
- [x] Webhook re-dispatch: first call → \`channel_not_implemented\`, second call → \`duplicate\`
- [x] PGlite unit tests for each behavior
- [x] \`pnpm typecheck && pnpm lint && pnpm test && pnpm build\` all green

## Test results

128 passed, 3 skipped (unchanged); 3 new dispatcher tests added.

## Notes

- \`skipReason\` is \`text\` in the schema, not a string-literal union, so no schema/type changes were needed.
- Fix 2 test drops the auto-named \`aois.user_id\` FK at runtime to dangle the reference (FK has \`ON DELETE CASCADE\` which would otherwise remove the AOI).

## Out of scope (per brief)

No changes to the partial unique index, no real webhook delivery, no Resend client edits, no surrounding refactors.