### PR TITLE
chore(notify): URL-scheme allow-list on inlineLinks (XSS hardening)

### DIFF
--- a/lib/notify/markdown.ts
+++ b/lib/notify/markdown.ts
@@ -42,14 +42,26 @@ function inlineItalics(escaped: string): string {
  *
  * Nested links and labels containing `]` or `(` are not supported and fall
  * through unchanged (they render as plain escaped text).
+ *
+ * URL-scheme allow-list: only `http://`, `https://`, `mailto:`, and
+ * site-relative URLs (`/...`) emit an anchor. Anything else
+ * (`javascript:`, `data:`, `file:`, …) degrades to the plain label text.
+ * The threat model is AI-generated brief content that — through model
+ * misalignment or prompt injection — slips a `javascript:` URL into the
+ * payload and gets rendered as a live anchor in HTML email or the
+ * dashboard. Relative URLs are allowed because `lib/share/url.ts` produces
+ * them in build-without-blocking (when `NEXT_PUBLIC_APP_URL` is unset).
  */
+const ALLOWED_SCHEME = /^(?:https?:\/\/|mailto:|\/)/i;
+
 function inlineLinks(escaped: string): string {
   // Operate on the escaped string. Brackets/parens are not in the HTML escape
   // set, so they survive verbatim — but the label cannot contain `]` and the
   // URL cannot contain `)`, which keeps the regex unambiguous.
   return escaped.replace(
     /\[([^\]\n]+)\]\(([^)\s]+)\)/g,
-    (_match, label: string, url: string) => `<a href="${url}">${label}</a>`,
+    (_match, label: string, url: string) =>
+      ALLOWED_SCHEME.test(url) ? `<a href="${url}">${label}</a>` : label,
   );
 }
 

--- a/lib/notify/markdown.ts
+++ b/lib/notify/markdown.ts
@@ -44,15 +44,18 @@ function inlineItalics(escaped: string): string {
  * through unchanged (they render as plain escaped text).
  *
  * URL-scheme allow-list: only `http://`, `https://`, `mailto:`, and
- * site-relative URLs (`/...`) emit an anchor. Anything else
- * (`javascript:`, `data:`, `file:`, …) degrades to the plain label text.
- * The threat model is AI-generated brief content that — through model
- * misalignment or prompt injection — slips a `javascript:` URL into the
- * payload and gets rendered as a live anchor in HTML email or the
- * dashboard. Relative URLs are allowed because `lib/share/url.ts` produces
- * them in build-without-blocking (when `NEXT_PUBLIC_APP_URL` is unset).
+ * site-relative URLs (`/...`, but not `//...`) emit an anchor. Anything
+ * else (`javascript:`, `data:`, `file:`, protocol-relative `//evil.com`,
+ * …) degrades to the plain label text. The threat model is AI-generated
+ * brief content that — through model misalignment or prompt injection —
+ * slips a hostile URL into the payload and gets rendered as a live anchor
+ * in HTML email or the dashboard. Protocol-relative URLs are explicitly
+ * blocked because browsers resolve them against the page scheme and will
+ * navigate cross-origin. Relative URLs are allowed because
+ * `lib/share/url.ts` produces them in build-without-blocking (when
+ * `NEXT_PUBLIC_APP_URL` is unset).
  */
-const ALLOWED_SCHEME = /^(?:https?:\/\/|mailto:|\/)/i;
+const ALLOWED_SCHEME = /^(?:https?:\/\/|mailto:|\/(?!\/))/i;
 
 function inlineLinks(escaped: string): string {
   // Operate on the escaped string. Brackets/parens are not in the HTML escape

--- a/tests/notify/markdown-link.test.ts
+++ b/tests/notify/markdown-link.test.ts
@@ -36,4 +36,56 @@ describe("markdown link rendering", () => {
     expect(out).toContain('<a href="https://a">A</a>');
     expect(out).toContain('<a href="https://b">B</a>');
   });
+
+  describe("URL-scheme allow-list", () => {
+    it("allows http://", () => {
+      const out = renderMarkdownToHtml("Visit [site](http://example.com).");
+      expect(out).toContain('<a href="http://example.com">site</a>');
+    });
+
+    it("allows https://", () => {
+      const out = renderMarkdownToHtml("Visit [site](https://example.com).");
+      expect(out).toContain('<a href="https://example.com">site</a>');
+    });
+
+    it("allows mailto:", () => {
+      const out = renderMarkdownToHtml("Email [us](mailto:user@example.com).");
+      expect(out).toContain('<a href="mailto:user@example.com">us</a>');
+    });
+
+    it("allows site-relative URLs (footer build-without-blocking case)", () => {
+      const out = renderMarkdownToHtml("[Snooze](/api/notify/snooze/abc)");
+      expect(out).toContain('<a href="/api/notify/snooze/abc">Snooze</a>');
+    });
+
+    it("rejects javascript: and renders plain label text", () => {
+      const out = renderMarkdownToHtml("Click [me](javascript:alert(1)) now.");
+      expect(out).not.toContain("<a ");
+      expect(out).not.toContain("javascript:");
+      expect(out).toContain("me");
+    });
+
+    it("rejects data: URLs", () => {
+      const out = renderMarkdownToHtml(
+        "[x](data:text/html,<script>alert(1)</script>)",
+      );
+      expect(out).not.toContain("<a ");
+      expect(out).not.toContain("data:");
+    });
+
+    it("rejects file: URLs", () => {
+      const out = renderMarkdownToHtml("[x](file:///etc/passwd)");
+      expect(out).not.toContain("<a ");
+      expect(out).not.toContain("file:");
+    });
+
+    it("rejects scheme with leading whitespace obfuscation", () => {
+      // Regex is anchored, so any non-allowed prefix is rejected.
+      const out = renderMarkdownToHtml("[x](JAVASCRIPT:alert(1))");
+      // Note: the closing `)` of `alert(1)` actually terminates the URL match
+      // at the first `)`, but even if extracted, `JAVASCRIPT:alert(1` would
+      // not match the allow-list and would degrade to label text.
+      expect(out).not.toContain("<a ");
+    });
+  });
 });

--- a/tests/notify/markdown-link.test.ts
+++ b/tests/notify/markdown-link.test.ts
@@ -79,13 +79,32 @@ describe("markdown link rendering", () => {
       expect(out).not.toContain("file:");
     });
 
-    it("rejects scheme with leading whitespace obfuscation", () => {
-      // Regex is anchored, so any non-allowed prefix is rejected.
+    it("rejects upper-case JAVASCRIPT: scheme", () => {
+      // The allow-list uses the `i` flag, so case-folded variants of allowed
+      // schemes still match — but case-folded `javascript:` is not in the
+      // allow-list at all, so it degrades to label text.
       const out = renderMarkdownToHtml("[x](JAVASCRIPT:alert(1))");
       // Note: the closing `)` of `alert(1)` actually terminates the URL match
       // at the first `)`, but even if extracted, `JAVASCRIPT:alert(1` would
       // not match the allow-list and would degrade to label text.
       expect(out).not.toContain("<a ");
+    });
+
+    it("rejects mixed-case JavaScript: scheme", () => {
+      const out = renderMarkdownToHtml("Click [me](JavaScript:alert(1)) now.");
+      expect(out).not.toContain("<a ");
+      expect(out).not.toContain("JavaScript:");
+      expect(out).toContain("me");
+    });
+
+    it("rejects protocol-relative //evil.com URLs", () => {
+      // `//evil.com/path` is resolved by browsers against the page scheme and
+      // navigates cross-origin. The `\/(?!\/)` lookahead in the allow-list
+      // prevents the relative-URL alternative from swallowing the first `/`.
+      const out = renderMarkdownToHtml("Visit [site](//evil.com/path) now.");
+      expect(out).not.toContain("<a ");
+      expect(out).not.toContain("//evil.com");
+      expect(out).toContain("site");
     });
   });
 });


### PR DESCRIPTION
agent: scout

URL-scheme allow-list in \`inlineLinks()\` (\`lib/notify/markdown.ts\`): allow \`http://\`, \`https://\`, \`mailto:\`, and site-relative URLs (\`/...\`); reject anything else (\`javascript:\`, \`data:\`, \`file:\`, …) and degrade to plain label text. Closes the XSS surface flagged by the Stage 7 reviewer on PR #406 — AI-generated brief content (Gemini via AI Gateway) that slipped a \`javascript:\` URL would otherwise render as a live anchor in HTML email and the dashboard brief view.

## Risk assessment

Worst case if this ships:
- A legitimate brief contains a link with an unrecognized-but-safe scheme (e.g. \`tel:\`, \`geo:\`) — it degrades to plain text. No crash, no broken layout, just no anchor. Brief content is AI-rendered from a structured schema today, none of which produces non-http schemes; if a future brief variant wants \`geo:\` (lat/lon links), one line of regex extends the allow-list.
- Site-relative URLs (\`/api/notify/snooze/...\`) are kept allowed because \`lib/share/url.ts\` produces them in build-without-blocking; cutting them would silently break footer action links in dev / preview emails.

No DB / migration / auth / cron changes. Pure markdown rendering.

## Verification

- \`pnpm typecheck\` — clean
- \`pnpm lint\` — clean
- \`pnpm test\` — 186 passed, 3 skipped (Docker-gated spatial; gated live)
- \`pnpm build\` — clean
- 7 new test cases cover http / https / mailto / relative ALLOW and javascript: / data: / file: / uppercase-scheme REJECT paths.