### PR TITLE
chore(notify): simplify dispatch.ts (587→426 LOC, ~27%)

### DIFF
--- a/lib/notify/dispatch.ts
+++ b/lib/notify/dispatch.ts
@@ -1,20 +1,9 @@
 /**
- * Stage 4 notification dispatcher.
+ * Stage 4 notification dispatcher. Single entry: `dispatchBrief`.
+ * See `pm/briefs/18-stage4-notification-dispatch.md` §Dispatcher.
  *
- * Single entry point: `dispatchBrief(db, briefId, deps?)`. Called once per
- * brief that Stage 3 just persisted.
- *
- * Steps (mirrors `pm/briefs/18-stage4-notification-dispatch.md` §Dispatcher):
- *   1. Load brief + AOI + rules + user email.
- *   2. Resolve channels (rules.notify_channels, fallback to users.email).
- *   3. Per-channel: idempotency check → pause/quiet-hours gate → send → persist.
- *
- * Webhook channels are persisted as `skipped, channel_not_implemented`
- * (Stage 6 owns Slack/Discord delivery). RESEND_API_KEY missing →
- * persisted as `config_missing`; the route warns once per poll.
- *
- * Two-backend repository pattern: every SQL touched is non-spatial and runs
- * identically on Neon+PostGIS and PGlite.
+ * Two-backend: every SQL touched is non-spatial and runs identically on
+ * Neon+PostGIS and PGlite.
  */
 import { createHash } from "node:crypto";
 import { sql } from "drizzle-orm";
@@ -44,6 +33,10 @@ export type DispatchDeps = {
   now?: Date;
 };
 
+type Channel =
+  | { type: "email"; target: string }
+  | { type: "webhook"; target: string };
+
 type LoadedBrief = {
   briefId: string;
   aoiId: string;
@@ -52,10 +45,7 @@ type LoadedBrief = {
   summary: string;
   pausedUntil: Date | null;
   quietHours: { tz: string; startHour: number; endHour: number } | null;
-  notifyChannels: Array<
-    | { type: "email"; target: string }
-    | { type: "webhook"; target: string }
-  >;
+  notifyChannels: Channel[];
   userEmail: string | null;
 };
 
@@ -65,23 +55,19 @@ export async function dispatchBrief(
   deps: DispatchDeps = {},
 ): Promise<DispatchOutcome> {
   const loaded = await loadBrief(db, briefId);
-  if (!loaded) {
-    return { briefId, attempts: [] };
-  }
+  if (!loaded) return { briefId, attempts: [] };
 
   const now = deps.now ?? new Date();
   const send = deps.send ?? ((a) => sendEmail(a));
-
   const channels = resolveChannels(loaded);
   const attempts: DispatchAttempt[] = [];
-  let firstSuccessRecorded = false;
 
   if (channels.length === 0) {
     const reason = isPendingPlaceholder(loaded.userEmail)
       ? "no_recipient_pending"
       : "no_recipient";
     const target = loaded.userEmail ?? "";
-    await persistAttempt(db, {
+    await insertNotificationRow(db, {
       aoiId: loaded.aoiId,
       briefId,
       channel: "email",
@@ -89,162 +75,82 @@ export async function dispatchBrief(
       status: "skipped",
       skipReason: reason,
     });
-    attempts.push({
-      status: "skipped",
-      channel: "email",
-      target,
-      reason,
-    });
+    attempts.push({ status: "skipped", channel: "email", target, reason });
     return { briefId, attempts };
   }
 
+  let firstSuccessRecorded = false;
   for (const ch of channels) {
-    if (ch.type === "webhook") {
-      const webhookHash = sha256(ch.target);
-      const existingWebhook = await findExistingTerminalRow(
-        db,
-        briefId,
-        "webhook",
-        webhookHash,
-      );
-      if (existingWebhook) {
-        attempts.push({
-          status: "skipped",
-          channel: "webhook",
-          target: ch.target,
-          reason: "duplicate",
-        });
-        continue;
-      }
-      await persistAttempt(db, {
-        aoiId: loaded.aoiId,
-        briefId,
-        channel: "webhook",
-        target: ch.target,
-        targetHash: webhookHash,
-        status: "skipped",
-        skipReason: "channel_not_implemented",
-      });
-      attempts.push({
-        status: "skipped",
-        channel: "webhook",
-        target: ch.target,
-        reason: "channel_not_implemented",
-      });
+    const target = ch.target;
+    const targetHash = sha256(target);
+    const base = { aoiId: loaded.aoiId, briefId, channel: ch.type, target, targetHash };
+
+    const skip = async (reason: string): Promise<void> => {
+      await insertNotificationRow(db, { ...base, status: "skipped", skipReason: reason });
+      attempts.push({ status: "skipped", channel: ch.type, target, reason });
+    };
+
+    if (await findExistingTerminalRow(db, briefId, ch.type, targetHash)) {
+      attempts.push({ status: "skipped", channel: ch.type, target, reason: "duplicate" });
       continue;
     }
 
-    const target = ch.target;
-    const targetHash = sha256(target);
-
-    const existing = await findExistingTerminalRow(db, briefId, "email", targetHash);
-    if (existing) {
-      attempts.push({
-        status: "skipped",
-        channel: "email",
-        target,
-        reason: "duplicate",
-      });
+    if (ch.type === "webhook") {
+      await skip("channel_not_implemented");
       continue;
     }
 
     if (loaded.pausedUntil && loaded.pausedUntil.getTime() > now.getTime()) {
-      await persistAttempt(db, {
-        aoiId: loaded.aoiId,
-        briefId,
-        channel: "email",
-        target,
-        targetHash,
-        status: "skipped",
-        skipReason: "paused",
-      });
-      attempts.push({
-        status: "skipped",
-        channel: "email",
-        target,
-        reason: "paused",
-      });
+      await skip("paused");
       continue;
     }
 
     // TODO Stage 6: hold + release as a morning digest at the top of the
     // quiet window per US-2 acceptance #3. Stage 4 is skip-only.
     if (loaded.quietHours && inQuietHours(now, loaded.quietHours)) {
-      await persistAttempt(db, {
-        aoiId: loaded.aoiId,
-        briefId,
-        channel: "email",
-        target,
-        targetHash,
-        status: "skipped",
-        skipReason: "quiet_hours",
-      });
-      attempts.push({
-        status: "skipped",
-        channel: "email",
-        target,
-        reason: "quiet_hours",
-      });
+      await skip("quiet_hours");
       continue;
     }
 
-    // Stage 7: mint a fresh quartet of action tokens for THIS outbound email.
-    // One quartet per (brief, channel, target) — never reused across emails so
-    // forwarding cannot grant the recipient permission to mutate the AOI.
+    // Mint a fresh quartet of action tokens for THIS outbound email — never
+    // reused across emails so forwarding cannot grant the recipient
+    // permission to mutate the AOI.
     const footerUrls = await mintFooterUrls(db, {
       aoiId: loaded.aoiId,
-      briefId: briefId,
+      briefId,
       target,
       now,
     });
-    const markdownWithFooter = appendFooter(loaded.renderedMarkdown, footerUrls);
-    const subject = buildSubject(loaded.summary);
     const result = await send({
       to: target,
-      subject,
-      markdown: markdownWithFooter,
+      subject: truncate(loaded.summary, 90),
+      markdown: appendFooter(loaded.renderedMarkdown, footerUrls),
     });
 
     if (!result.ok && result.code === "config_missing") {
-      await persistAttempt(db, {
-        aoiId: loaded.aoiId,
-        briefId,
-        channel: "email",
-        target,
-        targetHash,
-        status: "config_missing",
-      });
+      await insertNotificationRow(db, { ...base, status: "config_missing" });
       attempts.push({ status: "config_missing", channel: "email", target });
       continue;
     }
 
     if (!result.ok) {
-      await persistAttempt(db, {
-        aoiId: loaded.aoiId,
-        briefId,
-        channel: "email",
-        target,
-        targetHash,
+      const error = `${result.code}: ${result.message}`;
+      await insertNotificationRow(db, {
+        ...base,
         status: "failed",
-        error: truncate(`${result.code}: ${result.message}`, 500),
+        error: truncate(error, 500),
       });
-      attempts.push({
-        status: "failed",
-        channel: "email",
-        target,
-        error: `${result.code}: ${result.message}`,
-      });
+      attempts.push({ status: "failed", channel: "email", target, error });
       continue;
     }
 
-    const updateLastNotified = !firstSuccessRecorded;
     await persistSuccess(db, {
       aoiId: loaded.aoiId,
       briefId,
       target,
       targetHash,
       providerMessageId: result.providerMessageId,
-      updateLastNotified,
+      updateLastNotified: !firstSuccessRecorded,
     });
     firstSuccessRecorded = true;
     attempts.push({
@@ -258,56 +164,34 @@ export async function dispatchBrief(
   return { briefId, attempts };
 }
 
+const FOOTER_ACTIONS = ["snooze", "pause", "unsubscribe", "feedback"] as const;
+
 async function mintFooterUrls(
   db: AppDb,
   args: { aoiId: string; briefId: string; target: string; now: Date },
 ): Promise<FooterUrls> {
-  const channel = "email";
-  const snooze = await mintActionToken(db, {
-    aoiId: args.aoiId,
-    briefId: args.briefId,
-    action: "snooze",
-    channel,
-    target: args.target,
-    now: args.now,
-  });
-  const pause = await mintActionToken(db, {
-    aoiId: args.aoiId,
-    briefId: args.briefId,
-    action: "pause",
-    channel,
-    target: args.target,
-    now: args.now,
-  });
-  const unsub = await mintActionToken(db, {
-    aoiId: args.aoiId,
-    briefId: args.briefId,
-    action: "unsubscribe",
-    channel,
-    target: args.target,
-    now: args.now,
-  });
-  const feedback = await mintActionToken(db, {
-    aoiId: args.aoiId,
-    briefId: args.briefId,
-    action: "feedback",
-    channel,
-    target: args.target,
-    now: args.now,
-  });
+  const tokens = {} as Record<(typeof FOOTER_ACTIONS)[number], string>;
+  for (const action of FOOTER_ACTIONS) {
+    const { token } = await mintActionToken(db, {
+      aoiId: args.aoiId,
+      briefId: args.briefId,
+      action,
+      channel: "email",
+      target: args.target,
+      now: args.now,
+    });
+    tokens[action] = token;
+  }
   return {
-    snoozeUrl: notifyActionUrl("snooze", snooze.token),
-    pauseUrl: notifyActionUrl("pause", pause.token),
-    unsubscribeUrl: notifyActionUrl("unsubscribe", unsub.token),
-    feedbackYesUrl: notifyActionUrl("feedback", feedback.token, { v: "yes" }),
-    feedbackNoUrl: notifyActionUrl("feedback", feedback.token, { v: "no" }),
+    snoozeUrl: notifyActionUrl("snooze", tokens.snooze),
+    pauseUrl: notifyActionUrl("pause", tokens.pause),
+    unsubscribeUrl: notifyActionUrl("unsubscribe", tokens.unsubscribe),
+    feedbackYesUrl: notifyActionUrl("feedback", tokens.feedback, { v: "yes" }),
+    feedbackNoUrl: notifyActionUrl("feedback", tokens.feedback, { v: "no" }),
   };
 }
 
-function resolveChannels(loaded: LoadedBrief): Array<
-  | { type: "email"; target: string }
-  | { type: "webhook"; target: string }
-> {
+function resolveChannels(loaded: LoadedBrief): Channel[] {
   if (loaded.notifyChannels.length > 0) {
     return loaded.notifyChannels.filter(
       (c) => c.type !== "email" || !isPendingPlaceholder(c.target),
@@ -323,10 +207,6 @@ function isPendingPlaceholder(email: string | null | undefined): boolean {
   return typeof email === "string" && /@pending\.invalid$/.test(email);
 }
 
-function buildSubject(summary: string): string {
-  return truncate(summary, 90);
-}
-
 function truncate(s: string, max: number): string {
   return s.length <= max ? s : s.slice(0, max);
 }
@@ -335,13 +215,7 @@ function sha256(s: string): string {
   return createHash("sha256").update(s).digest("hex");
 }
 
-/**
- * Quiet-hours check — straightforward [startHour, endHour) window in the
- * configured tz. Wraparound (e.g. start=22, end=7) is supported via OR.
- *
- * Uses `Intl.DateTimeFormat` to read the hour in the AOI's tz; this is the
- * same tz handling the Stage 6 digest will need, kept tiny for Stage 4.
- */
+// Wraparound (e.g. start=22, end=7) handled via OR.
 export function inQuietHours(
   now: Date,
   qh: { tz: string; startHour: number; endHour: number },
@@ -351,8 +225,7 @@ export function inQuietHours(
     hour: "numeric",
     hour12: false,
   });
-  const parts = fmt.formatToParts(now);
-  const hourPart = parts.find((p) => p.type === "hour");
+  const hourPart = fmt.formatToParts(now).find((p) => p.type === "hour");
   if (!hourPart) return false;
   const hour = Number(hourPart.value) % 24;
   if (qh.startHour === qh.endHour) return false;
@@ -365,8 +238,14 @@ export function inQuietHours(
 // ---------------------------------------------------------------------------
 // DB load / persist
 
+function rowsOf<T>(result: unknown): T[] {
+  const r = result as { rows?: T[] } | T[];
+  if (Array.isArray(r)) return r;
+  return r.rows ?? [];
+}
+
 async function loadBrief(db: AppDb, briefId: string): Promise<LoadedBrief | null> {
-  const result = (await db.execute(sql`
+  const result = await db.execute(sql`
     SELECT
       b."id"                AS brief_id,
       b."aoi_id"            AS aoi_id,
@@ -384,40 +263,19 @@ async function loadBrief(db: AppDb, briefId: string): Promise<LoadedBrief | null
     LEFT JOIN "users" u     ON u."id" = a."user_id"
     WHERE b."id" = ${briefId}
     LIMIT 1
-  `)) as unknown as { rows?: Array<Record<string, unknown>> };
-  const rows = (result.rows ??
-    (result as unknown as Array<Record<string, unknown>>)) as Array<
-    Record<string, unknown>
-  >;
-  const row = rows[0];
+  `);
+  const row = rowsOf<Record<string, unknown>>(result)[0];
   if (!row) return null;
-
-  const payload = row.payload as { summary?: string } | string | null;
-  let summary = "";
-  if (typeof payload === "string") {
-    try {
-      const parsed = JSON.parse(payload) as { summary?: string };
-      summary = parsed?.summary ?? "";
-    } catch {
-      summary = "";
-    }
-  } else if (payload && typeof payload === "object") {
-    summary = typeof payload.summary === "string" ? payload.summary : "";
-  }
-
-  const channelsRaw = row.notify_channels;
-  const channels = parseChannels(channelsRaw);
-  const quietHours = parseQuietHours(row.quiet_hours);
 
   return {
     briefId: String(row.brief_id),
     aoiId: String(row.aoi_id),
     aoiName: String(row.aoi_name ?? ""),
     renderedMarkdown: String(row.rendered_markdown ?? ""),
-    summary,
+    summary: parseSummary(row.payload),
     pausedUntil: toDate(row.paused_until),
-    quietHours,
-    notifyChannels: channels,
+    quietHours: parseQuietHours(row.quiet_hours),
+    notifyChannels: parseChannels(row.notify_channels),
     userEmail:
       typeof row.user_email === "string" && row.user_email.length > 0
         ? row.user_email
@@ -425,38 +283,33 @@ async function loadBrief(db: AppDb, briefId: string): Promise<LoadedBrief | null
   };
 }
 
-function parseChannels(
-  raw: unknown,
-): Array<
-  | { type: "email"; target: string }
-  | { type: "webhook"; target: string }
-> {
-  let arr: unknown = raw;
-  if (typeof raw === "string") {
-    try {
-      arr = JSON.parse(raw);
-    } catch {
-      return [];
-    }
+function parseJsonish(raw: unknown): unknown {
+  if (typeof raw !== "string") return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
   }
+}
+
+function parseSummary(payload: unknown): string {
+  const v = parseJsonish(payload);
+  if (v && typeof v === "object" && "summary" in v) {
+    const s = (v as { summary: unknown }).summary;
+    if (typeof s === "string") return s;
+  }
+  return "";
+}
+
+function parseChannels(raw: unknown): Channel[] {
+  const arr = parseJsonish(raw);
   if (!Array.isArray(arr)) return [];
-  const out: Array<
-    | { type: "email"; target: string }
-    | { type: "webhook"; target: string }
-  > = [];
+  const out: Channel[] = [];
   for (const item of arr) {
-    if (
-      item &&
-      typeof item === "object" &&
-      "type" in item &&
-      "target" in item &&
-      typeof (item as { target: unknown }).target === "string"
-    ) {
-      const t = (item as { type: unknown }).type;
-      const target = (item as { target: string }).target;
-      if (t === "email") out.push({ type: "email", target });
-      else if (t === "webhook") out.push({ type: "webhook", target });
-    }
+    if (!item || typeof item !== "object") continue;
+    const { type, target } = item as { type?: unknown; target?: unknown };
+    if (typeof target !== "string") continue;
+    if (type === "email" || type === "webhook") out.push({ type, target });
   }
   return out;
 }
@@ -464,14 +317,7 @@ function parseChannels(
 function parseQuietHours(
   raw: unknown,
 ): { tz: string; startHour: number; endHour: number } | null {
-  let v: unknown = raw;
-  if (typeof v === "string") {
-    try {
-      v = JSON.parse(v);
-    } catch {
-      return null;
-    }
-  }
+  const v = parseJsonish(raw);
   if (!v || typeof v !== "object") return null;
   const o = v as { tz?: unknown; startHour?: unknown; endHour?: unknown };
   if (
@@ -490,7 +336,7 @@ async function findExistingTerminalRow(
   channel: string,
   targetHash: string,
 ): Promise<boolean> {
-  const result = (await db.execute(sql`
+  const result = await db.execute(sql`
     SELECT 1 AS one
     FROM "notifications_log"
     WHERE "brief_id" = ${briefId}
@@ -498,11 +344,8 @@ async function findExistingTerminalRow(
       AND "target_hash" = ${targetHash}
       AND "status" IN ('sent', 'skipped')
     LIMIT 1
-  `)) as unknown as { rows?: Array<{ one: number }> };
-  const rows = (result.rows ?? (result as unknown as Array<{ one: number }>)) as Array<{
-    one: number;
-  }>;
-  return rows.length > 0;
+  `);
+  return rowsOf(result).length > 0;
 }
 
 type PersistArgs = {
@@ -517,9 +360,43 @@ type PersistArgs = {
   skipReason?: string;
 };
 
-async function persistAttempt(db: AppDb, args: PersistArgs): Promise<void> {
+async function persistSuccess(
+  db: AppDb,
+  args: {
+    aoiId: string;
+    briefId: string;
+    target: string;
+    targetHash: string;
+    providerMessageId: string;
+    updateLastNotified: boolean;
+  },
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    await insertNotificationRow(tx, {
+      aoiId: args.aoiId,
+      briefId: args.briefId,
+      channel: "email",
+      target: args.target,
+      targetHash: args.targetHash,
+      status: "sent",
+      providerMessageId: args.providerMessageId,
+    });
+    if (args.updateLastNotified) {
+      await tx.execute(sql`
+        UPDATE "aoi_briefs"
+        SET "last_notified_at" = COALESCE("last_notified_at", now())
+        WHERE "id" = ${args.briefId}
+      `);
+    }
+  });
+}
+
+async function insertNotificationRow(
+  exec: { execute: AppDb["execute"] },
+  args: PersistArgs,
+): Promise<void> {
   const targetHash = args.targetHash ?? sha256(args.target);
-  await db.execute(sql`
+  await exec.execute(sql`
     INSERT INTO "notifications_log" (
       "aoi_id", "brief_id", "channel", "target", "target_hash",
       "status", "provider_message_id", "error", "skip_reason"
@@ -536,43 +413,6 @@ async function persistAttempt(db: AppDb, args: PersistArgs): Promise<void> {
     )
     ON CONFLICT DO NOTHING
   `);
-}
-
-async function persistSuccess(
-  db: AppDb,
-  args: {
-    aoiId: string;
-    briefId: string;
-    target: string;
-    targetHash: string;
-    providerMessageId: string;
-    updateLastNotified: boolean;
-  },
-): Promise<void> {
-  await db.transaction(async (tx) => {
-    await tx.execute(sql`
-      INSERT INTO "notifications_log" (
-        "aoi_id", "brief_id", "channel", "target", "target_hash",
-        "status", "provider_message_id"
-      ) VALUES (
-        ${args.aoiId},
-        ${args.briefId},
-        'email',
-        ${args.target},
-        ${args.targetHash},
-        'sent',
-        ${args.providerMessageId}
-      )
-      ON CONFLICT DO NOTHING
-    `);
-    if (args.updateLastNotified) {
-      await tx.execute(sql`
-        UPDATE "aoi_briefs"
-        SET "last_notified_at" = COALESCE("last_notified_at", now())
-        WHERE "id" = ${args.briefId}
-      `);
-    }
-  });
 }
 
 function toDate(v: unknown): Date | null {


### PR DESCRIPTION
agent: scout

Apply the simplify skill to \`lib/notify/dispatch.ts\` (587 → 426 LOC, ~27% reduction) per product review 2026-05-07 §3. No behavioral changes; all existing dispatcher tests pass without modification.

## Categorized simplifications

**Premature abstractions removed**
- \`buildSubject(summary)\` was a single-use one-line wrapper around \`truncate\`; inlined.
- \`persistAttempt\` body merged with the success-path INSERT into a shared \`insertNotificationRow(exec, args)\` accepting either an AppDb or a transaction handle.

**Repeated patterns collapsed**
- 4 near-identical \`mintActionToken\` calls in \`mintFooterUrls\` reduced to a loop over \`FOOTER_ACTIONS\`.
- Four copies of the persist-skip-then-push pattern (paused, quiet_hours, webhook) extracted into a \`skip(reason)\` closure; each branch is now one line.
- Duplicate-row check appeared twice with identical bodies; unified ahead of the channel-type fork.
- Three callers shared a \`result.rows ?? (result as Array<...>)\` shim. Extracted \`rowsOf<T>()\`.
- Three JSON parsers extracted into \`parseJsonish()\`.

**Comments**
- Deleted what-comments (steps evident from code).
- Kept the two real why-comments: token-quartet freshness rationale and Stage 6 quiet-hours digest TODO.

## Risk

The only structural risk: \`persistSuccess\` now calls \`insertNotificationRow(tx, ...)\` against the transaction handle instead of inlining SQL. \`tx.execute\` and \`db.execute\` are identical in shape across Drizzle's neon-http and PGlite drivers; both happy-path and config_missing tests exercise this and pass.

Worst case if a latent bug exists: an unrecorded successful send (no \`notifications_log\` row) → re-fires the email on next dispatch. Annoying but not destructive at v1 user count.

## Verification

- typecheck / lint clean
- 178 passed / 13 skipped (testcontainers without Docker locally; CI runs them)
- build clean