### PR TITLE
chore(firms): document fail-open contract on confidencePassesGate

### DIFF
--- a/lib/firms/matcher.ts
+++ b/lib/firms/matcher.ts
@@ -37,6 +37,27 @@ const MIN_CONFIDENCE_RANK: Record<string, number> = {
   h: 2,
 };
 
+/**
+ * Confidence gate for FIRMS detections.
+ *
+ * Today FIRMS confidence is one of two vocabularies: VIIRS letters
+ * ("l"/"n"/"h") or MODIS integers (0..100). Anything outside that dichotomy
+ * hits the unknown-token branch below.
+ *
+ * **Intentional fail-open contract**: unknown tokens are treated as
+ * "nominal", not dropped. Reasoning — for a stewardship product, silently
+ * dropping detections because NASA shipped a new vocabulary string is worse
+ * than admitting a marginal row past the `nominal` gate. The user can see
+ * and dismiss a borderline event; they cannot see one we never told them
+ * about.
+ *
+ * **Test contract**: `tests/firms-matcher-internals.test.ts` pins this
+ * behavior. If FIRMS introduces a new vocabulary that breaks the
+ * digit/letter dichotomy (e.g. mixed alphanumeric codes, new categorical
+ * labels), update BOTH this function AND that test together — extending
+ * the parser is the correct fix; making the test pass against the existing
+ * fail-open path is not.
+ */
 function confidencePassesGate(
   raw: string | null,
   aoiMin: string,
@@ -51,7 +72,8 @@ function confidencePassesGate(
   }
   const rank = MIN_CONFIDENCE_RANK[norm];
   if (rank == null) {
-    // Unknown token — fail open (count as "nominal") to avoid dropping data.
+    // Unknown token — fail open (count as "nominal"). See JSDoc above:
+    // changing this also requires updating firms-matcher-internals.test.ts.
     return (MIN_CONFIDENCE_RANK["nominal"] ?? 1) >= (MIN_CONFIDENCE_RANK[aoiMin] ?? 0);
   }
   return rank >= (MIN_CONFIDENCE_RANK[aoiMin] ?? 0);


### PR DESCRIPTION
agent: scout

Document the intentional fail-open contract on \`confidencePassesGate\`'s unknown-token branch, and flag the test-coupling so a future maintainer extending FIRMS' confidence vocabulary updates both the function and \`tests/firms-matcher-internals.test.ts\` together — rather than seeing the existing test pass and assuming the new vocabulary is handled.

Per PR #443 reviewer feedback. **Comment-only change.**

## What's added

- JSDoc above \`confidencePassesGate\` documenting:
  - Current FIRMS vocabularies (digit / letter dichotomy).
  - Intentional fail-open contract with stewardship-product reasoning (\"silent drop is worse than admitting a marginal row\").
  - Test-coupling at \`tests/firms-matcher-internals.test.ts\` with explicit \"update function + test together\" instruction.
- Short pointer comment in the unknown-token branch redirecting readers to the JSDoc.

## Risk

Zero behavioral risk (comment-only, no executable code touched). Only failure mode: comment goes stale if the function is later refactored without updating JSDoc — the in-branch pointer mitigates that.

## Verification

- Diff: +23/-1.
- typecheck/lint/test skip-ok per chore (zero executable change).