### PR TITLE
chore(notify): close token-action oracle on redemption failures + audit log

### DIFF
--- a/app/api/notify/_lib/handle.ts
+++ b/app/api/notify/_lib/handle.ts
@@ -61,29 +61,22 @@ export async function handleAction(
 
   const now = new Date();
 
-  // Pre-load so we can render specific failure messages.
+  // Collapse all redemption-failure modes (missing token, wrong action, expired)
+  // to a single 404 with an opaque message. Distinguishing them in the response
+  // would let an attacker who guessed a valid token use the four endpoints as an
+  // oracle for which (action, channel, target) it is bound to. With 256-bit
+  // entropy the practical attack is moot, but the principle costs us nothing.
   const loaded = await loadActionToken(db, token);
-  if (!loaded) {
+  const invalid =
+    !loaded ||
+    loaded.action !== action ||
+    loaded.expiresAt.getTime() <= now.getTime();
+  if (invalid) {
     return htmlResponse(
       404,
-      renderError("Link not found", "This action link is invalid or has been deleted."),
-    );
-  }
-  if (loaded.action !== action) {
-    return htmlResponse(
-      400,
       renderError(
-        "Wrong action",
-        "This link does not match the requested action.",
-      ),
-    );
-  }
-  if (loaded.expiresAt.getTime() <= now.getTime()) {
-    return htmlResponse(
-      410,
-      renderError(
-        "Link expired",
-        "This link has expired. You can adjust this AOI from the dashboard.",
+        "Link not found",
+        "This link is invalid or has expired. You can adjust this AOI from the dashboard.",
       ),
     );
   }
@@ -96,8 +89,11 @@ export async function handleAction(
   });
   if (!result.ok) {
     return htmlResponse(
-      400,
-      renderError("Could not redeem", `Redemption failed: ${result.reason}`),
+      404,
+      renderError(
+        "Link not found",
+        "This link is invalid or has expired. You can adjust this AOI from the dashboard.",
+      ),
     );
   }
 

--- a/pm/research-log/2026-05-07-token-endpoint-security-audit.md
+++ b/pm/research-log/2026-05-07-token-endpoint-security-audit.md
@@ -1,0 +1,118 @@
+# Token-endpoint security audit (Stage 6 + 7)
+
+Date: 2026-05-07
+Author: scout
+Scope: the five public, unauthenticated, token-bearing endpoints landed in
+Stage 6 / Stage 7 — `GET /brief/share/[token]`,
+`GET /api/notify/{snooze,pause,unsubscribe,feedback}/[token]`.
+
+## TL;DR
+
+The token plumbing is fundamentally sound: 256-bit `randomBytes` hex tokens,
+unique-indexed in the DB, scoped per `(aoi_id, brief_id, action, channel,
+target)`, with bounded TTLs (30d for snooze/pause/unsubscribe, 90d for
+feedback, 30d for share). Side-effects driven from the loaded row, not URL
+params, so no cross-AOI confused-deputy attack. Input is HTML-escaped
+through `escapeHtml`; no DOMPurify gap visible.
+
+One concrete fix shipped in this PR; the rest are catalogued below as
+brainstorm-only or out-of-scope per the audit's hard rules.
+
+## Shipped this PR
+
+**F1 — Failure-mode oracle on action endpoints (`app/api/notify/_lib/handle.ts:64-102`).**
+Before: invalid token → 404 "Link not found", wrong-action token → 400
+"Wrong action", expired token → 410 "Link expired", `redeemActionToken`
+failure → 400 with the structured reason in the body. An attacker who
+somehow obtained a valid token (mailbox compromise, log access, partial
+leak) could query all four `/api/notify/{action}/[token]` endpoints and
+read off which `action` the token was bound to from the status-code/body
+delta. With 256-bit entropy the prereq (knowing a valid token) is the
+hard part, but distinguishing failure modes costs us nothing and removes
+an oracle. Now: every redemption failure returns the same 404 + opaque
+message.
+
+The `?v=` validation on `/feedback` still returns 400 before any DB
+lookup — that path doesn't touch the token row, so it leaks nothing.
+
+## Catalogued, not fixed
+
+**F2 — Race in `redeemActionToken` (`lib/notify/action-tokens.ts:139-188`).**
+The `loadActionToken` → `UPDATE` pair is non-transactional. Two
+concurrent clicks on the same snooze link could both observe
+`redeemed_at = null` and both invoke `applySnooze`. In practice this is
+benign because every side-effect function is idempotent: snooze takes
+`max(current, candidate)`, pause sets a fixed indefinite timestamp,
+unsubscribe filters by `(type, target)`, feedback uses
+`INSERT ... ON CONFLICT DO UPDATE`. Worth tightening to a single SQL
+`UPDATE ... WHERE redeemed_at IS NULL RETURNING ...` if we ever add a
+non-idempotent side effect, but no current code path is at risk.
+
+**F3 — Tokens land in Vercel access logs.**
+URL-bearer tokens are by construction logged wherever the platform logs
+request URLs. Standard practice for magic-link / one-click systems
+(Stripe, Substack, Resend itself). Mitigations already in place: short
+TTL, idempotent redemption, `Cache-Control: no-store` on responses.
+Structural — would need to migrate to header-bearer tokens (breaks the
+GET-from-email model) or to single-use POST-with-confirmation (worse
+UX). Not worth it at current threat model. Document in a future ADR if
+we ever ship to a tenant whose log-access policy is weaker than
+Vercel's.
+
+**F4 — Dead-row growth (`aoi_briefs.share_token`, `notify_action_tokens`).**
+Expired share tokens are nulled out only when the user revokes via
+`clearBriefShareToken` (`lib/db/aoi-repository.ts:660`). An expired
+share token row stays `NOT NULL` with `share_expires_at < now()`
+forever; `getBriefByShareToken` rejects it but the column squats on the
+unique index. Same for `notify_action_tokens` — no purge job. At
+current scale (one user, hundreds of briefs / month) this is invisible.
+At 10k users it would be a few hundred MB of dead tokens per year, no
+correctness risk. Future cleanup: a daily cron that nulls
+`share_token` / `share_expires_at` for `share_expires_at < now() - 7d`
+and deletes `notify_action_tokens` rows with `expires_at < now() - 7d`.
+
+**F5 — Rate limiting (out of scope per audit hard rules).**
+None of the five endpoints have rate limits. Brute-forcing a 256-bit
+hex token is not feasible (~2^256 search space), and Vercel's edge
+network applies coarse abuse limits, but a per-IP / per-token-prefix
+rate limit on the `/api/notify/*` routes would be cheap defence in
+depth. Track as a Stage-8+ candidate — probably belongs alongside
+whatever observability we add for misuse.
+
+**F6 — `feedback` action, dual-purpose `redeemed_value`.**
+By design (`action-tokens.ts:170-186`), a recipient can flip yes ↔ no
+indefinitely until token expiry (90d). This is intentional per the code
+comment ("for `feedback` we DO want the second click to flip"). Worth
+flagging because it means a single feedback token observed in transit
+can be flipped by a network attacker; the row in `brief_feedback` is
+not authentication-bound. Acceptable for product-quality telemetry,
+not acceptable if we ever start using feedback as a trust signal in
+ranking.
+
+## Verified clean
+
+- **Token entropy**: 32 bytes from `node:crypto.randomBytes`, hex-encoded.
+  256 bits, suitable for bearer-secret use without hashing.
+- **String-comparison timing**: equality is DB-side on a unique-indexed
+  column, no app-side `===` on hashed material.
+- **Cross-AOI / confused deputy**: `applySnooze`/`applyPause`/
+  `applyUnsubscribe`/`applyFeedback` all key off `loaded.aoiId` from the
+  token row, never from URL params.
+- **HTML escaping**: `escapeHtml` covers `& < > " '`. Render paths only
+  inject AOI ids and a static title/body — no untrusted user content
+  goes in.
+- **CORS**: no explicit headers; Next.js default same-origin policy.
+  Endpoints are GET-with-bearer-secret, no credentials-required cookies,
+  so cross-origin reads are harmless even if they happened.
+- **Public share page (`app/brief/share/[token]/page.tsx`)** uses
+  `renderMarkdownToHtml` on `brief.renderedMarkdown`. The markdown is
+  AI-generated from a system prompt + structured Zod payload, not from
+  user input. If we ever let users edit briefs before sharing, audit
+  the markdown renderer for XSS.
+
+## Hard rules respected
+
+- No change to token entropy or hashing.
+- No rate limiting added.
+- No existing tests broken.
+- Diff < 50 LOC.


### PR DESCRIPTION
agent: scout

Audit of the five public token-bearer endpoints (Stage 6 share + Stage 7 notify actions) found one concrete fix worth shipping plus five lower-priority catalogued findings.

## Shipped — F1: opaque 404 on notify-action redemption failures

The notify-action handler distinguished missing / wrong-action / expired tokens with different status codes and bodies, giving an attacker who possessed a valid token an oracle for which action it was bound to. Collapse all redemption failures to a single 404 with an opaque message.

Worst case if it ships: a recipient who clicks an expired link sees \"Link not found\" instead of \"Link expired\" — slightly less helpful copy, recoverable by opening the dashboard (linked in the same response). Existing tests don't assert specific status codes for these failure paths.

Modified \`app/api/notify/_lib/handle.ts\` (~15 LOC net).

## Catalogued — \`pm/research-log/2026-05-07-token-endpoint-security-audit.md\`

- **F2** — non-transactional load+update race in \`redeemActionToken\` (currently benign — every side effect is idempotent).
- **F3** — bearer tokens in URL paths land in Vercel access logs (structural for magic-link systems; mitigated by short TTL + idempotency).
- **F4** — expired share tokens and \`notify_action_tokens\` rows never purged; future cron candidate.
- **F5** — no rate limiting (out of scope per audit hard rules).
- **F6** — \`feedback\` allows infinite yes↔no flips for 90d (fine for telemetry, would not be fine if used as a trust signal).

## Verified clean

- Token entropy: 256-bit \`crypto.randomBytes\`.
- No app-side string-comparison timing channel.
- No cross-AOI confused deputy (side effects key off \`loaded.aoiId\` not URL params).
- HTML escaping covers relevant chars.
- No surprising CORS.
- Share page only renders AI-generated markdown.

## Verification

- typecheck / lint clean
- test: 244 passed / 17 skipped
- build clean