### PR TITLE
chore(test): silence pg pool error during testcontainer teardown

### DIFF
--- a/db/test/testcontainer.ts
+++ b/db/test/testcontainer.ts
@@ -113,6 +113,15 @@ export async function startPostgisContainer(): Promise<TestcontainerHandle> {
 
   const url = container.getConnectionUri();
   const pool = new Pool({ connectionString: url, max: 4 });
+  // Swallow pool-level 'error' events so a connection torn down by the
+  // container shutdown does not surface as a vitest unhandled error. The
+  // `pg` Pool emits 'error' on idle clients whose sockets die — when the
+  // postgres process inside the container stops, every still-open socket
+  // gets a 57P01 FATAL. We always drain the pool first (see `stop()`), but
+  // node-postgres can fire one last 'error' between `end()` resolving and
+  // the kernel closing the FD, which vitest then reports as an unhandled
+  // rejection. A no-op listener is the documented escape hatch.
+  pool.on("error", () => {});
   const migrations = await loadMigrations();
   await pool.query(migrations);
 
@@ -121,11 +130,26 @@ export async function startPostgisContainer(): Promise<TestcontainerHandle> {
   (db as { __backend: string }).__backend = "neon";
   (db as { usePostGIS: boolean }).usePostGIS = true;
 
+  let stopped = false;
   return {
     db,
     pool,
     stop: async () => {
-      await pool.end();
+      if (stopped) return;
+      stopped = true;
+      // Order matters: drain the pool *before* stopping the container so
+      // pg sends a clean termination per connection. If `pool.end()` itself
+      // throws (e.g. a query in flight), still try to stop the container so
+      // we don't leak Docker resources between test files.
+      try {
+        await pool.end();
+      } catch (err) {
+        console.warn(
+          `[integration] pool.end() failed during teardown: ${
+            err instanceof Error ? err.message.split("\n")[0] : String(err)
+          }`,
+        );
+      }
       await container.stop();
     },
   };


### PR DESCRIPTION
agent: scout

Silence the post-stop pg pool \`'error'\` event in the PostGIS testcontainer so vitest stops flagging the FATAL 57P01 emitted when \`container.stop()\` kills still-open sockets.

## Symptom

PR #434 CI: 259/259 tests passed but vitest reported 1 unhandled error from \`tests/poll-to-brief.integration.test.ts\`:
> error: terminating connection due to administrator command (PG 57P01)

## Root cause

\`db/test/testcontainer.ts\` already drained \`pool.end()\` before \`container.stop()\` — order was correct. The race is in node-postgres's \`Pool\`: it emits a final \`'error'\` event on idle clients whose sockets are killed by FATAL 57P01. With no listener, Node's EventEmitter treats it as unhandled, and vitest reports it as a test-run failure even though every test passed.

## Fix (path A from the brief)

In \`db/test/testcontainer.ts\`:
1. Attach a no-op \`pool.on('error', () => {})\` immediately after Pool construction (documented escape hatch).
2. Wrap \`pool.end()\` in try/catch so \`container.stop()\` always runs (no Docker leak).
3. Make \`stop()\` idempotent via a \`stopped\` flag.

Diff: +25 / -1, single file.

## Risk

Worst case: the no-op listener swallows an unrelated pool \`'error'\` during a healthy test run. **Real query errors still surface via the awaited promise rejection**, so test logic still fails on real bugs. Test-only harness; production \`lib/db/client.ts\` untouched.

## Verification

- typecheck / lint clean
- Local flake repro requires Docker; relying on CI to validate.