### PR TITLE
chore(poll): COALESCE-protect retry_pending in closeJobRun

### DIFF
--- a/app/api/aoi/poll/route.ts
+++ b/app/api/aoi/poll/route.ts
@@ -73,6 +73,14 @@ export function _setTestNotifyDispatch(fn: NotifyDispatchFn | null): void {
   testNotifyDispatch = fn;
 }
 
+// Test-only re-export — keeps closeJobRun module-private for runtime callers
+// while letting unit tests exercise the COALESCE guards directly.
+export const _closeJobRunForTest = (
+  db: AppDb,
+  id: string,
+  args: CloseArgs,
+): Promise<void> => closeJobRun(db, id, args);
+
 // Hobby max function duration is 60s; we configure to that ceiling so a slow
 // FIRMS endpoint doesn't truncate mid-bucket.
 export const maxDuration = 60;
@@ -476,10 +484,14 @@ async function closeJobRun(
 ): Promise<void> {
   if (!id) return;
   // outcome / retry_pending only set on per-bucket child rows (the parent
-  // doesn't pass them); use COALESCE so the parent UPDATE leaves them at
-  // their column defaults (NULL / false).
+  // doesn't pass them); use COALESCE so an unspecified arg leaves the
+  // existing column value untouched. Today the freshness LATERAL filters
+  // on bucket = aoi.region_bucket and parent rows have bucket IS NULL, so
+  // a parent overwrite of a child's retry_pending could not be observed —
+  // but guarding here means future changes to that filter can't silently
+  // clobber a child retry signal.
   const outcome = args.outcome ?? null;
-  const retryPending = args.retryPending ?? false;
+  const retryPending = args.retryPending ?? null;
   await db.execute(sql`
     UPDATE "job_runs"
     SET
@@ -493,7 +505,7 @@ async function closeJobRun(
       "notifications_sent" = COALESCE("notifications_sent", 0) + ${args.notificationsSent ?? 0},
       "detections_pruned" = COALESCE("detections_pruned", 0) + ${args.detectionsPruned ?? 0},
       "outcome" = COALESCE(${outcome}, "outcome"),
-      "retry_pending" = ${retryPending}
+      "retry_pending" = COALESCE(${retryPending}, "retry_pending")
     WHERE "id" = ${id}
   `);
 }

--- a/tests/poll-close-job-run-guard.test.ts
+++ b/tests/poll-close-job-run-guard.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Reviewer-flagged hardening on Stage 8 (#411): closeJobRun must COALESCE-
+ * protect retry_pending the same way it protects outcome, so a parent row's
+ * no-arg close cannot clobber a child row's retry signal if the freshness
+ * filter is ever loosened from `bucket = aoi.region_bucket`.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import { makeFreshTestDb } from "@/db/test/pglite";
+import { _setTestDb, type AppDb } from "@/lib/db/client";
+import { _closeJobRunForTest } from "@/app/api/aoi/poll/route";
+import type { PGlite } from "@electric-sql/pglite";
+
+async function insertJobRun(
+  db: AppDb,
+  args: { bucket: string | null; retryPending: boolean; outcome: string | null },
+): Promise<string> {
+  const res = (await db.execute(sql`
+    INSERT INTO "job_runs" ("job_name", "bucket", "started_at", "status", "outcome", "retry_pending")
+    VALUES ('firms-poll', ${args.bucket}, NOW(), 'ok', ${args.outcome}, ${args.retryPending})
+    RETURNING id
+  `)) as unknown as { rows?: Array<{ id: string }> };
+  const rows = (res.rows ?? (res as unknown as Array<{ id: string }>)) as Array<{ id: string }>;
+  return rows[0].id;
+}
+
+async function readRun(
+  db: AppDb,
+  id: string,
+): Promise<{ outcome: string | null; retry_pending: boolean; status: string }> {
+  const res = (await db.execute(sql`
+    SELECT status, outcome, retry_pending FROM job_runs WHERE id = ${id}
+  `)) as unknown as {
+    rows?: Array<{ status: string; outcome: string | null; retry_pending: boolean }>;
+  };
+  const rows = (res.rows ??
+    (res as unknown as Array<{ status: string; outcome: string | null; retry_pending: boolean }>)) as Array<{
+    status: string;
+    outcome: string | null;
+    retry_pending: boolean;
+  }>;
+  return rows[0];
+}
+
+describe("closeJobRun — retry_pending COALESCE guard", () => {
+  let db: AppDb;
+  let pglite: PGlite;
+
+  beforeEach(async () => {
+    ({ db, pglite } = await makeFreshTestDb());
+    _setTestDb(db);
+  });
+
+  afterEach(async () => {
+    _setTestDb(null);
+    await pglite.close();
+  });
+
+  it("no-arg close on a row with retry_pending=true preserves it (does not clobber to false)", async () => {
+    const id = await insertJobRun(db, {
+      bucket: "5x5:W120_N35",
+      retryPending: true,
+      outcome: "rate_limited",
+    });
+
+    await _closeJobRunForTest(db, id, {
+      status: "ok",
+      error: null,
+      finishedAt: new Date(),
+    });
+
+    const row = await readRun(db, id);
+    expect(row.retry_pending).toBe(true);
+    // outcome guard already exists; assert here to anchor the parallel.
+    expect(row.outcome).toBe("rate_limited");
+    expect(row.status).toBe("ok");
+  });
+
+  it("explicit retryPending: false on a row with retry_pending=true DOES set it to false", async () => {
+    const id = await insertJobRun(db, {
+      bucket: "5x5:W120_N35",
+      retryPending: true,
+      outcome: "rate_limited",
+    });
+
+    await _closeJobRunForTest(db, id, {
+      status: "ok",
+      error: null,
+      finishedAt: new Date(),
+      retryPending: false,
+      outcome: "success",
+    });
+
+    const row = await readRun(db, id);
+    expect(row.retry_pending).toBe(false);
+    expect(row.outcome).toBe("success");
+  });
+
+  it("explicit retryPending: true on a row with retry_pending=false sets it to true", async () => {
+    const id = await insertJobRun(db, {
+      bucket: "5x5:W120_N35",
+      retryPending: false,
+      outcome: null,
+    });
+
+    await _closeJobRunForTest(db, id, {
+      status: "partial",
+      error: null,
+      finishedAt: new Date(),
+      retryPending: true,
+      outcome: "network_error",
+    });
+
+    const row = await readRun(db, id);
+    expect(row.retry_pending).toBe(true);
+    expect(row.outcome).toBe("network_error");
+  });
+});


### PR DESCRIPTION
agent: scout

COALESCE-protect \`retry_pending\` in \`closeJobRun\` the same way \`outcome\` is protected, so a parent run's no-arg close cannot clobber a child run's retry signal. Stage 8 reviewer follow-up (#411).

## Why

Today the freshness LATERAL filters on \`bucket = aoi.region_bucket\` and parent rows have \`bucket IS NULL\`, so the bug is invisible — but if that filter ever loosens, child \`retry_pending=true\` would silently flip to false on parent close.

## Risk

Identical behavior on hot paths (per-bucket children always pass \`retryPending\` explicitly; parent close now leaves the column at its default false instead of writing false). The new guard only changes behavior when a row already has \`retry_pending=true\` and \`closeJobRun\` is called without \`retryPending\` — exactly the case we want to preserve.

Schema: \`BOOLEAN NOT NULL DEFAULT false\`, so \`COALESCE\` on a non-null column is well-defined.

## Verification

- typecheck / lint clean
- 3 new tests pass (no-arg preserves, explicit false clears, explicit true sets)
- Full suite: 213 pass / 15 skip
- Build clean
- Diff: +134 / -4