### PR TITLE
chore(a11y): complete tablist pattern + interpolate AOI name into map label

### DIFF
--- a/app/dashboard/_components/aoi-map.tsx
+++ b/app/dashboard/_components/aoi-map.tsx
@@ -38,6 +38,7 @@ type DetectionPoint = {
 export type AoiMapProps =
   | {
       mode: "view";
+      name?: string;
       polygon: GeoJSONPolygon | GeoJSONMultiPolygon;
       bbox: GeoJSONPolygon;
       centroid: GeoJSONPoint;
@@ -107,11 +108,18 @@ export function AoiMap(props: AoiMapProps): React.ReactElement {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const ariaLabel =
+    props.mode === "view"
+      ? `Map of AOI ${props.name ?? "(unnamed)"}, polygon outlined, recent fire detections plotted`
+      : "Map for drawing an AOI polygon; click to add vertices, double-click to finish";
+
   return (
     <div className="w-full">
       <div
         ref={containerRef}
         data-testid="aoi-map-container"
+        role="img"
+        aria-label={ariaLabel}
         className="h-[420px] w-full rounded border border-[color:var(--muted)]"
         style={{ minHeight: 320 }}
       />

--- a/app/dashboard/aoi/[id]/page.tsx
+++ b/app/dashboard/aoi/[id]/page.tsx
@@ -68,6 +68,7 @@ export default async function AoiPage({ params }: Params) {
         <div className="mt-4">
           <AoiMapClient
             mode="view"
+            name={aoi.name}
             polygon={aoi.polygon}
             bbox={aoi.bbox}
             centroid={aoi.centroid}

--- a/app/dashboard/aoi/new/page.tsx
+++ b/app/dashboard/aoi/new/page.tsx
@@ -5,7 +5,7 @@
 
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 const AoiMap = dynamic(
   () => import("../../_components/aoi-map").then((m) => m.AoiMap),
@@ -14,9 +14,28 @@ const AoiMap = dynamic(
 
 type Tab = "upload" | "paste" | "draw";
 
+const TAB_ORDER: Tab[] = ["paste", "upload", "draw"];
+
 export default function NewAoiPage() {
   const router = useRouter();
   const [tab, setTab] = useState<Tab>("paste");
+  const tabRefs = useRef<Record<Tab, HTMLButtonElement | null>>({
+    paste: null,
+    upload: null,
+    draw: null,
+  });
+
+  function onTabKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+    e.preventDefault();
+    const idx = TAB_ORDER.indexOf(tab);
+    const next =
+      e.key === "ArrowRight"
+        ? TAB_ORDER[(idx + 1) % TAB_ORDER.length]
+        : TAB_ORDER[(idx - 1 + TAB_ORDER.length) % TAB_ORDER.length];
+    setTab(next);
+    tabRefs.current[next]?.focus();
+  }
   const [name, setName] = useState("");
   const [json, setJson] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -75,9 +94,22 @@ export default function NewAoiPage() {
   return (
     <div className="max-w-2xl">
       <h1 className="text-xl font-medium">Create AOI</h1>
-      <div className="mt-4 flex gap-2 text-sm">
+      <div
+        role="tablist"
+        aria-label="AOI input method"
+        onKeyDown={onTabKeyDown}
+        className="mt-4 flex gap-2 text-sm"
+      >
         <button
           type="button"
+          role="tab"
+          id="tab-paste"
+          aria-controls="panel-paste"
+          aria-selected={tab === "paste"}
+          tabIndex={tab === "paste" ? 0 : -1}
+          ref={(el) => {
+            tabRefs.current.paste = el;
+          }}
           onClick={() => setTab("paste")}
           className={`rounded px-3 py-1 ${tab === "paste" ? "bg-[color:var(--accent)] text-white" : "border"}`}
         >
@@ -85,6 +117,14 @@ export default function NewAoiPage() {
         </button>
         <button
           type="button"
+          role="tab"
+          id="tab-upload"
+          aria-controls="panel-upload"
+          aria-selected={tab === "upload"}
+          tabIndex={tab === "upload" ? 0 : -1}
+          ref={(el) => {
+            tabRefs.current.upload = el;
+          }}
           onClick={() => setTab("upload")}
           className={`rounded px-3 py-1 ${tab === "upload" ? "bg-[color:var(--accent)] text-white" : "border"}`}
         >
@@ -92,6 +132,14 @@ export default function NewAoiPage() {
         </button>
         <button
           type="button"
+          role="tab"
+          id="tab-draw"
+          aria-controls="panel-draw"
+          aria-selected={tab === "draw"}
+          tabIndex={tab === "draw" ? 0 : -1}
+          ref={(el) => {
+            tabRefs.current.draw = el;
+          }}
           onClick={() => setTab("draw")}
           className={`rounded px-3 py-1 ${tab === "draw" ? "bg-[color:var(--accent)] text-white" : "border"}`}
         >
@@ -100,7 +148,12 @@ export default function NewAoiPage() {
       </div>
 
       {tab === "draw" ? (
-        <div className="mt-6 flex flex-col gap-4">
+        <div
+          role="tabpanel"
+          id="panel-draw"
+          aria-labelledby="tab-draw"
+          className="mt-6 flex flex-col gap-4"
+        >
           <label className="flex flex-col gap-1 text-sm">
             <span>Name</span>
             <input
@@ -125,7 +178,13 @@ export default function NewAoiPage() {
           {busy ? <p className="text-sm">Creating…</p> : null}
         </div>
       ) : (
-        <form className="mt-6 flex flex-col gap-4" onSubmit={submit}>
+        <form
+          role="tabpanel"
+          id={tab === "paste" ? "panel-paste" : "panel-upload"}
+          aria-labelledby={tab === "paste" ? "tab-paste" : "tab-upload"}
+          className="mt-6 flex flex-col gap-4"
+          onSubmit={submit}
+        >
           <label className="flex flex-col gap-1 text-sm">
             <span>Name</span>
             <input


### PR DESCRIPTION
agent: scout

Reviewer follow-ups from PR #428: complete the partial tablist pattern on the AOI creation page and interpolate AOI name into the map aria-label so screen readers get specific context instead of generic placeholder.

## Changes

- \`app/dashboard/aoi/new/page.tsx\`: wired \`aria-controls\` / \`aria-labelledby\` / \`role=\"tabpanel\"\` between tabs and their content. Added roving tabindex and ArrowLeft/ArrowRight cycling with focus follow.
- \`app/dashboard/_components/aoi-map.tsx\`: added optional \`name\` prop and aria-label \"Map of AOI {name}, polygon outlined, recent fire detections plotted\" in view mode (\`role=\"img\"\` on container).
- \`app/dashboard/aoi/[id]/page.tsx\`: passes \`aoi.name\` through to the map.

## Risk

Worst case: ArrowLeft/Right handler intercepts arrow keys inside the tablist div. Scope is limited to the tab buttons themselves — form fields below are unaffected (handler is on the tablist \`<div>\`, not the page). Visual design unchanged.

## Notes

- Reviewer brief said the map already had an aria-label at line 117. Actually no aria-label existed in master — that was the closing \`/>\`. Added a new one with the reviewer's requested format. For draw-mode (where \`name\` isn't available), added a sensible label.
- The Paste and Upload tabs share a single \`<form>\` element. Made it the tabpanel for whichever of the two is active (id + aria-labelledby switch with the active tab). Draw is its own panel. Inactive panels unmounted — allowed ARIA pattern.

## Verification

- typecheck / lint clean
- test: 244 passed / 17 skipped (no regressions)
- build clean
- Diff: +72 / -4