### PR TITLE
Stage 8: authority perimeters (NIFC/CWFIS) + per-bucket freshness honesty

### DIFF
--- a/app/api/aoi/poll/route.ts
+++ b/app/api/aoi/poll/route.ts
@@ -39,6 +39,11 @@ import { matchDetectionsToAois } from "@/lib/firms/matcher";
 import { generateBriefForEvent, type GenerateOutcome } from "@/lib/ai/generate";
 import { dispatchBrief, type DispatchOutcome } from "@/lib/notify/dispatch";
 import { pruneOldDetections } from "@/lib/firms/prune";
+import {
+  firmsErrorToOutcome,
+  runStatusToOutcome,
+  type FreshnessOutcome,
+} from "@/lib/firms/freshness";
 
 // Test-only injection point: lets the integration suite bypass the live
 // FIRMS call without introducing a DI framework. Production leaves it null.
@@ -278,10 +283,13 @@ async function runOneBucket(
       dayRange: 1,
     });
     if (!fetchResult.ok) {
+      const mapped = firmsErrorToOutcome(fetchResult.code);
       await closeJobRun(db, childRunId, {
         status: "error",
         error: `${fetchResult.code}: ${fetchResult.message}`,
         firmsRequestCount: 1,
+        outcome: mapped.outcome,
+        retryPending: mapped.retryPending,
         finishedAt: new Date(),
       });
       return {
@@ -360,6 +368,7 @@ async function runOneBucket(
     }
 
     const status: "ok" | "partial" = briefError ? "partial" : "ok";
+    const mapped = runStatusToOutcome({ status, error: briefError });
 
     await closeJobRun(db, childRunId, {
       status,
@@ -369,6 +378,8 @@ async function runOneBucket(
       eventsCreated: matchOutcome.eventsCreated,
       briefsGenerated,
       notificationsSent,
+      outcome: mapped.outcome,
+      retryPending: mapped.retryPending,
       finishedAt: new Date(),
     });
 
@@ -391,10 +402,13 @@ async function runOneBucket(
       error: briefError ?? undefined,
     };
   } catch (err) {
+    const mapped = runStatusToOutcome({ status: "error", error: errMessage(err) });
     await closeJobRun(db, childRunId, {
       status: "error",
       error: errMessage(err),
       firmsRequestCount: 1,
+      outcome: mapped.outcome,
+      retryPending: mapped.retryPending,
       finishedAt: new Date(),
     });
     return {
@@ -449,6 +463,10 @@ type CloseArgs = {
   briefsGenerated?: number;
   notificationsSent?: number;
   detectionsPruned?: number;
+  /** Stage 8: user-facing taxonomy. Only set on per-bucket child rows. */
+  outcome?: FreshnessOutcome;
+  /** Stage 8: signals "(retrying)" in the AOI freshness banner. */
+  retryPending?: boolean;
 };
 
 async function closeJobRun(
@@ -457,6 +475,11 @@ async function closeJobRun(
   args: CloseArgs,
 ): Promise<void> {
   if (!id) return;
+  // outcome / retry_pending only set on per-bucket child rows (the parent
+  // doesn't pass them); use COALESCE so the parent UPDATE leaves them at
+  // their column defaults (NULL / false).
+  const outcome = args.outcome ?? null;
+  const retryPending = args.retryPending ?? false;
   await db.execute(sql`
     UPDATE "job_runs"
     SET
@@ -468,7 +491,9 @@ async function closeJobRun(
       "events_created" = COALESCE("events_created", 0) + ${args.eventsCreated ?? 0},
       "briefs_generated" = COALESCE("briefs_generated", 0) + ${args.briefsGenerated ?? 0},
       "notifications_sent" = COALESCE("notifications_sent", 0) + ${args.notificationsSent ?? 0},
-      "detections_pruned" = COALESCE("detections_pruned", 0) + ${args.detectionsPruned ?? 0}
+      "detections_pruned" = COALESCE("detections_pruned", 0) + ${args.detectionsPruned ?? 0},
+      "outcome" = COALESCE(${outcome}, "outcome"),
+      "retry_pending" = ${retryPending}
     WHERE "id" = ${id}
   `);
 }

--- a/app/dashboard/_components/freshness-banner.tsx
+++ b/app/dashboard/_components/freshness-banner.tsx
@@ -1,0 +1,91 @@
+/**
+ * Stage 8 — per-AOI freshness banner.
+ *
+ * Reads the most recent completed `job_runs` row for the AOI's bucket via
+ * `getAoiFreshness` and renders one of:
+ *   - happy: "Last polled 47 minutes ago"
+ *   - degraded (yellow): rate-limited / network error / timeout / partial /
+ *     stale-success
+ *   - first-poll-pending: when no completed run exists yet
+ *
+ * Honest-about-its-own-honesty: never silently renders nothing.
+ *
+ * Server component. `__testNow` is a test-only inject; the page-level caller
+ * never passes it. Pure server-side; no client JS.
+ */
+import type { AppDb } from "@/lib/db/client";
+import { getAoiFreshness } from "@/lib/db/freshness";
+import { formatRelative } from "@/lib/ui/relative-time";
+
+type Props = {
+  db: AppDb;
+  aoiId: string;
+  userId: string;
+  __testNow?: Date;
+};
+
+export async function FreshnessBanner({ db, aoiId, userId, __testNow }: Props) {
+  const now = __testNow ?? new Date();
+  const freshness = await getAoiFreshness(db, { aoiId, userId, now });
+
+  if (!freshness || !freshness.lastPolledAt) {
+    return (
+      <BannerShell tone="warn">
+        First poll pending — usually within 15 minutes
+      </BannerShell>
+    );
+  }
+
+  const rel = formatRelative(now, freshness.lastPolledAt);
+
+  if (freshness.outcome === "rate_limited") {
+    return (
+      <BannerShell tone="warn">
+        Last attempt: rate-limited{freshness.retryPending ? " — retrying next tick" : ""} ({rel})
+      </BannerShell>
+    );
+  }
+  if (freshness.outcome === "network_error") {
+    return (
+      <BannerShell tone="warn">
+        Last attempt: network error{freshness.retryPending ? " — retrying next tick" : ""} ({rel})
+      </BannerShell>
+    );
+  }
+  if (freshness.outcome === "timeout") {
+    return (
+      <BannerShell tone="warn">
+        Last attempt: timed out{freshness.retryPending ? " — retrying next tick" : ""} ({rel})
+      </BannerShell>
+    );
+  }
+  if (freshness.outcome === "partial") {
+    return (
+      <BannerShell tone="warn">
+        Last attempt: partial — some AOIs failed ({rel})
+      </BannerShell>
+    );
+  }
+  if (freshness.isStale) {
+    return (
+      <BannerShell tone="warn">
+        Polling delayed — last successful tick over 30 minutes ago ({rel})
+      </BannerShell>
+    );
+  }
+  return <BannerShell tone="muted">Last polled {rel}</BannerShell>;
+}
+
+function BannerShell({
+  tone,
+  children,
+}: {
+  tone: "muted" | "warn";
+  children: React.ReactNode;
+}) {
+  const className =
+    tone === "warn"
+      ? "rounded border border-[color:var(--warn)] bg-[color:var(--warn)]/10 px-3 py-2 text-sm text-[color:var(--foreground)]"
+      : "text-xs text-[color:var(--muted)]";
+  return <div className={className}>{children}</div>;
+}

--- a/app/dashboard/aoi/[id]/page.tsx
+++ b/app/dashboard/aoi/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/db/aoi-repository";
 import { RulesForm } from "../../_components/rules-form";
 import { AoiMapClient } from "../../_components/aoi-map-client";
+import { FreshnessBanner } from "../../_components/freshness-banner";
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -60,6 +61,9 @@ export default async function AoiPage({ params }: Params) {
         <div className="mt-3 text-xs text-[color:var(--muted)]">
           BBox: [{bbox[0][0].toFixed(2)}, {bbox[0][1].toFixed(2)}] →{" "}
           [{bbox[2][0].toFixed(2)}, {bbox[2][1].toFixed(2)}]
+        </div>
+        <div className="mt-3">
+          <FreshnessBanner db={db} aoiId={aoi.id} userId={auth.userId} />
         </div>
         <div className="mt-4">
           <AoiMapClient

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,7 @@
   --foreground: #1c1a16;
   --muted: #6b6357;
   --accent: #8a3a1a;
+  --warn: oklch(0.85 0.13 80);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -13,6 +14,7 @@
     --foreground: #ece7dd;
     --muted: #8d8578;
     --accent: #d87a4e;
+    --warn: oklch(0.7 0.13 80);
   }
 }
 

--- a/db/migrations/0006_stage8.sql
+++ b/db/migrations/0006_stage8.sql
@@ -1,0 +1,20 @@
+-- Stage 8 — A' pivot: authority-perimeter pre-fetch + per-bucket freshness.
+--
+-- Adds:
+--   * job_runs.outcome — user-facing taxonomy (success | rate_limited |
+--     network_error | timeout | partial). Operator-facing `status`
+--     (ok|partial|error|running) stays for compatibility.
+--   * job_runs.retry_pending — signal (not a promise) that the next cron
+--     tick will retry this bucket. Surfaced in the freshness banner copy.
+--   * Partial index on (bucket, started_at DESC) WHERE bucket IS NOT NULL —
+--     supports the per-AOI freshness lookup without scanning parent runs.
+--
+-- Authoritative source: pm/briefs/22-stage8-authority-perimeter-and-freshness.md.
+
+ALTER TABLE "job_runs"
+    ADD COLUMN IF NOT EXISTS "outcome" TEXT,
+    ADD COLUMN IF NOT EXISTS "retry_pending" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS "job_runs_bucket_started_at_idx"
+    ON "job_runs" ("bucket", "started_at" DESC)
+    WHERE "bucket" IS NOT NULL;

--- a/db/migrations/0006_stage8.test.sql
+++ b/db/migrations/0006_stage8.test.sql
@@ -1,0 +1,13 @@
+-- Stage 8 — PGlite-compatible variant of 0006_stage8.sql.
+--
+-- Identical to production: pure column additions + a partial index. PGlite
+-- supports partial indexes (verified in the migration test); if a future
+-- PGlite version regresses, drop the WHERE clause — the index is small.
+
+ALTER TABLE "job_runs"
+    ADD COLUMN IF NOT EXISTS "outcome" TEXT,
+    ADD COLUMN IF NOT EXISTS "retry_pending" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS "job_runs_bucket_started_at_idx"
+    ON "job_runs" ("bucket", "started_at" DESC)
+    WHERE "bucket" IS NOT NULL;

--- a/db/schema/index.ts
+++ b/db/schema/index.ts
@@ -326,6 +326,14 @@ export const jobRuns = pgTable("job_runs", {
   notificationsSent: integer("notifications_sent").notNull().default(0),
   /** Stage 7: count of `firms_detections` rows pruned by this run's retention sweep. */
   detectionsPruned: integer("detections_pruned"),
+  /**
+   * Stage 8: user-facing taxonomy distinct from operator-facing `status`.
+   *   "success" | "rate_limited" | "network_error" | "timeout" | "partial"
+   * Mapping from FIRMS errors lives in `lib/firms/freshness.ts`.
+   */
+  outcome: text("outcome"),
+  /** Stage 8: signal (not promise) — UI shows "(retrying)" until the next tick. */
+  retryPending: boolean("retry_pending").notNull().default(false),
   error: text("error"),
 });
 

--- a/db/test/pglite.ts
+++ b/db/test/pglite.ts
@@ -10,30 +10,24 @@
  * @testcontainers/postgresql harness instead — see `db/test/testcontainer.ts`.
  */
 import { PGlite } from "@electric-sql/pglite";
+import { readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { makePgliteDb, type AppDb } from "@/lib/db/client";
-
-/** Order matters — Stage N depends on Stage N-1. */
-const MIGRATIONS = [
-  "0000_init.test.sql",
-  "0001_stage2.test.sql",
-  "0002_stage3.test.sql",
-  "0003_stage4.test.sql",
-  "0004_stage5.test.sql",
-  "0005_stage7.test.sql",
-  "0006_stage8.test.sql",
-] as const;
 
 let cachedDDL: string | null = null;
 
 async function loadDDL(): Promise<string> {
   if (cachedDDL) return cachedDDL;
-  const parts: string[] = [];
-  for (const file of MIGRATIONS) {
-    const path = join(process.cwd(), "db", "migrations", file);
-    parts.push(await readFile(path, "utf8"));
-  }
+  const dir = join(process.cwd(), "db", "migrations");
+  // Enumerate PGlite-compatible migration variants dynamically. Filename
+  // pattern `NNNN_*.test.sql` is zero-padded so lexicographic sort == numeric.
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith(".test.sql"))
+    .sort();
+  const parts = await Promise.all(
+    files.map((f) => readFile(join(dir, f), "utf8")),
+  );
   cachedDDL = parts.join("\n");
   return cachedDDL;
 }

--- a/db/test/pglite.ts
+++ b/db/test/pglite.ts
@@ -22,6 +22,7 @@ const MIGRATIONS = [
   "0003_stage4.test.sql",
   "0004_stage5.test.sql",
   "0005_stage7.test.sql",
+  "0006_stage8.test.sql",
 ] as const;
 
 let cachedDDL: string | null = null;

--- a/db/test/testcontainer.ts
+++ b/db/test/testcontainer.ts
@@ -15,6 +15,7 @@
  * without Docker still passes — spatial tests skip with a visible notice.
  */
 import { execFile } from "node:child_process";
+import { readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -76,13 +77,16 @@ export type TestcontainerHandle = {
 
 async function loadMigrations(): Promise<string> {
   const dir = join(process.cwd(), "db", "migrations");
-  const stage1 = await readFile(join(dir, "0000_init.sql"), "utf8");
-  const stage2 = await readFile(join(dir, "0001_stage2.sql"), "utf8");
-  const stage3 = await readFile(join(dir, "0002_stage3.sql"), "utf8");
-  const stage4 = await readFile(join(dir, "0003_stage4.sql"), "utf8");
-  const stage5 = await readFile(join(dir, "0004_stage5.sql"), "utf8");
-  const stage7 = await readFile(join(dir, "0005_stage7.sql"), "utf8");
-  return [stage1, stage2, stage3, stage4, stage5, stage7].join("\n");
+  // Enumerate production migrations dynamically. Filename pattern is
+  // `NNNN_*.sql` (zero-padded, lexicographic == numeric). The PGlite-only
+  // `*.test.sql` variants are excluded so PostGIS DDL runs as-authored.
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith(".sql") && !f.endsWith(".test.sql"))
+    .sort();
+  const parts = await Promise.all(
+    files.map((f) => readFile(join(dir, f), "utf8")),
+  );
+  return parts.join("\n");
 }
 
 /**

--- a/lib/ai/authority/fetch.ts
+++ b/lib/ai/authority/fetch.ts
@@ -1,0 +1,206 @@
+/**
+ * Stage 8 — fetch the most recent authority-published fire perimeter near
+ * a detection. Used by the brief orchestrator to populate
+ * `BriefContext.authorityPerimeter` (replaces the Stage 3 hardcoded null).
+ *
+ * Build-without-blocking discipline: any failure (no covering source, HTTP
+ * error, timeout, parse error, no features in radius) returns null. The
+ * brief then ships with all-null perimeter fields exactly as it did in
+ * Stages 3–7. The next 15-min cron tick is the retry — no backoff loop.
+ */
+import { selectSourceForBucket, type AuthoritySource } from "./sources";
+
+export type AuthorityPerimeter = {
+  source: string;
+  postedTs: string;
+  containsDetection: boolean;
+  rawFeatureId?: string;
+};
+
+export type FetchPerimeterArgs = {
+  lat: number;
+  lon: number;
+  radiusKm?: number;
+  regionBucket: string;
+  now?: Date;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+};
+
+const DEFAULT_RADIUS_KM = 25;
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+type GeoJsonFeature = {
+  type: "Feature";
+  id?: unknown;
+  geometry: GeoJsonGeometry | null;
+  properties?: Record<string, unknown> | null;
+};
+
+type GeoJsonGeometry =
+  | { type: "Polygon"; coordinates: number[][][] }
+  | { type: "MultiPolygon"; coordinates: number[][][][] };
+
+type GeoJsonCollection = {
+  type: "FeatureCollection";
+  features?: GeoJsonFeature[];
+};
+
+export async function fetchAuthorityPerimeter(
+  args: FetchPerimeterArgs,
+): Promise<AuthorityPerimeter | null> {
+  const source = selectSourceForBucket(args.regionBucket);
+  if (!source) return null;
+
+  const radiusKm = args.radiusKm ?? DEFAULT_RADIUS_KM;
+  const timeoutMs = args.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchImpl = args.fetchImpl ?? fetch;
+
+  let res: Response;
+  try {
+    res = await fetchImpl(source.url, {
+      signal: AbortSignal.timeout(timeoutMs),
+      headers: { accept: "application/geo+json, application/json" },
+    });
+  } catch (err) {
+    console.warn(`[authority] ${source.id}: fetch failed: ${describeErr(err)}`);
+    return null;
+  }
+  if (!res.ok) {
+    console.warn(`[authority] ${source.id}: HTTP ${res.status}`);
+    return null;
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (err) {
+    console.warn(`[authority] ${source.id}: parse error: ${describeErr(err)}`);
+    return null;
+  }
+
+  const collection = body as GeoJsonCollection;
+  if (!collection || collection.type !== "FeatureCollection" || !Array.isArray(collection.features)) {
+    console.warn(`[authority] ${source.id}: not a FeatureCollection`);
+    return null;
+  }
+
+  const best = pickBestFeature(collection.features, source, args.lat, args.lon, radiusKm);
+  if (!best) return null;
+
+  return {
+    source: source.name,
+    postedTs: best.postedTs,
+    containsDetection: best.containsDetection,
+    rawFeatureId: source.extractFeatureId({ id: best.feature.id, properties: best.feature.properties ?? undefined }),
+  };
+}
+
+type Picked = {
+  feature: GeoJsonFeature;
+  postedTs: string;
+  containsDetection: boolean;
+};
+
+function pickBestFeature(
+  features: GeoJsonFeature[],
+  source: AuthoritySource,
+  lat: number,
+  lon: number,
+  radiusKm: number,
+): Picked | null {
+  let best: Picked | null = null;
+  let bestTs = -Infinity;
+  for (const f of features) {
+    if (!f || !f.geometry) continue;
+    const polys = toPolygonRings(f.geometry);
+    if (polys.length === 0) continue;
+    const centroid = polygonsCentroid(polys);
+    if (!centroid) continue;
+    const d = haversineKm(lat, lon, centroid.lat, centroid.lon);
+    if (d > radiusKm) continue;
+    const postedTs = source.extractPostedTs((f.properties ?? {}) as Record<string, unknown>);
+    if (!postedTs) continue;
+    const tsMs = new Date(postedTs).getTime();
+    if (!Number.isFinite(tsMs)) continue;
+    if (tsMs <= bestTs) continue;
+    bestTs = tsMs;
+    best = {
+      feature: f,
+      postedTs,
+      containsDetection: pointInAnyPolygon(lat, lon, polys),
+    };
+  }
+  return best;
+}
+
+function toPolygonRings(geom: GeoJsonGeometry): number[][][][] {
+  if (geom.type === "Polygon") return [geom.coordinates];
+  if (geom.type === "MultiPolygon") return geom.coordinates;
+  return [];
+}
+
+function polygonsCentroid(polys: number[][][][]): { lat: number; lon: number } | null {
+  // Mean of the outer-ring vertices across all polygons. Good enough for the
+  // radius filter — we don't need the exact area centroid.
+  let sumLon = 0;
+  let sumLat = 0;
+  let count = 0;
+  for (const poly of polys) {
+    const outer = poly[0];
+    if (!Array.isArray(outer)) continue;
+    for (const pt of outer) {
+      const lon = Number(pt[0]);
+      const lat = Number(pt[1]);
+      if (!Number.isFinite(lon) || !Number.isFinite(lat)) continue;
+      sumLon += lon;
+      sumLat += lat;
+      count += 1;
+    }
+  }
+  if (count === 0) return null;
+  return { lon: sumLon / count, lat: sumLat / count };
+}
+
+function pointInAnyPolygon(lat: number, lon: number, polys: number[][][][]): boolean {
+  for (const poly of polys) {
+    if (pointInPolygon(lon, lat, poly)) return true;
+  }
+  return false;
+}
+
+/** Ray casting on (x=lon, y=lat). Outer ring + inner holes (odd-even rule). */
+function pointInPolygon(x: number, y: number, rings: number[][][]): boolean {
+  let inside = false;
+  for (const ring of rings) {
+    let local = false;
+    for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+      const xi = ring[i][0];
+      const yi = ring[i][1];
+      const xj = ring[j][0];
+      const yj = ring[j][1];
+      const intersect =
+        yi > y !== yj > y &&
+        x < ((xj - xi) * (y - yi)) / (yj - yi || Number.EPSILON) + xi;
+      if (intersect) local = !local;
+    }
+    if (local) inside = !inside;
+  }
+  return inside;
+}
+
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(a)));
+}
+
+function describeErr(err: unknown): string {
+  if (err instanceof Error) return `${err.name}: ${err.message}`;
+  return String(err);
+}

--- a/lib/ai/authority/sources.ts
+++ b/lib/ai/authority/sources.ts
@@ -1,0 +1,139 @@
+/**
+ * Stage 8 — public authority-perimeter source catalog.
+ *
+ * Each source publishes recent fire perimeters as a public, key-free
+ * GeoJSON FeatureCollection. The orchestrator (`lib/ai/generate.ts`)
+ * pre-fetches the most recent feature near the detection and folds it into
+ * the brief context. Path A from brief 22; tool-calling (Path B) is a v1.1
+ * follow-up.
+ *
+ * Confirmed working endpoints (curl, 2026-05-07):
+ *   - NIFC WFIGS Interagency Perimeters Current
+ *     `https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/WFIGS_Interagency_Perimeters_Current/FeatureServer/0/query?where=1%3D1&outFields=*&f=geojson`
+ *     Sample feature props: poly_PolygonDateTime (epoch ms),
+ *     attr_FireDiscoveryDateTime (epoch ms), attr_IncidentName.
+ *   - CWFIS m3_polygons_current (Natural Resources Canada)
+ *     `https://cwfis.cfs.nrcan.gc.ca/geoserver/public/ows?service=WFS&version=2.0.0&request=GetFeature&typeNames=public:m3_polygons_current&outputFormat=application/json&srsName=EPSG:4326`
+ *     Sample feature props: lastdate (ISO 8601 string), firstdate, area.
+ *
+ * NOT shipped in Stage 8 (filed as Vanyo blocker):
+ *   - ICNF (Portugal): no key-free public GeoJSON perimeter endpoint found.
+ *     fogos.pt publishes incident POINTS only, not polygons. ICNF SGIF is
+ *     map-tile only. Per brief instructions: surfaced as a blocker, not
+ *     fabricated.
+ */
+
+export type AuthoritySourceId = "nifc" | "cwfis";
+
+export type AuthoritySource = {
+  id: AuthoritySourceId;
+  /** User-visible label persisted into `brief.context.authority_perimeter.source`. */
+  name: string;
+  /** Public GeoJSON URL. Confirmed key-free. */
+  url: string;
+  /**
+   * Predicate against `region_bucket` (e.g. "5x5:W125_N40"). True if this
+   * source's coverage area includes that 5°×5° tile. Cheaper and more
+   * accurate than a hardcoded prefix list.
+   */
+  coversBucket: (bucket: string) => boolean;
+  /**
+   * Extract the publication timestamp from a feature's properties. Returns
+   * an ISO 8601 string or null if the feature has no usable timestamp.
+   */
+  extractPostedTs: (props: Record<string, unknown>) => string | null;
+  /** Source-stable id for the feature (debug only — never sent to the LLM). */
+  extractFeatureId: (feature: { id?: unknown; properties?: Record<string, unknown> }) => string | undefined;
+};
+
+const NIFC: AuthoritySource = {
+  id: "nifc",
+  name: "NIFC WFIGS",
+  url: "https://services3.arcgis.com/T4QMspbfLg3qTGWY/arcgis/rest/services/WFIGS_Interagency_Perimeters_Current/FeatureServer/0/query?where=1%3D1&outFields=*&f=geojson",
+  coversBucket: (bucket) => {
+    // CONUS + Alaska + Hawaii. Bucket format: 5x5:<E|W><lonAbs>_<N|S><latAbs>
+    // CONUS roughly lon -125..-65, lat 24..50. Alaska lon -170..-130, lat 52..72.
+    // Hawaii lon -160..-154, lat 18..23.
+    const parsed = parseBucket(bucket);
+    if (!parsed) return false;
+    const { lon, lat } = parsed;
+    if (lat >= 24 && lat <= 50 && lon >= -125 && lon <= -65) return true;
+    if (lat >= 52 && lat <= 72 && lon >= -170 && lon <= -130) return true;
+    if (lat >= 18 && lat <= 23 && lon >= -160 && lon <= -154) return true;
+    return false;
+  },
+  extractPostedTs: (props) => {
+    // Prefer the polygon-as-of timestamp, fall back to discovery time.
+    const candidates = [
+      props.poly_PolygonDateTime,
+      props.poly_DateCurrent,
+      props.attr_FireDiscoveryDateTime,
+    ];
+    for (const v of candidates) {
+      if (typeof v === "number" && Number.isFinite(v)) {
+        const d = new Date(v);
+        if (Number.isFinite(d.getTime())) return d.toISOString();
+      }
+      if (typeof v === "string" && v) {
+        const d = new Date(v);
+        if (Number.isFinite(d.getTime())) return d.toISOString();
+      }
+    }
+    return null;
+  },
+  extractFeatureId: (feature) => {
+    if (typeof feature.id === "string" || typeof feature.id === "number") {
+      return String(feature.id);
+    }
+    const irwin = feature.properties?.attr_IrwinID;
+    if (typeof irwin === "string") return irwin;
+    return undefined;
+  },
+};
+
+const CWFIS: AuthoritySource = {
+  id: "cwfis",
+  name: "CWFIS",
+  url: "https://cwfis.cfs.nrcan.gc.ca/geoserver/public/ows?service=WFS&version=2.0.0&request=GetFeature&typeNames=public:m3_polygons_current&outputFormat=application/json&srsName=EPSG:4326",
+  coversBucket: (bucket) => {
+    // Canada roughly lon -141..-52, lat 41..83.
+    const parsed = parseBucket(bucket);
+    if (!parsed) return false;
+    const { lon, lat } = parsed;
+    return lat >= 41 && lat <= 83 && lon >= -141 && lon <= -52;
+  },
+  extractPostedTs: (props) => {
+    const v = props.lastdate ?? props.firstdate;
+    if (typeof v === "string" && v) {
+      const d = new Date(v);
+      if (Number.isFinite(d.getTime())) return d.toISOString();
+    }
+    return null;
+  },
+  extractFeatureId: (feature) => {
+    if (typeof feature.id === "string" || typeof feature.id === "number") {
+      return String(feature.id);
+    }
+    return undefined;
+  },
+};
+
+export const AUTHORITY_SOURCES: readonly AuthoritySource[] = [NIFC, CWFIS];
+
+export function selectSourceForBucket(bucket: string): AuthoritySource | null {
+  for (const s of AUTHORITY_SOURCES) {
+    if (s.coversBucket(bucket)) return s;
+  }
+  return null;
+}
+
+/** Parse the SW corner of a 5°×5° bucket key. */
+function parseBucket(bucket: string): { lon: number; lat: number } | null {
+  const m = /^5x5:([EW])(\d{3})_([NS])(\d{2})$/.exec(bucket);
+  if (!m) return null;
+  const [, lonHemi, lonAbs, latHemi, latAbs] = m;
+  const lon = (lonHemi === "W" ? -1 : 1) * Number(lonAbs);
+  const lat = (latHemi === "S" ? -1 : 1) * Number(latAbs);
+  if (!Number.isFinite(lon) || !Number.isFinite(lat)) return null;
+  return { lon, lat };
+}

--- a/lib/ai/authority/tool.ts
+++ b/lib/ai/authority/tool.ts
@@ -1,0 +1,33 @@
+/**
+ * Stage 8 — Path A wrapper around `fetchAuthorityPerimeter`.
+ *
+ * Despite the filename, this is NOT a Vercel AI SDK `tool()` call. AI SDK v6's
+ * `generateObject` does not accept a `tools` parameter — tools are only on
+ * `generateText` / `streamText`. Brief 22 §"Critical implementation question"
+ * resolved this to **Path A**: the orchestrator pre-fetches before calling
+ * the model, so the structured-output contract is preserved and there's only
+ * one LLM round-trip per brief.
+ *
+ * The wrapper exists so that a v1.1 swap to a literal LLM tool-call is a
+ * one-call change: the shape this returns is exactly what a `tool().execute`
+ * would resolve to.
+ */
+import { fetchAuthorityPerimeter, type FetchPerimeterArgs } from "./fetch";
+
+export type PerimeterToolResult = {
+  source: string | null;
+  posted_ts: string | null;
+  contains_detection: boolean | null;
+};
+
+export async function runAuthorityPerimeterTool(
+  args: FetchPerimeterArgs,
+): Promise<PerimeterToolResult> {
+  const r = await fetchAuthorityPerimeter(args);
+  if (!r) return { source: null, posted_ts: null, contains_detection: null };
+  return {
+    source: r.source,
+    posted_ts: r.postedTs,
+    contains_detection: r.containsDetection,
+  };
+}

--- a/lib/ai/generate.ts
+++ b/lib/ai/generate.ts
@@ -29,6 +29,11 @@ import {
 } from "./gateway";
 import { renderBriefMarkdown } from "./render";
 import { BriefSchema, type Brief } from "./schema";
+import {
+  fetchAuthorityPerimeter,
+  type AuthorityPerimeter,
+  type FetchPerimeterArgs,
+} from "./authority/fetch";
 
 export type GenerateOutcome =
   | { status: "generated"; eventId: string; briefId: string; modelId: string; gateReason: GateReason }
@@ -47,6 +52,12 @@ type GeneratorDeps = {
   }) => Promise<GatewayResult>;
   /** Override clock for deterministic testing of the gate window. */
   now?: Date;
+  /**
+   * Override the authority-perimeter fetch (Stage 8). Production injects null
+   * and the orchestrator calls the real `fetchAuthorityPerimeter`. Tests can
+   * stub a happy or rejecting impl; the brief still ships either way.
+   */
+  fetchPerimeter?: (args: FetchPerimeterArgs) => Promise<AuthorityPerimeter | null>;
 };
 
 const WINDOW_HOURS_DEFAULT = 24;
@@ -90,7 +101,7 @@ export async function generateBriefForEvent(
       lastSeenAt: loaded.lastSeenAt.toISOString(),
     },
     weather: null,
-    authorityPerimeter: null,
+    authorityPerimeter: await gatherAuthorityPerimeter(loaded, deps),
     priorEvents: loaded.priorEvents,
   };
 
@@ -145,6 +156,40 @@ export async function generateBriefForEvent(
 }
 
 // ---------------------------------------------------------------------------
+// Stage 8 — authority perimeter gather (Path A: orchestrator pre-fetch).
+
+async function gatherAuthorityPerimeter(
+  loaded: LoadedContext,
+  deps: GeneratorDeps,
+): Promise<{
+  source: string | null;
+  postedTs: string | null;
+  containsDetection: boolean | null;
+} | null> {
+  if (!loaded.nearestDetection || !loaded.regionBucket) return null;
+  const fetcher = deps.fetchPerimeter ?? fetchAuthorityPerimeter;
+  let r: AuthorityPerimeter | null;
+  try {
+    r = await fetcher({
+      lat: loaded.nearestDetection.lat,
+      lon: loaded.nearestDetection.lon,
+      regionBucket: loaded.regionBucket,
+    });
+  } catch (err) {
+    // Build-without-blocking — never let an authority fetch failure abort
+    // brief generation. Logged; the brief ships with all-null perimeter.
+    console.warn(`[authority] fetcher threw: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
+  if (!r) return null;
+  return {
+    source: r.source,
+    postedTs: r.postedTs,
+    containsDetection: r.containsDetection,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // DB load / persist
 
 type LoadedContext = {
@@ -164,6 +209,9 @@ type LoadedContext = {
   lastAoiEventBriefedAt: Date | null;
   satellites: string[];
   priorEvents: Array<{ date: string; description: string; outcome: string | null }>;
+  regionBucket: string;
+  /** Lat/lon of the nearest non-industrial detection in the event window, when known. */
+  nearestDetection: { lat: number; lon: number } | null;
 };
 
 async function loadEventContext(
@@ -271,6 +319,8 @@ async function loadEventContext(
     lastAoiEventBriefedAt: lastAoiBrief,
     satellites,
     priorEvents,
+    regionBucket,
+    nearestDetection,
   };
 }
 

--- a/lib/db/freshness.ts
+++ b/lib/db/freshness.ts
@@ -1,0 +1,102 @@
+/**
+ * Stage 8 — per-AOI freshness lookup for the dashboard.
+ *
+ * Joins `aois` → `job_runs` on bucket and returns the most recent completed
+ * (i.e. not 'running') run for that bucket. The AOI page uses this to render
+ * the freshness banner — "Last polled 47 minutes ago" or a yellow degraded
+ * variant.
+ *
+ * Two-backend repository pattern: pure SQL, runs identically on Neon and
+ * PGlite. Uses the partial index `job_runs_bucket_started_at_idx` for an
+ * O(log n) lookup.
+ */
+import { sql } from "drizzle-orm";
+import type { AppDb } from "./client";
+import type { FreshnessOutcome } from "@/lib/firms/freshness";
+
+export type AoiFreshness = {
+  bucket: string;
+  lastPolledAt: Date | null;
+  outcome: FreshnessOutcome | null;
+  retryPending: boolean;
+  /** True when last successful poll is older than the staleness window. */
+  isStale: boolean;
+};
+
+const STALE_AFTER_MS = 30 * 60 * 1000; // 30 min
+
+export async function getAoiFreshness(
+  db: AppDb,
+  args: { aoiId: string; userId: string; now?: Date },
+): Promise<AoiFreshness | null> {
+  const result = (await db.execute(sql`
+    SELECT
+      a."region_bucket"     AS bucket,
+      j."started_at"        AS started_at,
+      j."finished_at"       AS finished_at,
+      j."outcome"           AS outcome,
+      j."retry_pending"     AS retry_pending
+    FROM "aois" a
+    LEFT JOIN LATERAL (
+      SELECT "started_at", "finished_at", "outcome", "retry_pending"
+      FROM "job_runs"
+      WHERE "bucket" = a."region_bucket"
+        AND "status" <> 'running'
+      ORDER BY "started_at" DESC
+      LIMIT 1
+    ) j ON TRUE
+    WHERE a."id" = ${args.aoiId}
+      AND a."user_id" = ${args.userId}
+    LIMIT 1
+  `)) as unknown as {
+    rows?: Array<{
+      bucket: string;
+      started_at: Date | string | null;
+      finished_at: Date | string | null;
+      outcome: string | null;
+      retry_pending: boolean | null;
+    }>;
+  };
+  const rows = (result.rows ??
+    (result as unknown as Array<{
+      bucket: string;
+      started_at: Date | string | null;
+      finished_at: Date | string | null;
+      outcome: string | null;
+      retry_pending: boolean | null;
+    }>)) as Array<{
+    bucket: string;
+    started_at: Date | string | null;
+    finished_at: Date | string | null;
+    outcome: string | null;
+    retry_pending: boolean | null;
+  }>;
+  const row = rows[0];
+  if (!row) return null;
+
+  const finished = toDate(row.finished_at) ?? toDate(row.started_at);
+  const outcome = (row.outcome as FreshnessOutcome | null) ?? null;
+  const retryPending = Boolean(row.retry_pending);
+  const now = args.now ?? new Date();
+  const isStale =
+    outcome === "success" &&
+    finished != null &&
+    now.getTime() - finished.getTime() > STALE_AFTER_MS;
+  return {
+    bucket: row.bucket,
+    lastPolledAt: finished,
+    outcome,
+    retryPending,
+    isStale,
+  };
+}
+
+function toDate(v: unknown): Date | null {
+  if (v == null) return null;
+  if (v instanceof Date) return v;
+  if (typeof v === "string" || typeof v === "number") {
+    const d = new Date(v);
+    return Number.isFinite(d.getTime()) ? d : null;
+  }
+  return null;
+}

--- a/lib/firms/freshness.ts
+++ b/lib/firms/freshness.ts
@@ -1,0 +1,59 @@
+/**
+ * Stage 8 — pure mapping from FIRMS client / matcher / brief outcomes onto
+ * the user-facing `job_runs.outcome` taxonomy.
+ *
+ * Operator-facing `status` (ok|partial|error|running) stays on `job_runs`
+ * for compatibility — that audience is unchanged. `outcome` is what the
+ * AOI-page freshness banner reads.
+ */
+import type { FirmsFetchErrCode } from "./client";
+
+export type FreshnessOutcome =
+  | "success"
+  | "rate_limited"
+  | "network_error"
+  | "timeout"
+  | "partial";
+
+export type FreshnessOutcomeWithRetry = {
+  outcome: FreshnessOutcome;
+  /**
+   * Signal (not promise) that the next 15-min cron tick is the retry. Banner
+   * copy uses this to render "(retrying)" instead of "(failed)".
+   */
+  retryPending: boolean;
+};
+
+/** FIRMS fetch failure → freshness outcome. */
+export function firmsErrorToOutcome(code: FirmsFetchErrCode): FreshnessOutcomeWithRetry {
+  switch (code) {
+    case "rate_limited":
+    case "throttled_local":
+      return { outcome: "rate_limited", retryPending: true };
+    case "network_error":
+      return { outcome: "network_error", retryPending: true };
+    case "upstream_error":
+    case "parse_error":
+      return { outcome: "network_error", retryPending: true };
+    case "config_missing":
+      // Operator-facing failure; nothing to retry until secret is set. Surface
+      // as network_error to the user — the banner gets them attention either
+      // way; the operator-facing `status='error'` is the actionable signal.
+      return { outcome: "network_error", retryPending: false };
+  }
+}
+
+/** Bucket-run terminal status → freshness outcome. */
+export function runStatusToOutcome(args: {
+  status: "ok" | "partial" | "error";
+  error?: string | null;
+}): FreshnessOutcomeWithRetry {
+  if (args.status === "ok") return { outcome: "success", retryPending: false };
+  if (args.status === "partial") return { outcome: "partial", retryPending: false };
+  // status === 'error' without a more specific code → treat as network error
+  // and mark retry pending. AbortError is mapped to timeout below.
+  if (args.error && /AbortError|timeout/i.test(args.error)) {
+    return { outcome: "timeout", retryPending: true };
+  }
+  return { outcome: "network_error", retryPending: true };
+}

--- a/lib/ui/relative-time.ts
+++ b/lib/ui/relative-time.ts
@@ -1,0 +1,20 @@
+/**
+ * Stage 8 — minimal "47 minutes ago" formatter.
+ *
+ * In-repo to avoid pulling `date-fns` for one helper. Future-tense and
+ * sub-second deltas are out of scope (this is for the freshness banner).
+ */
+
+export function formatRelative(now: Date, then: Date): string {
+  const ms = now.getTime() - then.getTime();
+  if (!Number.isFinite(ms)) return "unknown time ago";
+  if (ms < 0) return "just now";
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return "less than a minute ago";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}

--- a/tests/ai/authority/fetch.live.test.ts
+++ b/tests/ai/authority/fetch.live.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Stage 8 — live endpoint smoke. Skipped unless AUTHORITY_PERIMETER_LIVE=1
+ * (mirrors the FIRMS_LIVE pattern). Run before merge to catch endpoint drift.
+ *
+ * Each source is hit with a known recent-fire region. Returning null is OK
+ * (no active fires today); throwing or rejecting is not — that surfaces an
+ * endpoint regression we should file as a blocker.
+ */
+import { describe, it, expect } from "vitest";
+import { fetchAuthorityPerimeter } from "@/lib/ai/authority/fetch";
+
+const live = process.env.AUTHORITY_PERIMETER_LIVE === "1";
+const d = live ? describe : describe.skip;
+
+d("authority perimeter live endpoints (AUTHORITY_PERIMETER_LIVE=1)", () => {
+  it("NIFC WFIGS — Northern California region", async () => {
+    const r = await fetchAuthorityPerimeter({
+      lat: 38.5,
+      lon: -122.7,
+      regionBucket: "5x5:W125_N35",
+      radiusKm: 500,
+      timeoutMs: 30_000,
+    });
+    // Either a hit (active fire near point) or null (none in radius). Both pass —
+    // we only fail on thrown errors or non-FeatureCollection bodies.
+    expect(r === null || typeof r.source === "string").toBe(true);
+  }, 35_000);
+
+  it("CWFIS — central Canada region", async () => {
+    const r = await fetchAuthorityPerimeter({
+      lat: 53.5,
+      lon: -113.5,
+      regionBucket: "5x5:W115_N50",
+      radiusKm: 500,
+      timeoutMs: 30_000,
+    });
+    expect(r === null || typeof r.source === "string").toBe(true);
+  }, 35_000);
+});

--- a/tests/ai/authority/fetch.test.ts
+++ b/tests/ai/authority/fetch.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Stage 8 — `fetchAuthorityPerimeter` unit tests with stubbed HTTP.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { fetchAuthorityPerimeter } from "@/lib/ai/authority/fetch";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function squarePolygon(centerLon: number, centerLat: number, halfDeg = 0.05): number[][][] {
+  // Roughly 5–10 km per side at mid-latitudes; small enough to keep test fixtures sane.
+  return [
+    [
+      [centerLon - halfDeg, centerLat - halfDeg],
+      [centerLon + halfDeg, centerLat - halfDeg],
+      [centerLon + halfDeg, centerLat + halfDeg],
+      [centerLon - halfDeg, centerLat + halfDeg],
+      [centerLon - halfDeg, centerLat - halfDeg],
+    ],
+  ];
+}
+
+const NIFC_BUCKET = "5x5:W125_N40"; // covered by NIFC
+
+describe("fetchAuthorityPerimeter", () => {
+  it("returns null when no source covers the bucket without making a network call", async () => {
+    const fetchImpl = vi.fn();
+    const r = await fetchAuthorityPerimeter({
+      lat: -33.9,
+      lon: 151.2,
+      regionBucket: "5x5:E150_S35", // Sydney — no source
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(r).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns the in-radius feature with most recent timestamp", async () => {
+    const detLat = 38.5;
+    const detLon = -122.7;
+    const olderTs = 1_770_000_000_000; // older
+    const newerTs = 1_775_000_000_000; // newer
+    const farTs = 1_780_000_000_000;   // newest, but outside radius
+
+    const collection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: 1,
+          geometry: { type: "Polygon", coordinates: squarePolygon(detLon + 0.1, detLat + 0.05) },
+          properties: { poly_PolygonDateTime: olderTs },
+        },
+        {
+          type: "Feature",
+          id: 2,
+          geometry: { type: "Polygon", coordinates: squarePolygon(detLon, detLat) },
+          properties: { poly_PolygonDateTime: newerTs },
+        },
+        {
+          type: "Feature",
+          id: 3,
+          // ~500 km away — outside default 25 km radius
+          geometry: { type: "Polygon", coordinates: squarePolygon(detLon + 5, detLat + 5) },
+          properties: { poly_PolygonDateTime: farTs },
+        },
+      ],
+    };
+
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(collection));
+    const r = await fetchAuthorityPerimeter({
+      lat: detLat,
+      lon: detLon,
+      regionBucket: NIFC_BUCKET,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(r).not.toBeNull();
+    expect(r!.source).toBe("NIFC WFIGS");
+    expect(r!.postedTs).toBe(new Date(newerTs).toISOString());
+    expect(r!.containsDetection).toBe(true);
+    expect(r!.rawFeatureId).toBe("2");
+  });
+
+  it("returns containsDetection=false when feature is in radius but does not contain the point", async () => {
+    const detLat = 38.5;
+    const detLon = -122.7;
+    const collection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: 1,
+          // Centroid ~12 km away (within 25 km), but the polygon is small and offset.
+          geometry: { type: "Polygon", coordinates: squarePolygon(detLon + 0.15, detLat) },
+          properties: { poly_PolygonDateTime: 1_775_000_000_000 },
+        },
+      ],
+    };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(collection));
+    const r = await fetchAuthorityPerimeter({
+      lat: detLat,
+      lon: detLon,
+      regionBucket: NIFC_BUCKET,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(r).not.toBeNull();
+    expect(r!.containsDetection).toBe(false);
+  });
+
+  it("returns null on 404", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("nope", { status: 404 }));
+    const r = await fetchAuthorityPerimeter({
+      lat: 38.5,
+      lon: -122.7,
+      regionBucket: NIFC_BUCKET,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(r).toBeNull();
+  });
+
+  it("returns null on rate limit (429)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("slow down", { status: 429 }));
+    const r = await fetchAuthorityPerimeter({
+      lat: 38.5,
+      lon: -122.7,
+      regionBucket: NIFC_BUCKET,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(r).toBeNull();
+  });
+
+  it("returns null on network rejection", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new TypeError("ECONNRESET"));
+    const r = await fetchAuthorityPerimeter({
+      lat: 38.5,
+      lon: -122.7,
+      regionBucket: NIFC_BUCKET,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(r).toBeNull();
+  });
+
+  it("returns null on malformed JSON body", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response("not-json{", { status: 200, headers: { "content-type": "application/json" } }),
+    );
+    const r = await fetchAuthorityPerimeter({
+      lat: 38.5,
+      lon: -122.7,
+      regionBucket: NIFC_BUCKET,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(r).toBeNull();
+  });
+
+  it("returns null when no features are in radius", async () => {
+    const collection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: 1,
+          geometry: { type: "Polygon", coordinates: squarePolygon(-100, 30) },
+          properties: { poly_PolygonDateTime: 1_775_000_000_000 },
+        },
+      ],
+    };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(collection));
+    const r = await fetchAuthorityPerimeter({
+      lat: 38.5,
+      lon: -122.7,
+      regionBucket: NIFC_BUCKET,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(r).toBeNull();
+  });
+});

--- a/tests/ai/authority/generate-integration.test.ts
+++ b/tests/ai/authority/generate-integration.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Stage 8 — orchestrator integration: stubs both the gateway AND the
+ * authority fetch, asserts the persisted `aoi_briefs.payload.context.
+ * authority_perimeter` carries fetched values and that a rejecting
+ * fetcher still ships a brief (build-without-blocking).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { makeFreshTestDb } from "@/db/test/pglite";
+import type { AppDb } from "@/lib/db/client";
+import { generateBriefForEvent } from "@/lib/ai/generate";
+import type { Brief } from "@/lib/ai/schema";
+import { SCHEMA_VERSION } from "@/lib/ai/schema";
+import type { GatewayResult } from "@/lib/ai/gateway";
+import type { PGlite } from "@electric-sql/pglite";
+
+const STUB_BRIEF: Brief = {
+  schema_version: SCHEMA_VERSION,
+  aoi: { id: "00000000-0000-4000-8000-000000000099", name: "Test", area_ha: 100 },
+  summary: "Stubbed.",
+  key_facts: {
+    nearest_detection_km: 8,
+    bearing_from_aoi_deg: 90,
+    wind_dir_deg: null,
+    wind_speed_kmh: null,
+    wind_toward_aoi: null,
+    detection_count_in_window: 2,
+    max_frp_mw: 12,
+    satellites: [],
+    window_hours: 24,
+  },
+  // Real LLM would echo back the perimeter; we hardcode a passing payload here
+  // because the test is about what the orchestrator PASSED IN, not what the
+  // model echoed. The persisted payload is the model's output.
+  context: {
+    weather_note: null,
+    authority_perimeter: {
+      source: "NIFC WFIGS",
+      posted_ts: "2026-05-07T11:00:00.000Z",
+      contains_detection: true,
+    },
+    prior_events: [],
+  },
+  recommended_watch_items: ["x"],
+  uncertainty: "stub",
+  next_brief_hint: { when: "next tick", trigger: "any" },
+};
+
+async function seed(db: AppDb): Promise<{ eventId: string; aoiId: string }> {
+  const polygon = JSON.stringify({
+    type: "Polygon",
+    coordinates: [
+      [
+        [-122.7, 38.4],
+        [-122.6, 38.4],
+        [-122.6, 38.5],
+        [-122.7, 38.5],
+        [-122.7, 38.4],
+      ],
+    ],
+  });
+  await db.execute(sql`
+    INSERT INTO "users" ("id", "email")
+    VALUES ('user_2authGen', 'auth@example.org')
+    ON CONFLICT ("id") DO NOTHING
+  `);
+  const aoiRes = (await db.execute(sql`
+    INSERT INTO "aois" (user_id, name, polygon, bbox, centroid, region_bucket, area_ha)
+    VALUES (
+      'user_2authGen', 'AuthAOI',
+      ${polygon}, ${polygon},
+      ${JSON.stringify({ type: "Point", coordinates: [-122.65, 38.45] })},
+      '5x5:W125_N35', 100
+    ) RETURNING id
+  `)) as unknown as { rows?: Array<{ id: string }> };
+  const aoiRows = (aoiRes.rows ?? (aoiRes as unknown as Array<{ id: string }>)) as Array<{ id: string }>;
+  const aoiId = aoiRows[0].id;
+  await db.execute(sql`
+    INSERT INTO "aoi_rules" (aoi_id, distance_buffer_km, min_confidence, min_frp_mw)
+    VALUES (${aoiId}, 25, 'nominal', 5)
+  `);
+  // Seed a non-industrial detection inside the window so loadEventContext
+  // resolves a nearestDetection.
+  const detGeom = JSON.stringify({ type: "Point", coordinates: [-122.6, 38.5] });
+  await db.execute(sql`
+    INSERT INTO "firms_detections" (
+      source, detected_at, geom, lat, lon, frp_mw, confidence, daynight,
+      acq_date, acq_time, bucket
+    ) VALUES (
+      'VIIRS_NOAA20_NRT', '2026-04-21T04:15:00Z', ${detGeom},
+      38.5, -122.6, 11, 'nominal', 'D', '2026-04-21', '0415',
+      '5x5:W125_N35'
+    )
+  `);
+  const evRes = (await db.execute(sql`
+    INSERT INTO "aoi_events" (
+      aoi_id, first_seen_at, last_seen_at,
+      nearest_distance_km, detection_count, peak_frp_mw,
+      dedupe_hash, status
+    ) VALUES (
+      ${aoiId}, '2026-04-21T04:00:00Z', '2026-04-21T04:30:00Z',
+      8, 2, 11, ${"hash-" + Math.random().toString(36).slice(2)}, 'new'
+    ) RETURNING id
+  `)) as unknown as { rows?: Array<{ id: string }> };
+  const evRows = (evRes.rows ?? (evRes as unknown as Array<{ id: string }>)) as Array<{ id: string }>;
+  return { aoiId, eventId: evRows[0].id };
+}
+
+describe("generateBriefForEvent — Stage 8 authority perimeter wiring", () => {
+  let db: AppDb;
+  let pglite: PGlite;
+  beforeEach(async () => {
+    ({ db, pglite } = await makeFreshTestDb());
+  });
+  afterEach(async () => {
+    await pglite.close();
+  });
+
+  it("calls fetchPerimeter with bucket+nearest detection and persists the result", async () => {
+    const { eventId, aoiId } = await seed(db);
+    let receivedArgs: { lat: number; lon: number; regionBucket: string } | null = null;
+    const fetchPerimeter = async (args: { lat: number; lon: number; regionBucket: string }) => {
+      receivedArgs = { lat: args.lat, lon: args.lon, regionBucket: args.regionBucket };
+      return {
+        source: "NIFC WFIGS",
+        postedTs: "2026-05-07T11:00:00.000Z",
+        containsDetection: true,
+      };
+    };
+    const stubGateway = async (): Promise<GatewayResult> => ({
+      ok: true,
+      brief: { ...STUB_BRIEF, aoi: { ...STUB_BRIEF.aoi, id: aoiId } },
+      modelId: "test/stub",
+      promptVersion: "v1",
+      latencyMs: 1,
+      costUsdEst: null,
+    });
+
+    const outcome = await generateBriefForEvent(db, eventId, {
+      gateway: stubGateway,
+      fetchPerimeter,
+    });
+    expect(outcome.status).toBe("generated");
+    expect(receivedArgs).not.toBeNull();
+    expect(receivedArgs!.regionBucket).toBe("5x5:W125_N35");
+    expect(receivedArgs!.lat).toBeCloseTo(38.5, 4);
+
+    const briefs = (await db.execute(sql`
+      SELECT payload FROM aoi_briefs WHERE event_id = ${eventId}
+    `)) as unknown as { rows?: Array<{ payload: { context: { authority_perimeter: unknown } } }> };
+    const brows = (briefs.rows ?? (briefs as unknown as Array<{ payload: { context: { authority_perimeter: unknown } } }>)) as Array<{
+      payload: { context: { authority_perimeter: { source: string | null; posted_ts: string | null; contains_detection: boolean | null } } };
+    }>;
+    expect(brows[0].payload.context.authority_perimeter.source).toBe("NIFC WFIGS");
+    expect(brows[0].payload.context.authority_perimeter.contains_detection).toBe(true);
+  });
+
+  it("ships the brief with all-null perimeter when fetcher rejects", async () => {
+    const { eventId, aoiId } = await seed(db);
+    const fetchPerimeter = async () => {
+      throw new Error("authority down");
+    };
+    const stubGateway = async (): Promise<GatewayResult> => ({
+      ok: true,
+      brief: {
+        ...STUB_BRIEF,
+        aoi: { ...STUB_BRIEF.aoi, id: aoiId },
+        context: {
+          weather_note: null,
+          authority_perimeter: { source: null, posted_ts: null, contains_detection: null },
+          prior_events: [],
+        },
+      },
+      modelId: "test/stub",
+      promptVersion: "v1",
+      latencyMs: 1,
+      costUsdEst: null,
+    });
+    const outcome = await generateBriefForEvent(db, eventId, {
+      gateway: stubGateway,
+      fetchPerimeter,
+    });
+    expect(outcome.status).toBe("generated");
+  });
+});

--- a/tests/ai/authority/tool.test.ts
+++ b/tests/ai/authority/tool.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Stage 8 — `runAuthorityPerimeterTool` returns the snake_case tool shape on
+ * hit and the all-null shape on miss; never throws. Future-proofs Path B.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { runAuthorityPerimeterTool } from "@/lib/ai/authority/tool";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const NIFC_BUCKET = "5x5:W125_N40";
+
+describe("runAuthorityPerimeterTool", () => {
+  it("returns snake_case fields on a hit", async () => {
+    const detLat = 38.5;
+    const detLon = -122.7;
+    const ts = 1_775_000_000_000;
+    const collection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          id: 7,
+          geometry: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [detLon - 0.05, detLat - 0.05],
+                [detLon + 0.05, detLat - 0.05],
+                [detLon + 0.05, detLat + 0.05],
+                [detLon - 0.05, detLat + 0.05],
+                [detLon - 0.05, detLat - 0.05],
+              ],
+            ],
+          },
+          properties: { poly_PolygonDateTime: ts },
+        },
+      ],
+    };
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(collection));
+    const r = await runAuthorityPerimeterTool({
+      lat: detLat,
+      lon: detLon,
+      regionBucket: NIFC_BUCKET,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(r).toEqual({
+      source: "NIFC WFIGS",
+      posted_ts: new Date(ts).toISOString(),
+      contains_detection: true,
+    });
+  });
+
+  it("returns all-null on miss without throwing", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("nope", { status: 404 }));
+    const r = await runAuthorityPerimeterTool({
+      lat: 38.5,
+      lon: -122.7,
+      regionBucket: NIFC_BUCKET,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(r).toEqual({ source: null, posted_ts: null, contains_detection: null });
+  });
+});

--- a/tests/db/freshness.test.ts
+++ b/tests/db/freshness.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Stage 8 — `getAoiFreshness` PGlite tests.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { makeFreshTestDb } from "@/db/test/pglite";
+import type { AppDb } from "@/lib/db/client";
+import { getAoiFreshness } from "@/lib/db/freshness";
+import type { PGlite } from "@electric-sql/pglite";
+
+async function seedAoi(
+  db: AppDb,
+  args: { userId: string; bucket: string; name?: string },
+): Promise<string> {
+  const polygon = JSON.stringify({
+    type: "Polygon",
+    coordinates: [
+      [
+        [-122.7, 38.4],
+        [-122.6, 38.4],
+        [-122.6, 38.5],
+        [-122.7, 38.5],
+        [-122.7, 38.4],
+      ],
+    ],
+  });
+  await db.execute(sql`
+    INSERT INTO "users" ("id", "email")
+    VALUES (${args.userId}, ${args.userId + "@example.org"})
+    ON CONFLICT ("id") DO NOTHING
+  `);
+  const res = (await db.execute(sql`
+    INSERT INTO "aois" (user_id, name, polygon, bbox, centroid, region_bucket, area_ha)
+    VALUES (
+      ${args.userId},
+      ${args.name ?? "Preserve"},
+      ${polygon},
+      ${polygon},
+      ${JSON.stringify({ type: "Point", coordinates: [-122.65, 38.45] })},
+      ${args.bucket},
+      100
+    )
+    RETURNING id
+  `)) as unknown as { rows?: Array<{ id: string }> };
+  const rows = (res.rows ?? (res as unknown as Array<{ id: string }>)) as Array<{ id: string }>;
+  return rows[0].id;
+}
+
+async function insertJobRun(
+  db: AppDb,
+  args: {
+    bucket: string | null;
+    startedAt: Date;
+    finishedAt?: Date | null;
+    status: string;
+    outcome?: string | null;
+    retryPending?: boolean;
+  },
+): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO "job_runs" ("job_name", "bucket", "started_at", "finished_at", "status", "outcome", "retry_pending")
+    VALUES (
+      'firms-poll',
+      ${args.bucket},
+      ${args.startedAt.toISOString()},
+      ${args.finishedAt ? args.finishedAt.toISOString() : null},
+      ${args.status},
+      ${args.outcome ?? null},
+      ${args.retryPending ?? false}
+    )
+  `);
+}
+
+describe("getAoiFreshness", () => {
+  let db: AppDb;
+  let pglite: PGlite;
+
+  beforeEach(async () => {
+    ({ db, pglite } = await makeFreshTestDb());
+  });
+  afterEach(async () => {
+    await pglite.close();
+  });
+
+  it("returns null when no completed run exists for the bucket", async () => {
+    const aoiId = await seedAoi(db, { userId: "user_2fresh1", bucket: "5x5:W125_N40" });
+    // A running row should be ignored.
+    await insertJobRun(db, {
+      bucket: "5x5:W125_N40",
+      startedAt: new Date("2026-05-07T12:00:00Z"),
+      status: "running",
+    });
+    const r = await getAoiFreshness(db, { aoiId, userId: "user_2fresh1" });
+    expect(r).not.toBeNull();
+    expect(r!.lastPolledAt).toBeNull();
+  });
+
+  it("picks the most recent completed run for the bucket", async () => {
+    const aoiId = await seedAoi(db, { userId: "user_2fresh2", bucket: "5x5:W125_N40" });
+    await insertJobRun(db, {
+      bucket: "5x5:W125_N40",
+      startedAt: new Date("2026-05-07T11:00:00Z"),
+      finishedAt: new Date("2026-05-07T11:01:00Z"),
+      status: "ok",
+      outcome: "success",
+    });
+    await insertJobRun(db, {
+      bucket: "5x5:W125_N40",
+      startedAt: new Date("2026-05-07T12:00:00Z"),
+      finishedAt: new Date("2026-05-07T12:01:00Z"),
+      status: "error",
+      outcome: "rate_limited",
+      retryPending: true,
+    });
+    const r = await getAoiFreshness(db, {
+      aoiId,
+      userId: "user_2fresh2",
+      now: new Date("2026-05-07T12:30:00Z"),
+    });
+    expect(r!.outcome).toBe("rate_limited");
+    expect(r!.retryPending).toBe(true);
+    expect(r!.isStale).toBe(false);
+  });
+
+  it("computes isStale when last success older than 30 min", async () => {
+    const aoiId = await seedAoi(db, { userId: "user_2fresh3", bucket: "5x5:W125_N40" });
+    await insertJobRun(db, {
+      bucket: "5x5:W125_N40",
+      startedAt: new Date("2026-05-07T11:00:00Z"),
+      finishedAt: new Date("2026-05-07T11:00:30Z"),
+      status: "ok",
+      outcome: "success",
+    });
+    const r = await getAoiFreshness(db, {
+      aoiId,
+      userId: "user_2fresh3",
+      // 31 minutes after finish
+      now: new Date("2026-05-07T11:31:31Z"),
+    });
+    expect(r!.outcome).toBe("success");
+    expect(r!.isStale).toBe(true);
+  });
+
+  it("does not leak other AOIs' bucket runs", async () => {
+    const aoiA = await seedAoi(db, { userId: "user_2fresh4", bucket: "5x5:W125_N40", name: "A" });
+    await seedAoi(db, { userId: "user_2fresh4", bucket: "5x5:W120_N40", name: "B" });
+    await insertJobRun(db, {
+      bucket: "5x5:W120_N40",
+      startedAt: new Date("2026-05-07T12:00:00Z"),
+      finishedAt: new Date("2026-05-07T12:01:00Z"),
+      status: "error",
+      outcome: "network_error",
+      retryPending: true,
+    });
+    const ra = await getAoiFreshness(db, { aoiId: aoiA, userId: "user_2fresh4" });
+    expect(ra!.bucket).toBe("5x5:W125_N40");
+    expect(ra!.outcome).toBeNull();
+    expect(ra!.lastPolledAt).toBeNull();
+  });
+
+  it("scopes to user — does not return another user's AOI", async () => {
+    const aoiId = await seedAoi(db, { userId: "user_2fresh5", bucket: "5x5:W125_N40" });
+    const r = await getAoiFreshness(db, { aoiId, userId: "user_2other" });
+    expect(r).toBeNull();
+  });
+});

--- a/tests/firms/freshness.test.ts
+++ b/tests/firms/freshness.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  firmsErrorToOutcome,
+  runStatusToOutcome,
+} from "@/lib/firms/freshness";
+
+describe("firmsErrorToOutcome", () => {
+  it("maps rate_limited and throttled_local to rate_limited+retry", () => {
+    expect(firmsErrorToOutcome("rate_limited")).toEqual({
+      outcome: "rate_limited",
+      retryPending: true,
+    });
+    expect(firmsErrorToOutcome("throttled_local")).toEqual({
+      outcome: "rate_limited",
+      retryPending: true,
+    });
+  });
+  it("maps network_error/upstream_error/parse_error to network_error+retry", () => {
+    expect(firmsErrorToOutcome("network_error").outcome).toBe("network_error");
+    expect(firmsErrorToOutcome("upstream_error").outcome).toBe("network_error");
+    expect(firmsErrorToOutcome("parse_error").outcome).toBe("network_error");
+    expect(firmsErrorToOutcome("network_error").retryPending).toBe(true);
+  });
+  it("maps config_missing to network_error+no-retry (operator-actionable)", () => {
+    expect(firmsErrorToOutcome("config_missing")).toEqual({
+      outcome: "network_error",
+      retryPending: false,
+    });
+  });
+});
+
+describe("runStatusToOutcome", () => {
+  it("status=ok → success, no retry", () => {
+    expect(runStatusToOutcome({ status: "ok" })).toEqual({
+      outcome: "success",
+      retryPending: false,
+    });
+  });
+  it("status=partial → partial, no retry", () => {
+    expect(runStatusToOutcome({ status: "partial" })).toEqual({
+      outcome: "partial",
+      retryPending: false,
+    });
+  });
+  it("status=error with timeout in error string → timeout, retry", () => {
+    expect(runStatusToOutcome({ status: "error", error: "AbortError: timed out" })).toEqual({
+      outcome: "timeout",
+      retryPending: true,
+    });
+  });
+  it("status=error generic → network_error, retry", () => {
+    expect(runStatusToOutcome({ status: "error", error: "boom" })).toEqual({
+      outcome: "network_error",
+      retryPending: true,
+    });
+  });
+});

--- a/tests/poll-freshness.test.ts
+++ b/tests/poll-freshness.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Stage 8 — poll route writes the new freshness columns.
+ *
+ * PGlite-backed (no PostGIS needed; the matcher tolerates the non-postgis
+ * backend via its turf-style fallback). Stubs FIRMS to return:
+ *   - one bucket: rate-limited error
+ *   - one bucket: success (no detections)
+ * Then asserts the per-bucket job_runs rows carry outcome / retry_pending,
+ * and asserts getAoiFreshness reports the expected banner state for an AOI
+ * in each bucket.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { makeFreshTestDb } from "@/db/test/pglite";
+import { _setTestDb, type AppDb } from "@/lib/db/client";
+import {
+  _setTestFirmsFetch,
+  _setTestBriefGen,
+  _setTestNotifyDispatch,
+  POST as pollPost,
+} from "@/app/api/aoi/poll/route";
+import { getAoiFreshness } from "@/lib/db/freshness";
+import type { PGlite } from "@electric-sql/pglite";
+
+async function seedAoi(
+  db: AppDb,
+  args: { userId: string; bucket: string; name: string },
+): Promise<string> {
+  const polygon = JSON.stringify({
+    type: "Polygon",
+    coordinates: [
+      [
+        [-122.7, 38.4],
+        [-122.6, 38.4],
+        [-122.6, 38.5],
+        [-122.7, 38.5],
+        [-122.7, 38.4],
+      ],
+    ],
+  });
+  await db.execute(sql`
+    INSERT INTO "users" ("id", "email")
+    VALUES (${args.userId}, ${args.userId + "@example.org"})
+    ON CONFLICT ("id") DO NOTHING
+  `);
+  const res = (await db.execute(sql`
+    INSERT INTO "aois" (user_id, name, polygon, bbox, centroid, region_bucket, area_ha)
+    VALUES (
+      ${args.userId}, ${args.name},
+      ${polygon}, ${polygon},
+      ${JSON.stringify({ type: "Point", coordinates: [-122.65, 38.45] })},
+      ${args.bucket}, 100
+    ) RETURNING id
+  `)) as unknown as { rows?: Array<{ id: string }> };
+  const rows = (res.rows ?? (res as unknown as Array<{ id: string }>)) as Array<{ id: string }>;
+  await db.execute(sql`
+    INSERT INTO "aoi_rules" (aoi_id, distance_buffer_km, min_confidence, min_frp_mw)
+    VALUES (${rows[0].id}, 25, 'nominal', 5)
+  `);
+  return rows[0].id;
+}
+
+describe("poll route — Stage 8 freshness writes", () => {
+  let db: AppDb;
+  let pglite: PGlite;
+
+  beforeEach(async () => {
+    ({ db, pglite } = await makeFreshTestDb());
+    _setTestDb(db);
+    process.env.CRON_SECRET = "cron-secret";
+    process.env.FIRMS_MAP_KEY = "firms-key";
+    process.env.DATABASE_URL = "postgres://stub/stub";
+    // Brief gen and notify dispatch are noops so this test stays focused on
+    // freshness writes from the FIRMS path.
+    _setTestBriefGen(async (_db, eventId) => ({
+      status: "skipped",
+      eventId,
+      reason: "config_missing",
+    }));
+    _setTestNotifyDispatch(async () => ({ briefId: "x", attempts: [] }));
+  });
+
+  afterEach(async () => {
+    _setTestDb(null);
+    _setTestFirmsFetch(null);
+    _setTestBriefGen(null);
+    _setTestNotifyDispatch(null);
+    await pglite.close();
+  });
+
+  it("rate_limited bucket → outcome=rate_limited + retry_pending=true; success bucket → outcome=success", async () => {
+    const aoiRl = await seedAoi(db, {
+      userId: "user_2pollFresh",
+      bucket: "5x5:W125_N35",
+      name: "RateLimitedAOI",
+    });
+    const aoiOk = await seedAoi(db, {
+      userId: "user_2pollFresh",
+      bucket: "5x5:W120_N35",
+      name: "OkAOI",
+    });
+
+    _setTestFirmsFetch(async (args) => {
+      if (args.bbox[0] >= -125 && args.bbox[2] <= -120) {
+        // rate-limited bucket
+        return {
+          ok: false,
+          code: "rate_limited",
+          message: "FIRMS quota",
+          status: 429,
+        };
+      }
+      return {
+        ok: true,
+        source: args.source,
+        bbox: args.bbox,
+        dayRange: args.dayRange ?? 1,
+        detections: [],
+        emptyArea: true,
+      };
+    });
+
+    const res = await pollPost(
+      new Request("http://localhost/api/aoi/poll", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer cron-secret",
+          "content-type": "application/json",
+        },
+        body: "",
+      }) as Parameters<typeof pollPost>[0],
+    );
+    expect(res.status).toBe(200);
+
+    const child = (await db.execute(sql`
+      SELECT bucket, status, outcome, retry_pending FROM job_runs WHERE bucket IS NOT NULL ORDER BY bucket
+    `)) as unknown as {
+      rows?: Array<{ bucket: string; status: string; outcome: string | null; retry_pending: boolean }>;
+    };
+    const rows = (child.rows ??
+      (child as unknown as Array<{ bucket: string; status: string; outcome: string | null; retry_pending: boolean }>)) as Array<{
+      bucket: string;
+      status: string;
+      outcome: string | null;
+      retry_pending: boolean;
+    }>;
+    expect(rows).toHaveLength(2);
+    const rl = rows.find((r) => r.bucket === "5x5:W125_N35")!;
+    const ok = rows.find((r) => r.bucket === "5x5:W120_N35")!;
+    expect(rl.outcome).toBe("rate_limited");
+    expect(rl.retry_pending).toBe(true);
+    expect(ok.outcome).toBe("success");
+    expect(ok.retry_pending).toBe(false);
+
+    const fRl = await getAoiFreshness(db, { aoiId: aoiRl, userId: "user_2pollFresh" });
+    expect(fRl!.outcome).toBe("rate_limited");
+    expect(fRl!.retryPending).toBe(true);
+    const fOk = await getAoiFreshness(db, { aoiId: aoiOk, userId: "user_2pollFresh" });
+    expect(fOk!.outcome).toBe("success");
+  });
+});

--- a/tests/ui/freshness-banner.smoke.test.tsx
+++ b/tests/ui/freshness-banner.smoke.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Stage 8 — `<FreshnessBanner>` smoke test. Renders happy + each degraded
+ * variant by stubbing the freshness query directly via PGlite seed.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { renderToStaticMarkup } from "react-dom/server.node";
+import { makeFreshTestDb } from "@/db/test/pglite";
+import type { AppDb } from "@/lib/db/client";
+import { FreshnessBanner } from "@/app/dashboard/_components/freshness-banner";
+import type { PGlite } from "@electric-sql/pglite";
+
+async function seedAoi(db: AppDb, userId: string, bucket: string): Promise<string> {
+  const polygon = JSON.stringify({
+    type: "Polygon",
+    coordinates: [
+      [
+        [-122.7, 38.4],
+        [-122.6, 38.4],
+        [-122.6, 38.5],
+        [-122.7, 38.5],
+        [-122.7, 38.4],
+      ],
+    ],
+  });
+  await db.execute(sql`
+    INSERT INTO "users" ("id", "email")
+    VALUES (${userId}, ${userId + "@example.org"})
+    ON CONFLICT ("id") DO NOTHING
+  `);
+  const res = (await db.execute(sql`
+    INSERT INTO "aois" (user_id, name, polygon, bbox, centroid, region_bucket, area_ha)
+    VALUES (
+      ${userId}, 'A',
+      ${polygon}, ${polygon},
+      ${JSON.stringify({ type: "Point", coordinates: [-122.65, 38.45] })},
+      ${bucket}, 100
+    ) RETURNING id
+  `)) as unknown as { rows?: Array<{ id: string }> };
+  const rows = (res.rows ?? (res as unknown as Array<{ id: string }>)) as Array<{ id: string }>;
+  return rows[0].id;
+}
+
+async function insertRun(
+  db: AppDb,
+  args: {
+    bucket: string;
+    startedAt: Date;
+    finishedAt: Date;
+    status: string;
+    outcome: string | null;
+    retryPending: boolean;
+  },
+): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO "job_runs" ("job_name", "bucket", "started_at", "finished_at", "status", "outcome", "retry_pending")
+    VALUES ('firms-poll', ${args.bucket}, ${args.startedAt.toISOString()}, ${args.finishedAt.toISOString()}, ${args.status}, ${args.outcome}, ${args.retryPending})
+  `);
+}
+
+describe("<FreshnessBanner>", () => {
+  let db: AppDb;
+  let pglite: PGlite;
+  beforeEach(async () => {
+    ({ db, pglite } = await makeFreshTestDb());
+  });
+  afterEach(async () => {
+    await pglite.close();
+  });
+
+  it("renders 'First poll pending' when no completed run exists", async () => {
+    const aoiId = await seedAoi(db, "user_ban1", "5x5:W125_N40");
+    const node = await FreshnessBanner({
+      db,
+      aoiId,
+      userId: "user_ban1",
+      __testNow: new Date("2026-05-07T12:00:00Z"),
+    });
+    const html = renderToStaticMarkup(node);
+    expect(html).toContain("First poll pending");
+    expect(html).toContain("--warn");
+  });
+
+  it("renders happy 'Last polled N minutes ago' for a fresh success", async () => {
+    const aoiId = await seedAoi(db, "user_ban2", "5x5:W125_N40");
+    await insertRun(db, {
+      bucket: "5x5:W125_N40",
+      startedAt: new Date("2026-05-07T11:53:00Z"),
+      finishedAt: new Date("2026-05-07T11:53:10Z"),
+      status: "ok",
+      outcome: "success",
+      retryPending: false,
+    });
+    const node = await FreshnessBanner({
+      db,
+      aoiId,
+      userId: "user_ban2",
+      __testNow: new Date("2026-05-07T12:00:00Z"),
+    });
+    const html = renderToStaticMarkup(node);
+    expect(html).toContain("Last polled");
+    expect(html).toContain("minutes ago");
+    expect(html).not.toContain("--warn");
+  });
+
+  it("renders rate-limited yellow banner with retry hint", async () => {
+    const aoiId = await seedAoi(db, "user_ban3", "5x5:W125_N40");
+    await insertRun(db, {
+      bucket: "5x5:W125_N40",
+      startedAt: new Date("2026-05-07T11:55:00Z"),
+      finishedAt: new Date("2026-05-07T11:55:01Z"),
+      status: "error",
+      outcome: "rate_limited",
+      retryPending: true,
+    });
+    const node = await FreshnessBanner({
+      db,
+      aoiId,
+      userId: "user_ban3",
+      __testNow: new Date("2026-05-07T12:00:00Z"),
+    });
+    const html = renderToStaticMarkup(node);
+    expect(html).toContain("rate-limited");
+    expect(html).toContain("retrying next tick");
+    expect(html).toContain("--warn");
+  });
+
+  it("renders stale-success banner past the 30-min boundary", async () => {
+    const aoiId = await seedAoi(db, "user_ban4", "5x5:W125_N40");
+    await insertRun(db, {
+      bucket: "5x5:W125_N40",
+      startedAt: new Date("2026-05-07T11:00:00Z"),
+      finishedAt: new Date("2026-05-07T11:00:10Z"),
+      status: "ok",
+      outcome: "success",
+      retryPending: false,
+    });
+    const node = await FreshnessBanner({
+      db,
+      aoiId,
+      userId: "user_ban4",
+      __testNow: new Date("2026-05-07T11:31:00Z"),
+    });
+    const html = renderToStaticMarkup(node);
+    expect(html).toContain("Polling delayed");
+    expect(html).toContain("--warn");
+  });
+});


### PR DESCRIPTION
## Summary

Closes two thesis-adherence gaps named by the 2026-05-07 product review:

1. **Authority perimeters in briefs.** Orchestrator now pre-fetches the most recent authority-published fire perimeter near the detection (NIFC for US, CWFIS for Canada) and folds it into \`BriefContext.authorityPerimeter\`. Replaces the Stage 3 hardcoded \`null\` on \`lib/ai/generate.ts:93\`.
2. **Per-bucket freshness honesty.** Each AOI page renders a \`<FreshnessBanner>\` reading the most recent \`job_runs\` row for that AOI's bucket. Happy: \"Last polled 47 minutes ago\". Degraded (yellow): \"rate-limited — retrying next tick\", \"network error\", \"timed out\", \"Polling delayed\", or \"First poll pending\".

agent: dev
Implements pm/briefs/22-stage8-authority-perimeter-and-freshness.md
stage-pr: 8

## Live-endpoint confirmation matrix (2026-05-07)

| Source | Status | URL | Timestamp field |
| --- | --- | --- | --- |
| NIFC WFIGS (US) | ✅ confirmed | \`services3.arcgis.com/.../WFIGS_Interagency_Perimeters_Current/FeatureServer/0/query?...&f=geojson\` | \`poly_PolygonDateTime\` |
| CWFIS (Canada) | ✅ confirmed | \`cwfis.cfs.nrcan.gc.ca/geoserver/public/ows?service=WFS&...&srsName=EPSG:4326\` | \`lastdate\` |
| ICNF (Portugal) | ⚠️ not shipped — surfaced as Vanyo blocker | n/a | n/a |

ICNF: only map tiles publicly available; \`fogos.pt\` returns incident POINTS not polygons. Per brief instructions, no fabricated endpoint added. Orchestrator will append to \`pm/blockers.md\`.

## Test results

- typecheck ✅
- lint ✅
- test: 197 passed / 15 skipped (testcontainer suites)
- build ✅
- Live test (\`AUTHORITY_PERIMETER_LIVE=1\`): NIFC + CWFIS both confirmed working

## Things to challenge in review

- \`coversBucket\` predicates use rectangular bounding boxes rather than prefix matches. Brief's \`bucketPrefixes: string[]\` would need ~80 prefixes for CONUS; predicate is cheaper.
- Polygon \"centroid\" used for radius filter is mean of outer-ring vertices, not area centroid. Adequate for 25 km radius gate.
- In-repo ray-casting PIP instead of pulling \`@turf/*\` (named in brief but not actually a project dep).
- ICNF surfaced as blocker per AGENTS.md no-fabrication rather than ship a best-effort guess URL. If you'd rather ship a guess + fallback, say so.

## Out of scope

- Path B (literal LLM tool-call via \`generateText\`) — v1.1.
- Sources beyond NIFC + CWFIS — v1.1.
- Weather context — separate gap from product review.
- Retry-with-backoff within single cron tick.