### PR TITLE
Stage 9: watch-confirmed email + first-AOI backfill (closes Flow 1)

### DIFF
--- a/app/api/aoi/route.ts
+++ b/app/api/aoi/route.ts
@@ -2,13 +2,60 @@
  * /api/aoi — list + create AOIs.
  *
  * Spec: docs/SPEC-A-prime-v1.md §API surface.
- * Auth: single-user stub until Stage 5 (Clerk).
+ * Auth: Clerk per-user via `withDb`.
  * Runtime: Node.js (default) — pg driver is not Edge-compatible.
+ *
+ * Stage 9: after the 201 returns, two best-effort tasks fire via Next.js
+ * `after()` (the App Router post-response primitive):
+ *   1. `dispatchWatchConfirmed` — one-shot "now watching ..." email.
+ *   2. `backfillForNewAoi` — synchronous backfill over last 24h FIRMS for
+ *      this AOI's bucket. Failures here MUST NOT break AOI creation.
+ *
+ * Backfill-path decision (per brief 23 §"Open questions"): we chose Path A
+ * (`after` from `next/server`). It's the documented Next.js / Vercel
+ * primitive for "do this after responding," requires no new route, and
+ * preserves the single AOI-creation transaction. If Vercel logs ever show
+ * function termination before `after`'s callback resolves, switch to Path C
+ * (internal `/api/aoi/[id]/backfill` self-call) per the brief.
  */
 import { NextResponse, type NextRequest } from "next/server";
+import { after } from "next/server";
 import { aoiCreateSchema } from "@/lib/validators/aoi";
 import { createAoi, listAois } from "@/lib/db/aoi-repository";
 import { parseJson, withDb } from "@/lib/api/handlers";
+import {
+  dispatchWatchConfirmed,
+  absoluteAoiUrl,
+} from "@/lib/notify/watch-confirmed";
+import { backfillForNewAoi } from "@/lib/firms/backfill";
+import type { AppDb } from "@/lib/db/client";
+
+// Hobby max function duration is 60s. Most of the backfill happens after the
+// 201 returns, but the function instance must stay alive until `after`'s
+// callback resolves — so we still want the 60s ceiling.
+export const maxDuration = 60;
+export const runtime = "nodejs";
+
+// Test-only injection points so PGlite tests can exercise the after-response
+// path synchronously and stub out network deps.
+type AfterFn = (cb: () => void | Promise<void>) => void;
+let testAfterImpl: AfterFn | null = null;
+let testWatchConfirmed: typeof dispatchWatchConfirmed | null = null;
+let testBackfill: typeof backfillForNewAoi | null = null;
+
+export function _setTestAfterImpl(fn: AfterFn | null): void {
+  testAfterImpl = fn;
+}
+export function _setTestWatchConfirmed(
+  fn: typeof dispatchWatchConfirmed | null,
+): void {
+  testWatchConfirmed = fn;
+}
+export function _setTestBackfill(
+  fn: typeof backfillForNewAoi | null,
+): void {
+  testBackfill = fn;
+}
 
 export async function GET(): Promise<NextResponse> {
   return withDb(async ({ db, userId }) => {
@@ -34,6 +81,16 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       name: parsed.value.name,
       geometry: parsed.value.geometry,
     });
+
+    scheduleAfterResponse(db, {
+      aoiId: aoi.id,
+      userId,
+      aoiName: aoi.name,
+      regionBucket: aoi.regionBucket,
+      areaHa: aoi.areaHa,
+      createdAt: aoi.createdAt,
+    });
+
     return NextResponse.json(
       {
         aoi: {
@@ -58,4 +115,66 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       { status: 201 },
     );
   });
+}
+
+const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+
+function scheduleAfterResponse(
+  db: AppDb,
+  args: {
+    aoiId: string;
+    userId: string;
+    aoiName: string;
+    regionBucket: string;
+    areaHa: number;
+    createdAt: Date;
+  },
+): void {
+  const watchConfirmed = testWatchConfirmed ?? dispatchWatchConfirmed;
+  const backfill = testBackfill ?? backfillForNewAoi;
+  const firstPollAt = new Date(args.createdAt.getTime() + FIFTEEN_MIN_MS);
+
+  const work = async (): Promise<void> => {
+    try {
+      await watchConfirmed(db, {
+        aoiId: args.aoiId,
+        userId: args.userId,
+        aoiName: args.aoiName,
+        regionBucket: args.regionBucket,
+        areaHa: args.areaHa,
+        firstPollAt,
+        aoiUrl: absoluteAoiUrl(args.aoiId),
+      });
+    } catch (err) {
+      console.warn(`[aoi.post] watch-confirmed dispatch failed: ${errMessage(err)}`);
+    }
+    try {
+      await backfill(db, {
+        aoiId: args.aoiId,
+        userId: args.userId,
+        regionBucket: args.regionBucket,
+      });
+    } catch (err) {
+      console.warn(`[aoi.post] backfill failed: ${errMessage(err)}`);
+    }
+  };
+
+  if (testAfterImpl) {
+    testAfterImpl(work);
+    return;
+  }
+  try {
+    after(work);
+  } catch (err) {
+    // `after` throws when called outside a request scope (e.g. in unit tests
+    // that exercise the route handler directly). Fall back to fire-and-forget
+    // so the wiring still runs; production always has a request scope.
+    console.warn(`[aoi.post] after() unavailable; running inline: ${errMessage(err)}`);
+    void work();
+  }
+}
+
+function errMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
 }

--- a/db/migrations/0007_stage9.sql
+++ b/db/migrations/0007_stage9.sql
@@ -1,0 +1,21 @@
+-- Stage 9 — A' pivot: watch-confirmed email + first-AOI backfill.
+--
+-- Adds:
+--   * notifications_log.kind — discriminator so watch-confirmed rows can be
+--     distinguished from brief-dispatch rows in launch-week queries. Defaults
+--     to 'brief'; existing rows are backfilled by the column default.
+--   * Drops NOT NULL on notifications_log.brief_id — a watch-confirmed row
+--     has no brief, so brief_id is NULL for kind='watch_confirmed'.
+--   * Index on (kind, created_at DESC) — supports filtering by row kind in
+--     launch-readiness queries without scanning the whole log.
+--
+-- Authoritative source: pm/briefs/23-stage9-watch-confirmed-and-first-poll-backfill.md.
+
+ALTER TABLE "notifications_log"
+    ADD COLUMN IF NOT EXISTS "kind" TEXT NOT NULL DEFAULT 'brief';
+
+ALTER TABLE "notifications_log"
+    ALTER COLUMN "brief_id" DROP NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "notifications_log_kind_created_at_idx"
+    ON "notifications_log" ("kind", "sent_at" DESC);

--- a/db/migrations/0007_stage9.test.sql
+++ b/db/migrations/0007_stage9.test.sql
@@ -1,0 +1,12 @@
+-- Stage 9 — PGlite-compatible variant of 0007_stage9.sql.
+--
+-- Identical to production: pure column add + a NOT NULL drop + an index.
+
+ALTER TABLE "notifications_log"
+    ADD COLUMN IF NOT EXISTS "kind" TEXT NOT NULL DEFAULT 'brief';
+
+ALTER TABLE "notifications_log"
+    ALTER COLUMN "brief_id" DROP NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "notifications_log_kind_created_at_idx"
+    ON "notifications_log" ("kind", "sent_at" DESC);

--- a/db/schema/index.ts
+++ b/db/schema/index.ts
@@ -270,9 +270,18 @@ export const notificationsLog = pgTable("notifications_log", {
   aoiId: uuid("aoi_id")
     .notNull()
     .references(() => aois.id, { onDelete: "cascade" }),
-  briefId: uuid("brief_id")
-    .notNull()
-    .references(() => aoiBriefs.id, { onDelete: "cascade" }),
+  /**
+   * Stage 9: nullable so watch-confirmed rows (no brief) can be persisted.
+   * Stage 4 brief-dispatch rows still set this to a non-null aoi_briefs.id.
+   */
+  briefId: uuid("brief_id").references(() => aoiBriefs.id, {
+    onDelete: "cascade",
+  }),
+  /**
+   * Stage 9: "brief" (Stage 4 dispatch) | "watch_confirmed" (Stage 9 one-shot
+   * AOI-creation email). Defaulted to 'brief' so historical rows are honest.
+   */
+  kind: text("kind").notNull().default("brief"),
   /** "email" for v1; "webhook" reserved (always recorded as skipped). */
   channel: text("channel").notNull(),
   /** Plaintext recipient (operator-readable). */

--- a/lib/firms/backfill.ts
+++ b/lib/firms/backfill.ts
@@ -1,0 +1,253 @@
+/**
+ * Stage 9 — first-AOI backfill.
+ *
+ * Single entry point: `backfillForNewAoi(db, args)`. Called immediately after
+ * AOI creation (post-response via `next/server`'s `after`) to give a user who
+ * arrives mid-fire an immediate brief instead of waiting up to 15 minutes for
+ * the next cron tick.
+ *
+ * Behaviour:
+ *   1. Open a `job_runs` row with `job_name='aoi-backfill'` so cron-poll
+ *      latency metrics aren't contaminated.
+ *   2. Skip cleanly when `FIRMS_MAP_KEY` is unset (build-without-blocking).
+ *   3. Fetch last 24h of FIRMS detections for the new AOI's bucket.
+ *   4. Run the matcher scoped to JUST this AOI.
+ *   5. Pipe matches through the brief generator + Stage 4 dispatcher.
+ *
+ * Failures must NOT propagate — the AOI POST returns 201 either way.
+ */
+import { sql } from "drizzle-orm";
+import type { AppDb } from "@/lib/db/client";
+import {
+  fetchAreaCsv,
+  type FirmsBbox,
+  type FirmsFetchResult,
+  type FirmsSource,
+} from "./client";
+import { bucketToBbox } from "./buckets";
+import { matchDetectionsToAois } from "./matcher";
+import {
+  generateBriefForEvent,
+  type GenerateOutcome,
+} from "@/lib/ai/generate";
+import { dispatchBrief, type DispatchOutcome } from "@/lib/notify/dispatch";
+
+export type BackfillOutcome = {
+  aoiId: string;
+  status: "ok" | "skipped" | "error";
+  reason?: "config_missing" | "fetch_failed";
+  detectionsFetched: number;
+  detectionsMatched: number;
+  eventsCreated: number;
+  briefsGenerated: number;
+  notificationsSent: number;
+  durationMs: number;
+};
+
+export type FirmsFetchFn = (args: {
+  source: FirmsSource;
+  bbox: FirmsBbox;
+  dayRange?: number;
+}) => Promise<FirmsFetchResult>;
+
+export type BackfillArgs = {
+  aoiId: string;
+  userId: string;
+  regionBucket: string;
+  source?: FirmsSource;
+  now?: Date;
+  fetchImpl?: FirmsFetchFn;
+  briefGen?: typeof generateBriefForEvent;
+  notifyDispatch?: typeof dispatchBrief;
+};
+
+const DEFAULT_SOURCE: FirmsSource = "VIIRS_NOAA20_NRT";
+
+export async function backfillForNewAoi(
+  db: AppDb,
+  args: BackfillArgs,
+): Promise<BackfillOutcome> {
+  const start = Date.now();
+  const source = args.source ?? DEFAULT_SOURCE;
+  const runId = await openJobRun(db, args.regionBucket, start);
+
+  if (!process.env.FIRMS_MAP_KEY && !args.fetchImpl) {
+    await closeJobRun(db, runId, {
+      status: "ok",
+      finishedAt: new Date(),
+    });
+    return {
+      aoiId: args.aoiId,
+      status: "skipped",
+      reason: "config_missing",
+      detectionsFetched: 0,
+      detectionsMatched: 0,
+      eventsCreated: 0,
+      briefsGenerated: 0,
+      notificationsSent: 0,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  let bbox: FirmsBbox;
+  try {
+    bbox = bucketToBbox(args.regionBucket);
+  } catch (err) {
+    await closeJobRun(db, runId, {
+      status: "error",
+      error: errMessage(err),
+      finishedAt: new Date(),
+    });
+    return {
+      aoiId: args.aoiId,
+      status: "error",
+      reason: "fetch_failed",
+      detectionsFetched: 0,
+      detectionsMatched: 0,
+      eventsCreated: 0,
+      briefsGenerated: 0,
+      notificationsSent: 0,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  const fetchFn = args.fetchImpl ?? fetchAreaCsv;
+  const fetchResult = await fetchFn({ source, bbox, dayRange: 1 });
+  if (!fetchResult.ok) {
+    await closeJobRun(db, runId, {
+      status: "error",
+      error: `${fetchResult.code}: ${fetchResult.message}`,
+      firmsRequestCount: 1,
+      finishedAt: new Date(),
+    });
+    return {
+      aoiId: args.aoiId,
+      status: "error",
+      reason: "fetch_failed",
+      detectionsFetched: 0,
+      detectionsMatched: 0,
+      eventsCreated: 0,
+      briefsGenerated: 0,
+      notificationsSent: 0,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  const matchOutcome = await matchDetectionsToAois(db, {
+    bucket: args.regionBucket,
+    source,
+    detections: fetchResult.detections,
+    aoiIds: [args.aoiId],
+  });
+
+  let briefsGenerated = 0;
+  const generatedBriefIds: string[] = [];
+  const briefGen = args.briefGen ?? generateBriefForEvent;
+  for (const eventId of matchOutcome.createdEventIds) {
+    let outcome: GenerateOutcome;
+    try {
+      outcome = await briefGen(db, eventId);
+    } catch (err) {
+      outcome = { status: "error", eventId, reason: errMessage(err) };
+    }
+    if (outcome.status === "generated") {
+      briefsGenerated += 1;
+      if (outcome.briefId) generatedBriefIds.push(outcome.briefId);
+    }
+  }
+
+  let notificationsSent = 0;
+  const dispatcher = args.notifyDispatch ?? dispatchBrief;
+  for (const briefId of generatedBriefIds) {
+    let outcome: DispatchOutcome;
+    try {
+      outcome = await dispatcher(db, briefId);
+    } catch {
+      continue;
+    }
+    for (const a of outcome.attempts) {
+      if (a.status === "sent") notificationsSent += 1;
+    }
+  }
+
+  await closeJobRun(db, runId, {
+    status: "ok",
+    firmsRequestCount: 1,
+    detectionsInserted: matchOutcome.detectionsInserted,
+    eventsCreated: matchOutcome.eventsCreated,
+    briefsGenerated,
+    notificationsSent,
+    finishedAt: new Date(),
+  });
+
+  return {
+    aoiId: args.aoiId,
+    status: "ok",
+    detectionsFetched: fetchResult.detections.length,
+    detectionsMatched: matchOutcome.detectionsInserted,
+    eventsCreated: matchOutcome.eventsCreated,
+    briefsGenerated,
+    notificationsSent,
+    durationMs: Date.now() - start,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// job_runs helpers
+//
+// Kept local to avoid coupling the cron route's helpers; the SQL is small and
+// duplicate INSERT/UPDATE trivially safe.
+
+async function openJobRun(
+  db: AppDb,
+  bucket: string,
+  startedAtMs: number,
+): Promise<string> {
+  const startedAt = new Date(startedAtMs).toISOString();
+  const result = (await db.execute(sql`
+    INSERT INTO "job_runs" ("job_name", "bucket", "started_at", "status")
+    VALUES ('aoi-backfill', ${bucket}, ${startedAt}, 'running')
+    RETURNING "id"
+  `)) as unknown as { rows?: Array<{ id: string | number | bigint }> };
+  const rows = (result.rows ?? (result as unknown as Array<{ id: string | number | bigint }>)) as Array<{
+    id: string | number | bigint;
+  }>;
+  return String(rows[0]?.id ?? "");
+}
+
+type CloseArgs = {
+  status: "ok" | "error";
+  error?: string;
+  finishedAt: Date;
+  firmsRequestCount?: number;
+  detectionsInserted?: number;
+  eventsCreated?: number;
+  briefsGenerated?: number;
+  notificationsSent?: number;
+};
+
+async function closeJobRun(
+  db: AppDb,
+  id: string,
+  args: CloseArgs,
+): Promise<void> {
+  if (!id) return;
+  await db.execute(sql`
+    UPDATE "job_runs"
+    SET
+      "finished_at" = ${args.finishedAt.toISOString()},
+      "status" = ${args.status},
+      "error" = ${args.error ?? null},
+      "firms_request_count" = COALESCE("firms_request_count", 0) + ${args.firmsRequestCount ?? 0},
+      "detections_inserted" = COALESCE("detections_inserted", 0) + ${args.detectionsInserted ?? 0},
+      "events_created" = COALESCE("events_created", 0) + ${args.eventsCreated ?? 0},
+      "briefs_generated" = COALESCE("briefs_generated", 0) + ${args.briefsGenerated ?? 0},
+      "notifications_sent" = COALESCE("notifications_sent", 0) + ${args.notificationsSent ?? 0}
+    WHERE "id" = ${id}
+  `);
+}
+
+function errMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/lib/firms/matcher.ts
+++ b/lib/firms/matcher.ts
@@ -59,6 +59,13 @@ export type MatchArgs = {
   bucket: string;
   source: FirmsSource;
   detections: FirmsDetection[];
+  /**
+   * Stage 9: when set, restrict matching to ONLY these AOIs in the bucket.
+   * Used by the first-AOI backfill to avoid creating events for other AOIs
+   * that happen to share the bucket. When undefined/null, matches against
+   * all active AOIs in the bucket (cron-poll behaviour, unchanged).
+   */
+  aoiIds?: string[];
 };
 
 export type MatchResult = {
@@ -100,7 +107,7 @@ export async function matchDetectionsToAois(
 
   // 2. For each AOI in the bucket, find matching non-industrial detections
   //    *from this poll* and UPSERT events.
-  const matches = await findAoiMatches(db, args.bucket, pollStart);
+  const matches = await findAoiMatches(db, args.bucket, pollStart, args.aoiIds);
   for (const match of matches) {
     const outcome = await upsertEvent(db, args.bucket, args.source, match);
     if (outcome.kind === "created") {
@@ -238,6 +245,7 @@ async function findAoiMatches(
   db: AppDb,
   bucket: string,
   pollStart: Date,
+  aoiIds?: string[],
 ): Promise<PerAoiMatch[]> {
   if (!db.usePostGIS) {
     // PGlite does not expose ST_DWithin; the non-spatial tests cover the
@@ -246,6 +254,18 @@ async function findAoiMatches(
     // shaped API; spatial correctness is covered by the testcontainer tests.
     return [];
   }
+
+  // Build an OR-of-equals filter rather than ANY($1::uuid[]) — node-postgres
+  // serializes a JS array as a comma-joined string by default, which Postgres
+  // rejects as a malformed array literal. The OR form is parameterized cleanly
+  // for any reasonable aoiIds.length (single-AOI backfill is the only caller).
+  const aoiFilter =
+    aoiIds && aoiIds.length > 0
+      ? sql` AND a."id" IN (${sql.join(
+          aoiIds.map((id) => sql`${id}`),
+          sql`, `,
+        )})`
+      : sql``;
 
   const result = (await db.execute(sql`
     WITH active_detections AS (
@@ -264,6 +284,7 @@ async function findAoiMatches(
       LEFT JOIN "aoi_rules" r ON r."aoi_id" = a."id"
       WHERE a."archived_at" IS NULL
         AND a."region_bucket" = ${bucket}
+        ${aoiFilter}
     ),
     matches AS (
       SELECT

--- a/lib/geo/region-bucket.ts
+++ b/lib/geo/region-bucket.ts
@@ -30,3 +30,18 @@ export function regionBucketFromLonLat(lon: number, lat: number): string {
   const latHemi = swLat < 0 ? "S" : "N";
   return `5x5:${lonHemi}${lonAbs}_${latHemi}${latAbs}`;
 }
+
+const BUCKET_RE = /^5x5:([EW])(\d{3})_([NS])(\d{2})$/;
+
+/**
+ * Human-readable rendering of a region-bucket key for email/UI copy.
+ * Produces a short string like "5°×5° tile, SW corner 125°W 35°N".
+ */
+export function humanizeRegionBucket(bucket: string): string {
+  const m = BUCKET_RE.exec(bucket);
+  if (!m) return bucket;
+  const [, lonHemi, lonAbs, latHemi, latAbs] = m;
+  const lon = `${parseInt(lonAbs, 10)}°${lonHemi}`;
+  const lat = `${parseInt(latAbs, 10)}°${latHemi}`;
+  return `5°×5° tile, SW corner ${lon} ${lat}`;
+}

--- a/lib/notify/watch-confirmed-template.ts
+++ b/lib/notify/watch-confirmed-template.ts
@@ -1,0 +1,68 @@
+/**
+ * Stage 9 — watch-confirmed email body renderer.
+ *
+ * Produces a deterministic markdown body for the one-shot "now watching ..."
+ * email dispatched by `dispatchWatchConfirmed` after AOI creation.
+ */
+import { humanizeRegionBucket } from "@/lib/geo/region-bucket";
+
+export type WatchConfirmedTemplateArgs = {
+  aoiName: string;
+  regionBucket: string;
+  areaHa: number;
+  firstPollAt: Date;
+  aoiUrl: string;
+};
+
+export type RenderedEmail = {
+  subject: string;
+  markdown: string;
+};
+
+export function renderWatchConfirmedEmail(
+  args: WatchConfirmedTemplateArgs,
+): RenderedEmail {
+  const subject = `Now watching ${args.aoiName}`;
+  const region = humanizeRegionBucket(args.regionBucket);
+  const area = formatHectares(args.areaHa);
+  const firstPoll = formatUtc(args.firstPollAt);
+
+  const markdown = [
+    `# Now watching ${args.aoiName}`,
+    ``,
+    `Hi,`,
+    ``,
+    `Your area "${args.aoiName}" (${area}, region: ${region}) is now being watched.`,
+    ``,
+    `We poll NASA FIRMS every 15 minutes for new fire detections.`,
+    `Your first poll is scheduled by ${firstPoll} (usually within 15 minutes).`,
+    `If a detection inside or near your polygon meets the alert thresholds,`,
+    `you will receive a situation brief.`,
+    ``,
+    `View this AOI: ${args.aoiUrl}`,
+    `Edit alert rules: ${args.aoiUrl}/rules`,
+    ``,
+    `— Wildfire Nowcast`,
+    `Free, open, AI-native fire intelligence for stewardship — depth over speed.`,
+    ``,
+  ].join("\n");
+
+  return { subject, markdown };
+}
+
+function formatHectares(areaHa: number): string {
+  if (!Number.isFinite(areaHa)) return "unknown area";
+  if (areaHa >= 100) return `${Math.round(areaHa).toLocaleString("en-US")} ha`;
+  return `${areaHa.toFixed(1)} ha`;
+}
+
+function formatUtc(d: Date): string {
+  if (!(d instanceof Date) || !Number.isFinite(d.getTime())) {
+    return "the next cron tick";
+  }
+  const iso = d.toISOString();
+  // "2026-05-07T14:32:00Z" -> "2026-05-07 14:32 UTC"
+  const date = iso.slice(0, 10);
+  const time = iso.slice(11, 16);
+  return `${date} ${time} UTC`;
+}

--- a/lib/notify/watch-confirmed.ts
+++ b/lib/notify/watch-confirmed.ts
@@ -1,0 +1,200 @@
+/**
+ * Stage 9 — watch-confirmed email dispatcher.
+ *
+ * Single entry point: `dispatchWatchConfirmed`. Sends the one-shot
+ * "Now watching {AOI name}. First poll at {UTC time}." email after AOI
+ * creation. Uses the Stage 4 `sendEmail` Resend client; persists a
+ * `notifications_log` row with `kind='watch_confirmed'` and `brief_id=NULL`.
+ *
+ * Idempotency: hash on `(aoi_id)` only. A duplicate AOI POST (rare) finds the
+ * prior 'sent' row and returns `{ status: "skipped", reason: "duplicate" }`.
+ *
+ * Two-backend: only non-spatial SQL touched here; identical on Neon+PostGIS
+ * and PGlite.
+ */
+import { createHash } from "node:crypto";
+import { sql } from "drizzle-orm";
+import type { AppDb } from "@/lib/db/client";
+import { sendEmail, type SendResult } from "./resend";
+import { renderWatchConfirmedEmail } from "./watch-confirmed-template";
+
+export type WatchConfirmedOutcome =
+  | { status: "sent"; providerMessageId: string }
+  | {
+      status: "skipped";
+      reason: "no_recipient" | "no_recipient_pending" | "duplicate";
+    }
+  | { status: "config_missing" }
+  | { status: "failed"; error: string };
+
+export type DispatchWatchConfirmedArgs = {
+  aoiId: string;
+  userId: string;
+  aoiName: string;
+  regionBucket: string;
+  areaHa: number;
+  firstPollAt: Date;
+  aoiUrl: string;
+  now?: Date;
+  sendImpl?: (args: {
+    to: string;
+    subject: string;
+    markdown: string;
+  }) => Promise<SendResult>;
+};
+
+export async function dispatchWatchConfirmed(
+  db: AppDb,
+  args: DispatchWatchConfirmedArgs,
+): Promise<WatchConfirmedOutcome> {
+  const targetHash = sha256(`watch_confirmed:${args.aoiId}`);
+
+  const prior = await findPriorRow(db, args.aoiId, targetHash);
+  if (prior) {
+    return { status: "skipped", reason: "duplicate" };
+  }
+
+  const userEmail = await loadUserEmail(db, args.userId);
+  if (!userEmail) {
+    await insertRow(db, {
+      aoiId: args.aoiId,
+      target: "",
+      targetHash,
+      status: "skipped",
+      skipReason: "no_recipient",
+    });
+    return { status: "skipped", reason: "no_recipient" };
+  }
+  if (isPendingPlaceholder(userEmail)) {
+    await insertRow(db, {
+      aoiId: args.aoiId,
+      target: userEmail,
+      targetHash,
+      status: "skipped",
+      skipReason: "no_recipient_pending",
+    });
+    return { status: "skipped", reason: "no_recipient_pending" };
+  }
+
+  const { subject, markdown } = renderWatchConfirmedEmail({
+    aoiName: args.aoiName,
+    regionBucket: args.regionBucket,
+    areaHa: args.areaHa,
+    firstPollAt: args.firstPollAt,
+    aoiUrl: args.aoiUrl,
+  });
+
+  const send = args.sendImpl ?? ((a) => sendEmail(a));
+  const result = await send({ to: userEmail, subject, markdown });
+
+  if (!result.ok && result.code === "config_missing") {
+    await insertRow(db, {
+      aoiId: args.aoiId,
+      target: userEmail,
+      targetHash,
+      status: "config_missing",
+    });
+    return { status: "config_missing" };
+  }
+
+  if (!result.ok) {
+    const error = `${result.code}: ${result.message}`;
+    await insertRow(db, {
+      aoiId: args.aoiId,
+      target: userEmail,
+      targetHash,
+      status: "failed",
+      error: truncate(error, 500),
+    });
+    return { status: "failed", error };
+  }
+
+  await insertRow(db, {
+    aoiId: args.aoiId,
+    target: userEmail,
+    targetHash,
+    status: "sent",
+    providerMessageId: result.providerMessageId,
+  });
+  return { status: "sent", providerMessageId: result.providerMessageId };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+
+type InsertArgs = {
+  aoiId: string;
+  target: string;
+  targetHash: string;
+  status: "sent" | "failed" | "skipped" | "config_missing";
+  providerMessageId?: string;
+  error?: string;
+  skipReason?: string;
+};
+
+async function insertRow(db: AppDb, args: InsertArgs): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO "notifications_log" (
+      "aoi_id", "brief_id", "kind", "channel", "target", "target_hash",
+      "status", "provider_message_id", "error", "skip_reason"
+    ) VALUES (
+      ${args.aoiId},
+      NULL,
+      'watch_confirmed',
+      'email',
+      ${args.target},
+      ${args.targetHash},
+      ${args.status},
+      ${args.providerMessageId ?? null},
+      ${args.error ?? null},
+      ${args.skipReason ?? null}
+    )
+  `);
+}
+
+async function findPriorRow(
+  db: AppDb,
+  aoiId: string,
+  targetHash: string,
+): Promise<boolean> {
+  const result = (await db.execute(sql`
+    SELECT 1 AS one FROM "notifications_log"
+    WHERE "aoi_id" = ${aoiId}
+      AND "kind" = 'watch_confirmed'
+      AND "target_hash" = ${targetHash}
+      AND "status" IN ('sent', 'skipped', 'config_missing')
+    LIMIT 1
+  `)) as unknown as { rows?: Array<{ one: number }> };
+  const rows = (result.rows ?? (result as unknown as Array<{ one: number }>)) as Array<{
+    one: number;
+  }>;
+  return rows.length > 0;
+}
+
+async function loadUserEmail(db: AppDb, userId: string): Promise<string | null> {
+  const result = (await db.execute(sql`
+    SELECT "email" FROM "users" WHERE "id" = ${userId} LIMIT 1
+  `)) as unknown as { rows?: Array<{ email: string | null }> };
+  const rows = (result.rows ?? (result as unknown as Array<{ email: string | null }>)) as Array<{
+    email: string | null;
+  }>;
+  const email = rows[0]?.email;
+  return typeof email === "string" && email.length > 0 ? email : null;
+}
+
+function isPendingPlaceholder(email: string): boolean {
+  return /@pending\.invalid$/.test(email);
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max);
+}
+
+export function absoluteAoiUrl(aoiId: string): string {
+  const host = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "") ?? "http://localhost:3000";
+  return `${host}/dashboard/aoi/${aoiId}`;
+}

--- a/tests/aoi-post-after-response.test.ts
+++ b/tests/aoi-post-after-response.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Stage 9 — AOI POST after-response wiring tests.
+ *
+ * The route uses Next.js `after()` to schedule watch-confirmed dispatch +
+ * backfill post-response. In tests we install a synchronous `_setTestAfterImpl`
+ * that runs the callback inline so we can assert side effects.
+ *
+ * Verifies:
+ *   - 201 returned with the AOI shape
+ *   - watch-confirmed dispatcher invoked with the right args
+ *   - backfill invoked with the right args
+ *   - watch-confirmed throwing does NOT prevent backfill or break the 201
+ *   - backfill throwing does NOT prevent the 201
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { PGlite } from "@electric-sql/pglite";
+import { makeFreshTestDb } from "@/db/test/pglite";
+import { _setTestDb, type AppDb } from "@/lib/db/client";
+import { _setTestAuth } from "@/lib/auth/context";
+import {
+  POST as aoiCreate,
+  _setTestAfterImpl,
+  _setTestWatchConfirmed,
+  _setTestBackfill,
+} from "@/app/api/aoi/route";
+
+const ROUTE_USER_ID = "user_2abcStage9";
+
+const SONOMA_POLY = {
+  type: "Polygon",
+  coordinates: [
+    [
+      [-122.72, 38.42],
+      [-122.62, 38.42],
+      [-122.62, 38.5],
+      [-122.72, 38.5],
+      [-122.72, 38.42],
+    ],
+  ],
+};
+
+function jsonReq(body: unknown): Request {
+  return new Request("http://localhost/api/aoi", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("AOI POST — after-response wiring (Stage 9)", () => {
+  let db: AppDb;
+  let pglite: PGlite;
+  const queue: Array<() => void | Promise<void>> = [];
+
+  beforeEach(async () => {
+    ({ db, pglite } = await makeFreshTestDb());
+    _setTestDb(db);
+    _setTestAuth(() => ({ ok: true, userId: ROUTE_USER_ID }));
+    queue.length = 0;
+    _setTestAfterImpl((cb) => {
+      queue.push(cb);
+    });
+  });
+
+  afterEach(async () => {
+    _setTestDb(null);
+    _setTestAuth(null);
+    _setTestAfterImpl(null);
+    _setTestWatchConfirmed(null);
+    _setTestBackfill(null);
+    await pglite.close();
+  });
+
+  async function drainQueue(): Promise<void> {
+    while (queue.length > 0) {
+      const cb = queue.shift()!;
+      await cb();
+    }
+  }
+
+  it("schedules watch-confirmed and backfill via after(); returns 201", async () => {
+    const watchCalls: Array<{ aoiId: string; aoiName: string }> = [];
+    const backfillCalls: Array<{ aoiId: string; regionBucket: string }> = [];
+    _setTestWatchConfirmed(async (_db, args) => {
+      watchCalls.push({ aoiId: args.aoiId, aoiName: args.aoiName });
+      return { status: "sent", providerMessageId: "fake" };
+    });
+    _setTestBackfill(async (_db, args) => {
+      backfillCalls.push({ aoiId: args.aoiId, regionBucket: args.regionBucket });
+      return {
+        aoiId: args.aoiId,
+        status: "ok",
+        detectionsFetched: 0,
+        detectionsMatched: 0,
+        eventsCreated: 0,
+        briefsGenerated: 0,
+        notificationsSent: 0,
+        durationMs: 1,
+      };
+    });
+
+    const res = await aoiCreate(
+      jsonReq({ name: "Spring Creek Preserve", geometry: SONOMA_POLY }) as Parameters<typeof aoiCreate>[0],
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { aoi: { id: string; name: string } };
+    expect(body.aoi.name).toBe("Spring Creek Preserve");
+
+    // Queue holds the after-callback; nothing fired yet.
+    expect(watchCalls).toHaveLength(0);
+    await drainQueue();
+
+    expect(watchCalls).toHaveLength(1);
+    expect(watchCalls[0].aoiId).toBe(body.aoi.id);
+    expect(watchCalls[0].aoiName).toBe("Spring Creek Preserve");
+    expect(backfillCalls).toHaveLength(1);
+    expect(backfillCalls[0].aoiId).toBe(body.aoi.id);
+    expect(backfillCalls[0].regionBucket).toBe("5x5:W125_N35");
+  });
+
+  it("watch-confirmed throwing does not prevent backfill nor break the 201", async () => {
+    let backfillCalled = false;
+    _setTestWatchConfirmed(async () => {
+      throw new Error("simulated email outage");
+    });
+    _setTestBackfill(async (_db, args) => {
+      backfillCalled = true;
+      return {
+        aoiId: args.aoiId,
+        status: "ok",
+        detectionsFetched: 0,
+        detectionsMatched: 0,
+        eventsCreated: 0,
+        briefsGenerated: 0,
+        notificationsSent: 0,
+        durationMs: 1,
+      };
+    });
+
+    const res = await aoiCreate(
+      jsonReq({ name: "Test", geometry: SONOMA_POLY }) as Parameters<typeof aoiCreate>[0],
+    );
+    expect(res.status).toBe(201);
+    await drainQueue();
+    expect(backfillCalled).toBe(true);
+  });
+
+  it("backfill throwing does not break the 201", async () => {
+    _setTestWatchConfirmed(async () => ({
+      status: "sent",
+      providerMessageId: "x",
+    }));
+    _setTestBackfill(async () => {
+      throw new Error("simulated firms outage");
+    });
+
+    const res = await aoiCreate(
+      jsonReq({ name: "Test", geometry: SONOMA_POLY }) as Parameters<typeof aoiCreate>[0],
+    );
+    expect(res.status).toBe(201);
+    await drainQueue();
+    // No throw — both AOI creation and 201 succeed; the after-task swallowed
+    // the backfill error per the brief's failure-isolation rule.
+  });
+});

--- a/tests/firms-matcher.integration.test.ts
+++ b/tests/firms-matcher.integration.test.ts
@@ -272,4 +272,104 @@ describeIntegration("FIRMS matcher — PostGIS integration", () => {
     expect(Number(events.rows[0].peak_frp_mw)).toBeCloseTo(18.5, 1);
   });
 
+  it("Stage 9 — aoiIds scopes matching to a single AOI in the bucket", async () => {
+    // Add a second AOI in the same bucket. A detection that matches both
+    // (same buffer, same bucket) should only create an event for the AOI we
+    // restrict to via aoiIds.
+    const otherPoly = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [SONOMA_LON + 0.20, SONOMA_LAT - 0.04],
+          [SONOMA_LON + 0.30, SONOMA_LAT - 0.04],
+          [SONOMA_LON + 0.30, SONOMA_LAT + 0.04],
+          [SONOMA_LON + 0.20, SONOMA_LAT + 0.04],
+          [SONOMA_LON + 0.20, SONOMA_LAT - 0.04],
+        ],
+      ],
+    };
+    await handle!.pool.query(
+      `INSERT INTO aois (user_id, name, polygon, bbox, centroid, region_bucket, area_ha)
+       VALUES (
+         'user_2matcherIntegOwner',
+         'Other AOI',
+         ST_Multi(ST_SetSRID(ST_GeomFromGeoJSON($1), 4326)),
+         ST_SetSRID(ST_Envelope(ST_GeomFromGeoJSON($1)), 4326),
+         ST_SetSRID(ST_Centroid(ST_GeomFromGeoJSON($1)), 4326),
+         $2,
+         500
+       )`,
+      [JSON.stringify(otherPoly), SONOMA_BUCKET],
+    );
+    await handle!.pool.query(
+      `INSERT INTO aoi_rules (aoi_id, distance_buffer_km, min_confidence, min_frp_mw)
+       SELECT id, 25, 'nominal', 5 FROM aois WHERE name = 'Other AOI'`,
+    );
+    const ids = await handle!.pool.query(
+      `SELECT id FROM aois WHERE name = 'Spring Creek Preserve'`,
+    );
+    const targetAoiId = ids.rows[0].id as string;
+
+    const det = makeDet(SONOMA_LAT + 0.08, SONOMA_LON + 0.10);
+    const scoped = await matchDetectionsToAois(handle!.db, {
+      bucket: SONOMA_BUCKET,
+      source: "VIIRS_NOAA20_NRT",
+      detections: [det],
+      aoiIds: [targetAoiId],
+    });
+    expect(scoped.eventsCreated).toBe(1);
+    const eventsForOther = await handle!.pool.query(
+      `SELECT COUNT(*)::int AS c FROM aoi_events
+       WHERE aoi_id IN (SELECT id FROM aois WHERE name = 'Other AOI')`,
+    );
+    expect(eventsForOther.rows[0].c).toBe(0);
+    const eventsForTarget = await handle!.pool.query(
+      `SELECT COUNT(*)::int AS c FROM aoi_events WHERE aoi_id = $1`,
+      [targetAoiId],
+    );
+    expect(eventsForTarget.rows[0].c).toBe(1);
+  });
+
+  it("Stage 9 — aoiIds undefined preserves original full-bucket behaviour", async () => {
+    // Two AOIs in the same bucket; without aoiIds, both should match a
+    // detection that's near both polygons.
+    const otherPoly = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [SONOMA_LON + 0.20, SONOMA_LAT - 0.04],
+          [SONOMA_LON + 0.30, SONOMA_LAT - 0.04],
+          [SONOMA_LON + 0.30, SONOMA_LAT + 0.04],
+          [SONOMA_LON + 0.20, SONOMA_LAT + 0.04],
+          [SONOMA_LON + 0.20, SONOMA_LAT - 0.04],
+        ],
+      ],
+    };
+    await handle!.pool.query(
+      `INSERT INTO aois (user_id, name, polygon, bbox, centroid, region_bucket, area_ha)
+       VALUES (
+         'user_2matcherIntegOwner',
+         'Other AOI',
+         ST_Multi(ST_SetSRID(ST_GeomFromGeoJSON($1), 4326)),
+         ST_SetSRID(ST_Envelope(ST_GeomFromGeoJSON($1)), 4326),
+         ST_SetSRID(ST_Centroid(ST_GeomFromGeoJSON($1)), 4326),
+         $2,
+         500
+       )`,
+      [JSON.stringify(otherPoly), SONOMA_BUCKET],
+    );
+    await handle!.pool.query(
+      `INSERT INTO aoi_rules (aoi_id, distance_buffer_km, min_confidence, min_frp_mw)
+       SELECT id, 25, 'nominal', 5 FROM aois WHERE name = 'Other AOI'`,
+    );
+    // Detection between both polygons — within 25 km of each.
+    const det = makeDet(SONOMA_LAT, SONOMA_LON + 0.13);
+    const result = await matchDetectionsToAois(handle!.db, {
+      bucket: SONOMA_BUCKET,
+      source: "VIIRS_NOAA20_NRT",
+      detections: [det],
+    });
+    expect(result.eventsCreated).toBe(2);
+  });
+
 });

--- a/tests/firms/backfill.test.ts
+++ b/tests/firms/backfill.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Stage 9 — backfill unit tests on PGlite.
+ *
+ * PGlite has no PostGIS, so the matcher's spatial step returns []. These
+ * tests cover:
+ *   - config_missing skip path (FIRMS_MAP_KEY unset, no fetchImpl override)
+ *   - fetch error path
+ *   - happy path (job_runs row, 'aoi-backfill', detections inserted)
+ *
+ * Single-AOI scope and full integration end-to-end are exercised in
+ * `tests/firms-matcher.integration.test.ts` (matcher) plus the AOI POST
+ * after-response test that pipes through the real wiring.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import type { PGlite } from "@electric-sql/pglite";
+import { makeFreshTestDb } from "@/db/test/pglite";
+import type { AppDb } from "@/lib/db/client";
+import { backfillForNewAoi } from "@/lib/firms/backfill";
+import type { FirmsFetchResult } from "@/lib/firms/client";
+
+async function seedAoi(db: AppDb): Promise<{ aoiId: string; userId: string }> {
+  const userId = `stub-user-${Math.random().toString(36).slice(2, 8)}`;
+  await db.execute(sql`
+    INSERT INTO "users" (id, email) VALUES (${userId}, 'owner@example.org')
+  `);
+  const polygon = JSON.stringify({
+    type: "Polygon",
+    coordinates: [
+      [[-122.7, 38.4], [-122.6, 38.4], [-122.6, 38.5], [-122.7, 38.5], [-122.7, 38.4]],
+    ],
+  });
+  const r = (await db.execute(sql`
+    INSERT INTO "aois" (user_id, name, polygon, bbox, centroid, region_bucket, area_ha)
+    VALUES (
+      ${userId}, 'Test AOI', ${polygon}, ${polygon},
+      ${JSON.stringify({ type: "Point", coordinates: [-122.65, 38.45] })},
+      '5x5:W125_N35', 100
+    ) RETURNING id
+  `)) as unknown as { rows?: Array<{ id: string }> };
+  const rows = (r.rows ?? (r as unknown as Array<{ id: string }>)) as Array<{ id: string }>;
+  await db.execute(sql`
+    INSERT INTO "aoi_rules" (aoi_id) VALUES (${rows[0].id})
+  `);
+  return { aoiId: rows[0].id, userId };
+}
+
+async function readJobRuns(db: AppDb): Promise<Array<Record<string, unknown>>> {
+  const r = (await db.execute(sql`
+    SELECT * FROM "job_runs" WHERE "job_name" = 'aoi-backfill'
+    ORDER BY "started_at" ASC
+  `)) as unknown as { rows?: Array<Record<string, unknown>> };
+  return (r.rows ?? (r as unknown as Array<Record<string, unknown>>)) as Array<Record<string, unknown>>;
+}
+
+describe("backfillForNewAoi — PGlite", () => {
+  let db: AppDb;
+  let pglite: PGlite;
+  const originalKey = process.env.FIRMS_MAP_KEY;
+
+  beforeEach(async () => {
+    ({ db, pglite } = await makeFreshTestDb());
+  });
+
+  afterEach(async () => {
+    await pglite.close();
+    if (originalKey === undefined) delete process.env.FIRMS_MAP_KEY;
+    else process.env.FIRMS_MAP_KEY = originalKey;
+  });
+
+  it("FIRMS_MAP_KEY unset → returns skipped/config_missing, no firms_detections written", async () => {
+    delete process.env.FIRMS_MAP_KEY;
+    const { aoiId, userId } = await seedAoi(db);
+    const outcome = await backfillForNewAoi(db, {
+      aoiId,
+      userId,
+      regionBucket: "5x5:W125_N35",
+    });
+    expect(outcome.status).toBe("skipped");
+    expect(outcome.reason).toBe("config_missing");
+    const detRows = (await db.execute(sql`SELECT COUNT(*)::int AS c FROM "firms_detections"`)) as unknown as {
+      rows?: Array<{ c: number }>;
+    };
+    const c = (detRows.rows ?? (detRows as unknown as Array<{ c: number }>))[0].c;
+    expect(Number(c)).toBe(0);
+    const runs = await readJobRuns(db);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe("ok");
+    expect(runs[0].bucket).toBe("5x5:W125_N35");
+  });
+
+  it("FIRMS fetch error → returns error/fetch_failed; job_runs row closed status=error", async () => {
+    const { aoiId, userId } = await seedAoi(db);
+    const fetchImpl = async (): Promise<FirmsFetchResult> => ({
+      ok: false,
+      code: "upstream_error",
+      message: "FIRMS 502",
+    });
+    const outcome = await backfillForNewAoi(db, {
+      aoiId,
+      userId,
+      regionBucket: "5x5:W125_N35",
+      fetchImpl,
+    });
+    expect(outcome.status).toBe("error");
+    expect(outcome.reason).toBe("fetch_failed");
+    const runs = await readJobRuns(db);
+    expect(runs[0].status).toBe("error");
+    expect(String(runs[0].error)).toContain("upstream_error");
+  });
+
+  it("happy path — fetch succeeds, opens & closes aoi-backfill job_run", async () => {
+    const { aoiId, userId } = await seedAoi(db);
+    const fetchImpl = async (): Promise<FirmsFetchResult> => ({
+      ok: true,
+      source: "VIIRS_NOAA20_NRT",
+      bbox: [-125, 35, -120, 40],
+      dayRange: 1,
+      detections: [
+        {
+          latitude: 38.45,
+          longitude: -122.65,
+          brightTi4: 320,
+          brightTi5: 290,
+          scan: 0.4,
+          track: 0.4,
+          acqDate: "2026-05-07",
+          acqTime: "1234",
+          satellite: "N20",
+          instrument: "VIIRS",
+          confidence: "n",
+          version: "2.0",
+          frp: 12,
+          daynight: "D",
+        },
+      ],
+      emptyArea: false,
+    });
+    const outcome = await backfillForNewAoi(db, {
+      aoiId,
+      userId,
+      regionBucket: "5x5:W125_N35",
+      fetchImpl,
+    });
+    expect(outcome.status).toBe("ok");
+    expect(outcome.detectionsFetched).toBe(1);
+    const runs = await readJobRuns(db);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe("ok");
+    expect(runs[0].job_name).toBe("aoi-backfill");
+    expect(runs[0].bucket).toBe("5x5:W125_N35");
+  });
+});

--- a/tests/notify/watch-confirmed-template.test.ts
+++ b/tests/notify/watch-confirmed-template.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Stage 9 — watch-confirmed email template snapshot tests.
+ *
+ * The body shape is part of the user-visible contract; small edits should
+ * fail loudly so reviewers see the diff.
+ */
+import { describe, expect, it } from "vitest";
+import { renderWatchConfirmedEmail } from "@/lib/notify/watch-confirmed-template";
+
+describe("renderWatchConfirmedEmail", () => {
+  const baseArgs = {
+    aoiName: "Spring Creek Preserve",
+    regionBucket: "5x5:W125_N35",
+    areaHa: 850.5,
+    firstPollAt: new Date("2026-05-07T14:30:00Z"),
+    aoiUrl: "http://localhost:3000/dashboard/aoi/abc-123",
+  };
+
+  it("subject is exactly 'Now watching {aoiName}'", () => {
+    const r = renderWatchConfirmedEmail(baseArgs);
+    expect(r.subject).toBe("Now watching Spring Creek Preserve");
+  });
+
+  it("body contains AOI name, area, region, firstPollAt, and aoiUrl", () => {
+    const r = renderWatchConfirmedEmail(baseArgs);
+    expect(r.markdown).toContain("Spring Creek Preserve");
+    expect(r.markdown).toContain("851 ha"); // rounded
+    expect(r.markdown).toContain("125°W 35°N");
+    expect(r.markdown).toContain("2026-05-07 14:30 UTC");
+    expect(r.markdown).toContain("http://localhost:3000/dashboard/aoi/abc-123");
+    expect(r.markdown).toContain("/rules");
+    expect(r.markdown).toContain("Wildfire Nowcast");
+  });
+
+  it("small areas use one decimal of precision", () => {
+    const r = renderWatchConfirmedEmail({ ...baseArgs, areaHa: 12.34 });
+    expect(r.markdown).toContain("12.3 ha");
+  });
+});

--- a/tests/notify/watch-confirmed.test.ts
+++ b/tests/notify/watch-confirmed.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Stage 9 — watch-confirmed dispatcher unit tests on PGlite.
+ *
+ * Mirrors the structure of `tests/notify/dispatch.test.ts`. Covers:
+ *   - happy path → row inserted, kind='watch_confirmed', status='sent'
+ *   - duplicate call → second call returns skipped/duplicate, no second row
+ *   - sendImpl returns config_missing → row inserted with status='config_missing'
+ *   - JIT @pending.invalid email → skipped/no_recipient_pending, send not called
+ *   - missing user → skipped/no_recipient
+ *   - sendImpl returns provider_error → row inserted status='failed'
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import type { PGlite } from "@electric-sql/pglite";
+import { makeFreshTestDb } from "@/db/test/pglite";
+import type { AppDb } from "@/lib/db/client";
+import { dispatchWatchConfirmed } from "@/lib/notify/watch-confirmed";
+import type { SendResult } from "@/lib/notify/resend";
+
+async function seedAoi(
+  db: AppDb,
+  opts: { userEmail?: string; userId?: string } = {},
+): Promise<{ aoiId: string; userId: string }> {
+  const userId = opts.userId ?? `stub-user-${Math.random().toString(36).slice(2, 8)}`;
+  const userEmail = opts.userEmail ?? "owner@example.org";
+  await db.execute(sql`
+    INSERT INTO "users" (id, email) VALUES (${userId}, ${userEmail})
+  `);
+  const polygon = JSON.stringify({
+    type: "Polygon",
+    coordinates: [
+      [[-122.7, 38.4], [-122.6, 38.4], [-122.6, 38.5], [-122.7, 38.5], [-122.7, 38.4]],
+    ],
+  });
+  const aoiRes = (await db.execute(sql`
+    INSERT INTO "aois" (user_id, name, polygon, bbox, centroid, region_bucket, area_ha)
+    VALUES (
+      ${userId}, 'Spring Creek Preserve', ${polygon}, ${polygon},
+      ${JSON.stringify({ type: "Point", coordinates: [-122.65, 38.45] })},
+      '5x5:W125_N35', 850.5
+    ) RETURNING id
+  `)) as unknown as { rows?: Array<{ id: string }> };
+  const rows = (aoiRes.rows ?? (aoiRes as unknown as Array<{ id: string }>)) as Array<{ id: string }>;
+  return { aoiId: rows[0].id, userId };
+}
+
+async function readRows(
+  db: AppDb,
+  aoiId: string,
+): Promise<Array<Record<string, unknown>>> {
+  const r = (await db.execute(sql`
+    SELECT * FROM "notifications_log"
+    WHERE "aoi_id" = ${aoiId} AND "kind" = 'watch_confirmed'
+    ORDER BY "sent_at" ASC
+  `)) as unknown as { rows?: Array<Record<string, unknown>> };
+  return (r.rows ?? (r as unknown as Array<Record<string, unknown>>)) as Array<Record<string, unknown>>;
+}
+
+const baseArgs = (aoiId: string, userId: string) => ({
+  aoiId,
+  userId,
+  aoiName: "Spring Creek Preserve",
+  regionBucket: "5x5:W125_N35",
+  areaHa: 850.5,
+  firstPollAt: new Date("2026-05-07T14:30:00Z"),
+  aoiUrl: "http://localhost:3000/dashboard/aoi/abc",
+});
+
+describe("dispatchWatchConfirmed — PGlite", () => {
+  let db: AppDb;
+  let pglite: PGlite;
+
+  beforeEach(async () => {
+    ({ db, pglite } = await makeFreshTestDb());
+  });
+
+  afterEach(async () => {
+    await pglite.close();
+  });
+
+  it("happy path — sends and inserts row with kind='watch_confirmed'", async () => {
+    const { aoiId, userId } = await seedAoi(db);
+    let captured: { to: string; subject: string; markdown: string } | null = null;
+    const sendImpl = async (a: {
+      to: string;
+      subject: string;
+      markdown: string;
+    }): Promise<SendResult> => {
+      captured = a;
+      return { ok: true, providerMessageId: "resend-stage9-1", latencyMs: 12 };
+    };
+    const outcome = await dispatchWatchConfirmed(db, {
+      ...baseArgs(aoiId, userId),
+      sendImpl,
+    });
+    expect(outcome.status).toBe("sent");
+    if (outcome.status === "sent") {
+      expect(outcome.providerMessageId).toBe("resend-stage9-1");
+    }
+    expect(captured).not.toBeNull();
+    expect(captured!.to).toBe("owner@example.org");
+    expect(captured!.subject).toContain("Now watching Spring Creek Preserve");
+    expect(captured!.markdown).toContain("Spring Creek Preserve");
+    expect(captured!.markdown).toContain("2026-05-07 14:30 UTC");
+
+    const rows = await readRows(db, aoiId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("sent");
+    expect(rows[0].kind).toBe("watch_confirmed");
+    expect(rows[0].brief_id).toBeNull();
+    expect(rows[0].provider_message_id).toBe("resend-stage9-1");
+  });
+
+  it("duplicate call → second invocation is skipped/duplicate, no second row", async () => {
+    const { aoiId, userId } = await seedAoi(db);
+    const sendImpl = async (): Promise<SendResult> => ({
+      ok: true,
+      providerMessageId: "x",
+      latencyMs: 1,
+    });
+    await dispatchWatchConfirmed(db, { ...baseArgs(aoiId, userId), sendImpl });
+    const second = await dispatchWatchConfirmed(db, {
+      ...baseArgs(aoiId, userId),
+      sendImpl,
+    });
+    expect(second.status).toBe("skipped");
+    if (second.status === "skipped") {
+      expect(second.reason).toBe("duplicate");
+    }
+    const rows = await readRows(db, aoiId);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("config_missing → row inserted with status='config_missing'", async () => {
+    const { aoiId, userId } = await seedAoi(db);
+    const sendImpl = async (): Promise<SendResult> => ({
+      ok: false,
+      code: "config_missing",
+      message: "RESEND_API_KEY not set",
+      latencyMs: 0,
+    });
+    const outcome = await dispatchWatchConfirmed(db, {
+      ...baseArgs(aoiId, userId),
+      sendImpl,
+    });
+    expect(outcome.status).toBe("config_missing");
+    const rows = await readRows(db, aoiId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("config_missing");
+  });
+
+  it("@pending.invalid email → skipped/no_recipient_pending, send not called", async () => {
+    const { aoiId, userId } = await seedAoi(db, {
+      userEmail: "user_xyz@pending.invalid",
+    });
+    let called = false;
+    const sendImpl = async (): Promise<SendResult> => {
+      called = true;
+      return { ok: true, providerMessageId: "x", latencyMs: 1 };
+    };
+    const outcome = await dispatchWatchConfirmed(db, {
+      ...baseArgs(aoiId, userId),
+      sendImpl,
+    });
+    expect(called).toBe(false);
+    expect(outcome.status).toBe("skipped");
+    if (outcome.status === "skipped") {
+      expect(outcome.reason).toBe("no_recipient_pending");
+    }
+    const rows = await readRows(db, aoiId);
+    expect(rows[0].skip_reason).toBe("no_recipient_pending");
+  });
+
+  it("missing user → skipped/no_recipient", async () => {
+    const { aoiId } = await seedAoi(db);
+    const outcome = await dispatchWatchConfirmed(db, {
+      ...baseArgs(aoiId, "nonexistent-user"),
+    });
+    expect(outcome.status).toBe("skipped");
+    if (outcome.status === "skipped") {
+      expect(outcome.reason).toBe("no_recipient");
+    }
+  });
+
+  it("provider_error → row written status='failed'; dispatcher does not throw", async () => {
+    const { aoiId, userId } = await seedAoi(db);
+    const sendImpl = async (): Promise<SendResult> => ({
+      ok: false,
+      code: "provider_error",
+      message: "boom",
+      latencyMs: 0,
+    });
+    const outcome = await dispatchWatchConfirmed(db, {
+      ...baseArgs(aoiId, userId),
+      sendImpl,
+    });
+    expect(outcome.status).toBe("failed");
+    const rows = await readRows(db, aoiId);
+    expect(rows[0].status).toBe("failed");
+    expect(String(rows[0].error)).toContain("provider_error");
+  });
+});


### PR DESCRIPTION
## Summary

Stage 9 closes SPEC Flow 1 end-to-end so launch acceptance #2 (\"cold start to first watch ≤ 5 min\") is structurally measurable.

Two product-visible additions, both wired off \`POST /api/aoi\`:

1. **Watch-confirmed email** — one-shot \"Now watching {AOI name}. First poll by {UTC time}.\" Sends via Stage 4 Resend client, idempotent on \`(aoi_id)\`, persisted as \`notifications_log.kind='watch_confirmed'\`.
2. **First-AOI backfill** — runs immediately after the 201 via Next.js \`after()\`, fetches last 24h FIRMS for the new AOI's bucket, matches scoped to JUST this AOI, pipes any matches through brief generator + Stage 4 dispatcher.

Both best-effort: failures log and the 201 still returns.

agent: dev
Implements pm/briefs/23-stage9-watch-confirmed-and-first-poll-backfill.md
stage-pr: 9

## Acceptance criteria (from brief 23)

- [x] \`POST /api/aoi\` dispatches watch-confirmed email post-response
- [x] Email body lists AOI name, area, region (humanized), expected first-poll time, AOI URL, rules URL
- [x] Idempotency on \`(aoi_id)\` — duplicate POST → skipped/duplicate
- [x] First-AOI backfill scoped to just this AOI's region bucket
- [x] Backfill records under \`job_runs.job_name = 'aoi-backfill'\`
- [x] AOI POST returns 201 even if email or backfill fails
- [x] \`RESEND_API_KEY\` / \`FIRMS_MAP_KEY\` unset → skipped, AOI still creates
- [x] Migration \`0007_stage9.sql\` + \`.test.sql\`; \`notifications_log.kind\` column added with default \`'brief'\`
- [x] \`brief_id\` nullability dropped (per brief §Open questions #2)
- [x] PGlite unit tests for both dispatchers + matcher \`aoiIds\` filter
- [x] All four checks green

## Backfill-path decision

**Chose Path A — Next.js \`after()\`** from \`next/server\`. Stable in Next.js 16, no new dep, no new route, preserves single AOI-creation transaction. Route guards with try/catch, falls back to fire-and-forget if \`after()\` throws (test scope without injection). If preview logs ever show the function terminating before \`after()\` resolves, brief's Path C (internal route) is the documented fallback.

## Test results

- typecheck / lint / build clean
- test: 228 passed / 17 skipped (Docker-gated PostGIS integration)

## Notable design choices

- \`notifications_log.brief_id\` had \`NOT NULL\`; the migration drops it because watch-confirmed rows don't have a brief.
- Matcher \`aoiIds\` filter uses \`IN (?, ?, ...)\` rather than \`ANY(\$1::uuid[])\` because node-postgres serializes JS arrays as comma-joined strings (Postgres rejects). Documented inline.
- \`firstPollAt = createdAt + 15 min\` per brief strawman; copy says \"by {time} (usually within 15 minutes)\" so we don't over-claim.

## Out of scope (per brief)

- Resend sender-domain verification (Stage 4 deferred)
- Async / queue-based backfill (Vercel Queues, Inngest) — \`after()\` is the v1 strawman
- Watch-confirmed for AOI updates / unpause / re-activation
- Webhook channel for watch-confirmed
- \`/api/aoi/[id]/backfill\` route — only build if Path A breaks