### PR TITLE
chore(db): final 5 decodeRows callsites (closes the consolidation)

### DIFF
--- a/app/api/aoi/poll/route.ts
+++ b/app/api/aoi/poll/route.ts
@@ -27,6 +27,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 import { sql } from "drizzle-orm";
 import { tryGetDb, type AppDb } from "@/lib/db/client";
+import { decodeRows } from "@/lib/db/decode-rows";
 import { apiError, dbUnavailableResponse } from "@/lib/api/errors";
 import {
   fetchAreaCsv,
@@ -450,14 +451,12 @@ async function openJobRun(
   startedAtMs: number,
 ): Promise<string> {
   const startedAt = new Date(startedAtMs).toISOString();
-  const result = (await db.execute(sql`
+  const result = await db.execute(sql`
     INSERT INTO "job_runs" ("job_name", "bucket", "started_at", "status")
     VALUES (${jobName}, ${bucket}, ${startedAt}, 'running')
     RETURNING "id"
-  `)) as unknown as { rows?: Array<{ id: string | number | bigint }> };
-  const rows = (result.rows ?? (result as unknown as Array<{ id: string | number | bigint }>)) as Array<{
-    id: string | number | bigint;
-  }>;
+  `);
+  const rows = decodeRows<{ id: string | number | bigint }>(result);
   return String(rows[0]?.id ?? "");
 }
 

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -7,29 +7,23 @@ import { NextResponse } from "next/server";
 import { sql } from "drizzle-orm";
 import { withDb } from "@/lib/api/handlers";
 import { apiError } from "@/lib/api/errors";
+import { decodeRows } from "@/lib/db/decode-rows";
 
 export const runtime = "nodejs";
 
 export async function GET(): Promise<NextResponse> {
   return withDb(async ({ db, userId }) => {
-    const result = (await db.execute(sql`
+    const result = await db.execute(sql`
       SELECT "id", "email", "gemini_api_key_enc"
       FROM "users"
       WHERE "id" = ${userId}
       LIMIT 1
-    `)) as unknown as {
-      rows?: Array<{ id: string; email: string; gemini_api_key_enc: unknown }>;
-    };
-    const rows = (result.rows ??
-      (result as unknown as Array<{
-        id: string;
-        email: string;
-        gemini_api_key_enc: unknown;
-      }>)) as Array<{
+    `);
+    const rows = decodeRows<{
       id: string;
       email: string;
       gemini_api_key_enc: unknown;
-    }>;
+    }>(result);
     const row = rows[0];
     if (!row) return apiError("not_found", "User row missing");
     return NextResponse.json({

--- a/lib/db/freshness.ts
+++ b/lib/db/freshness.ts
@@ -12,6 +12,7 @@
  */
 import { sql } from "drizzle-orm";
 import type { AppDb } from "./client";
+import { decodeRows } from "./decode-rows";
 import type { FreshnessOutcome } from "@/lib/firms/freshness";
 
 export type AoiFreshness = {
@@ -29,7 +30,7 @@ export async function getAoiFreshness(
   db: AppDb,
   args: { aoiId: string; userId: string; now?: Date },
 ): Promise<AoiFreshness | null> {
-  const result = (await db.execute(sql`
+  const result = await db.execute(sql`
     SELECT
       a."region_bucket"     AS bucket,
       j."started_at"        AS started_at,
@@ -48,29 +49,14 @@ export async function getAoiFreshness(
     WHERE a."id" = ${args.aoiId}
       AND a."user_id" = ${args.userId}
     LIMIT 1
-  `)) as unknown as {
-    rows?: Array<{
-      bucket: string;
-      started_at: Date | string | null;
-      finished_at: Date | string | null;
-      outcome: string | null;
-      retry_pending: boolean | null;
-    }>;
-  };
-  const rows = (result.rows ??
-    (result as unknown as Array<{
-      bucket: string;
-      started_at: Date | string | null;
-      finished_at: Date | string | null;
-      outcome: string | null;
-      retry_pending: boolean | null;
-    }>)) as Array<{
+  `);
+  const rows = decodeRows<{
     bucket: string;
     started_at: Date | string | null;
     finished_at: Date | string | null;
     outcome: string | null;
     retry_pending: boolean | null;
-  }>;
+  }>(result);
   const row = rows[0];
   if (!row) return null;
 

--- a/lib/notify/action-tokens.ts
+++ b/lib/notify/action-tokens.ts
@@ -14,6 +14,7 @@
 import { randomBytes } from "node:crypto";
 import { sql } from "drizzle-orm";
 import type { AppDb } from "@/lib/db/client";
+import { decodeRows } from "@/lib/db/decode-rows";
 
 export type ActionKind = "snooze" | "pause" | "unsubscribe" | "feedback";
 
@@ -96,18 +97,15 @@ export async function loadActionToken(
   token: string,
 ): Promise<LoadedToken | null> {
   if (!token) return null;
-  const result = (await db.execute(sql`
+  const result = await db.execute(sql`
     SELECT
       "token", "aoi_id", "brief_id", "action", "channel", "target",
       "expires_at", "redeemed_at", "redeemed_value"
     FROM "notify_action_tokens"
     WHERE "token" = ${token}
     LIMIT 1
-  `)) as unknown as { rows?: Array<Record<string, unknown>> };
-  const rows = (result.rows ??
-    (result as unknown as Array<Record<string, unknown>>)) as Array<
-    Record<string, unknown>
-  >;
+  `);
+  const rows = decodeRows<Record<string, unknown>>(result);
   const row = rows[0];
   if (!row) return null;
   const expiresAt = toDate(row.expires_at);

--- a/lib/notify/actions.ts
+++ b/lib/notify/actions.ts
@@ -9,6 +9,7 @@
  */
 import { sql } from "drizzle-orm";
 import type { AppDb } from "@/lib/db/client";
+import { decodeRows } from "@/lib/db/decode-rows";
 import type { LoadedToken } from "./action-tokens";
 
 const SNOOZE_HOURS = 24;
@@ -22,25 +23,16 @@ async function readRules(
   db: AppDb,
   aoiId: string,
 ): Promise<{ pausedUntil: Date | null; channels: ChannelEntry[] } | null> {
-  const result = (await db.execute(sql`
+  const result = await db.execute(sql`
     SELECT "paused_until", "notify_channels"
     FROM "aoi_rules"
     WHERE "aoi_id" = ${aoiId}
     LIMIT 1
-  `)) as unknown as {
-    rows?: Array<{
-      paused_until: Date | string | null;
-      notify_channels: unknown;
-    }>;
-  };
-  const rows = (result.rows ??
-    (result as unknown as Array<{
-      paused_until: Date | string | null;
-      notify_channels: unknown;
-    }>)) as Array<{
+  `);
+  const rows = decodeRows<{
     paused_until: Date | string | null;
     notify_channels: unknown;
-  }>;
+  }>(result);
   const row = rows[0];
   if (!row) return null;
   const pausedUntil =


### PR DESCRIPTION
agent: scout

## What and why

Consolidate the final 5 \`decodeRows\` callsites flagged out-of-scope on PR #433. Same swap pattern: replace the inline \`(result.rows ?? (result as unknown as T[])) as T[]\` cast with \`decodeRows<T>(result)\` from \`@/lib/db/decode-rows\`.

After this lands, the entire repo's dual-backend row-unwrap is consolidated to a single helper. Total callsites now using \`decodeRows\`: 4 (PR #431) + 17 (PR #433) + 5 (this PR) = **26**.

## Callsites consolidated

- \`lib/notify/actions.ts\` — \`readRules\`
- \`lib/notify/action-tokens.ts\` — \`loadActionToken\`
- \`lib/db/freshness.ts\` — \`getAoiFreshness\`
- \`app/api/me/route.ts\` — \`GET\`
- \`app/api/aoi/poll/route.ts\` — \`openJobRun\`

Net **−31 lines**.

## Risk

Worst case: zero — pure refactor of an existing typed boundary already used at 21 other callsites in master. \`decodeRows\` returns \`[]\` on null/non-array shapes, which is observationally identical to the prior code's \`rows[0]\` returning \`undefined\`.

## Verification

- typecheck / lint / build clean
- test: 244 passed / 17 skipped (no delta vs master)