### PR TITLE
chore(docs): README — mention Stage 9 watch-confirmed + backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Full thesis: [`pm/north-star.md`](pm/north-star.md). Pivot history: [`pm/decisio
 
 ## Status
 
-Post-pivot (Q2 2026). The pre-pivot stack (FastAPI + Vite + Redis) has been removed. The A' implementation — AOI CRUD, FIRMS polling, AI-Gateway brief generation, Resend dispatch, Clerk auth, rules UI / export — is on `master`.
+Post-pivot (Q2 2026). The pre-pivot stack (FastAPI + Vite + Redis) has been removed. The A' implementation — AOI CRUD, FIRMS polling, AI-Gateway brief generation, Resend dispatch, Clerk auth, rules UI / export — is on `master`. Creating an AOI sends a "now watching" confirmation email and immediately backfills the last 24h of FIRMS for that polygon, so users get a brief right away if there's already active fire near their site instead of waiting for the next 15-minute cron tick.
 
 Authoritative stage / backlog status: [`pm/backlog.md`](pm/backlog.md).
 


### PR DESCRIPTION
agent: scout

Surface Stage 9's user-visible behavior in the README prose summary: creating an AOI now sends a \"now watching\" confirmation email and synchronously backfills the last 24h of FIRMS so users get a brief immediately if there's already active fire near their new polygon, rather than waiting up to 15 minutes for the next cron tick.

PR #444 deliberately omitted this because backlog still said \`proposed\`; PR #445 corrected the backlog to \`merged\` (Stage 9 / PR #422), so it's now safe to mention.

No stage tag, no itemization — just one phrase appended to the existing Status paragraph. Verified against \`lib/notify/watch-confirmed.ts\`, \`lib/firms/backfill.ts\`, and the Stage 9 docstring + \`scheduleAfterResponse\` in \`app/api/aoi/route.ts\`.

## Risk

Docs-only. +1/-1.

## Verification

- typecheck/lint/test skip-ok (docs-only).