### PR TITLE
chore(docs): README — cover Stage 7-8 surface + all 6 subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Full thesis: [`pm/north-star.md`](pm/north-star.md). Pivot history: [`pm/decisio
 
 ## Status
 
-Post-pivot (Q2 2026). The pre-pivot stack (FastAPI + Vite + Redis) has been removed. The A' implementation — AOI CRUD, FIRMS polling, AI-Gateway brief generation, Resend dispatch, Clerk auth, rules UI / export — is on `master`.
+Post-pivot (Q2 2026). The pre-pivot stack (FastAPI + Vite + Redis) has been removed. The A' implementation — AOI CRUD, FIRMS polling, AI-Gateway brief generation with authority-perimeter (NIFC / CWFIS) context, Resend dispatch, Clerk auth, rules UI / export, and a MapLibre-based dashboard view of AOIs with detection overlay — is on `master`.
 
 Authoritative stage / backlog status: [`pm/backlog.md`](pm/backlog.md).
 
@@ -37,7 +37,16 @@ pnpm db:migrate
 
 ## How the project is run
 
-Solo-operated, with a Claude Code agent harness driving day-to-day work. The harness reads [`loop.md`](loop.md) each tick and dispatches to subagents in [`.claude/agents/`](.claude/agents/) (`pm`, `dev`, `reviewer`, `scout`). Stage PRs always require Vanyo's review; chores can auto-merge under the gate in `loop.md`.
+Solo-operated, with a Claude Code agent harness driving day-to-day work. The harness reads [`loop.md`](loop.md) each tick and dispatches to subagents in [`.claude/agents/`](.claude/agents/):
+
+- `pm` — owns the `pm/` workspace (briefs, backlog, blockers, ADR drafts, research-log condensation).
+- `dev` — implements one stage or chore per run on a dedicated branch.
+- `reviewer` — adversarial PR review against brief acceptance criteria; posts LGTM or BLOCKER.
+- `scout` — background chores (dead-code audit, dependency bumps, doc drift, link sweeps); capped at one PR per UTC day.
+- `cutover` — one-shot Phase 0 agent that landed the A' pivot on master; retired post-merge.
+- `product-reviewer` — high-level product critic on thesis fit, flow coherence, and feature scope.
+
+Stage PRs always require Vanyo's review; chores can auto-merge under the gate in `loop.md`.
 
 Doctrine for human + AI agents: [`AGENTS.md`](AGENTS.md), [`pm/PM_CLAUDE.md`](pm/PM_CLAUDE.md).
 


### PR DESCRIPTION
agent: scout

Cover the surface added by Stages 7-8 in the README prose summary (MapLibre AOI dashboard with detection overlay, authority-perimeter NIFC/CWFIS context in AI briefs) and expand the subagent list from 4 to all 6 agents (\`pm\`, \`dev\`, \`reviewer\`, \`scout\`, \`cutover\`, \`product-reviewer\`) with one-line roles drawn from each agent's front-matter description. Follow-up to PR #442's two flagged drift items.

## Stage 9 note

Stage 9 (watch-confirmed email + first-AOI backfill) is \`proposed\` per \`pm/backlog.md\` line 23 — even though it actually merged earlier today via PR #422 (\`86e34e2\`). The scout (correctly) didn't claim surface based on stale backlog state. **Backlog status fix queued as a separate chore.**

## Risk

Worst case: prose minor-drift if a future stage merges. Authoritative pointer (\`pm/backlog.md\`) remains canonical source.

## Verification

- typecheck / lint skip-ok (docs-only).
- Subagent list cross-checked against \`.claude/agents/*.md\` (6 files).
- Stage 7/8 surface confirmed via \`app/dashboard/_components/aoi-map*.tsx\` and \`lib/ai/authority/\`.
- Net +11 / -2.