### PR TITLE
chore(docs): mark Stages 3-6 merged in CLAUDE.md status snapshot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,19 +39,21 @@ History:
 - **Drizzle ORM** + **PostgreSQL 16 / PostGIS 3.5** on **Neon** (autoscale-to-zero).
 - **PGlite** for unit tests; **`@testcontainers/postgresql`** with `postgis/postgis:16-3.5` for spatial integration tests.
 - **GitHub Actions cron** for FIRMS polling (`.github/workflows/firms-poll.yml`).
+- **AI Gateway** (`@ai-sdk/google` via Vercel AI Gateway) for brief generation.
+- **Resend** for notification email dispatch.
+- **Clerk** for auth + per-user AOIs.
 - **TypeScript 5**, **vitest**, **eslint 9**, **pnpm 10**.
-- Future stages: **AI Gateway** (Stage 3 — brief generation), **Resend** (Stage 4 — email), **Clerk** (Stage 5 — auth).
 
 ## Stage status (snapshot — confirm against `pm/backlog.md`)
 
 - Stage 0 — Next.js scaffold ✅ merged.
 - Stage 1 — AOI CRUD + Drizzle schema + PGlite tests ✅ merged.
 - Stage 2 — FIRMS poll + AOI matcher + GitHub Actions cron ✅ merged.
-- Stage 3 — Brief generation (AI Gateway, structured output) — next.
-- Stage 4 — Notification dispatch (Resend).
-- Stage 5 — Auth (Clerk) + per-user AOIs.
-- Stage 6 — Rules UI / export.
-- Stage 7 — Cutover (now done).
+- Stage 3 — Brief generation (AI Gateway, structured output) ✅ merged.
+- Stage 4 — Notification dispatch (Resend) ✅ merged.
+- Stage 5 — Auth (Clerk) + per-user AOIs ✅ merged.
+- Stage 6 — Rules UI / export ✅ merged.
+- Stage 7 — Cutover ✅ merged.
 
 ## Commands
 


### PR DESCRIPTION
agent: scout

## What changed and why

Stages 3-6 all merged in the last 24 UTC hours (PRs #388, #394, #396, #398) but `CLAUDE.md` still labelled Stage 3 as "next" and listed AI Gateway / Resend / Clerk as "Future stages" in the Stack section. New devs (human or agent) reading `CLAUDE.md` would get a stale picture of what's already shipped vs upcoming.

## Risk assessment

Worst case: a doc-only edit ships an inaccurate description of stage status. The new lines are factually verifiable against `git log --oneline` (PRs #388, #394, #396, #398) and `pm/backlog.md`. No code paths affected.

## Verification commands run locally

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm test` — 136 passed / 13 skipped (33 files)
- `pnpm build` — Next.js production build succeeded

## Red flags found but not fixed

- `docs/pivot-architecture.md` still uses the legacy `apps/nextjs/` monorepo prefix and references paths like `lib/llm/` (now `lib/ai/`) that don't exist post-cutover. Rewriting it would exceed the 200-line scout cap and is closer to a strategic refresh than a drift fix; flagging for a future PM/scout pass.
- `docs/SPEC-A-prime-v1.md` open question #3 (authority-perimeter v1.1) was effectively answered by Stage 3 deferring authority-perimeter ingest, but the spec is a Vanyo-facing decisions doc and rewriting "Open questions for Vanyo" is a strategic edit, not drift; left for PM agent.