### PR TITLE
chore(tests): unit coverage for lib/share/ token + url (10 tests)

### DIFF
--- a/tests/share/token.test.ts
+++ b/tests/share/token.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { _setMintTokenForTest, mintShareToken } from "@/lib/share/token";
+
+describe("mintShareToken", () => {
+  afterEach(() => {
+    _setMintTokenForTest(null);
+  });
+
+  it("returns 64 lowercase hex chars (32 bytes) by default", () => {
+    const tok = mintShareToken();
+    expect(tok).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("produces unique tokens across many mints", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 1000; i++) seen.add(mintShareToken());
+    expect(seen.size).toBe(1000);
+  });
+
+  it("uses the test override when set, then restores real randomness on null", () => {
+    _setMintTokenForTest(() => "tok_fixed");
+    expect(mintShareToken()).toBe("tok_fixed");
+    expect(mintShareToken()).toBe("tok_fixed");
+
+    _setMintTokenForTest(null);
+    const real = mintShareToken();
+    expect(real).not.toBe("tok_fixed");
+    expect(real).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/tests/share/url.test.ts
+++ b/tests/share/url.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { notifyActionUrl, publicShareUrl } from "@/lib/share/url";
+
+describe("publicShareUrl", () => {
+  const original = process.env.NEXT_PUBLIC_APP_URL;
+  afterEach(() => {
+    if (original === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
+    else process.env.NEXT_PUBLIC_APP_URL = original;
+  });
+
+  it("returns a relative path when NEXT_PUBLIC_APP_URL is unset", () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    expect(publicShareUrl("abc")).toBe("/brief/share/abc");
+  });
+
+  it("strips a single trailing slash from the host", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://example.com/";
+    expect(publicShareUrl("abc")).toBe("https://example.com/brief/share/abc");
+  });
+
+  it("preserves a host with no trailing slash", () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://example.com";
+    expect(publicShareUrl("abc")).toBe("https://example.com/brief/share/abc");
+  });
+});
+
+describe("notifyActionUrl", () => {
+  const original = process.env.NEXT_PUBLIC_APP_URL;
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://example.com";
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
+    else process.env.NEXT_PUBLIC_APP_URL = original;
+  });
+
+  it("builds a bare action URL when no query is provided", () => {
+    expect(notifyActionUrl("snooze", "tok123")).toBe(
+      "https://example.com/api/notify/snooze/tok123",
+    );
+  });
+
+  it("treats an empty query object as no query", () => {
+    expect(notifyActionUrl("pause", "tok123", {})).toBe(
+      "https://example.com/api/notify/pause/tok123",
+    );
+  });
+
+  it("appends and URL-encodes query parameters", () => {
+    const url = notifyActionUrl("feedback", "tok123", {
+      rating: "thumbs up",
+      from: "a&b",
+    });
+    expect(url).toBe(
+      "https://example.com/api/notify/feedback/tok123?rating=thumbs+up&from=a%26b",
+    );
+  });
+
+  it("works for every action variant", () => {
+    for (const action of ["snooze", "pause", "unsubscribe", "feedback"] as const) {
+      expect(notifyActionUrl(action, "t")).toContain(`/api/notify/${action}/t`);
+    }
+  });
+});


### PR DESCRIPTION
agent: scout

Add unit coverage for \`lib/share/\` token mint and URL helpers — both modules had branches reachable only through the route handler.

## What changed

- **\`tests/share/url.test.ts\`** — covers \`publicShareUrl\` (relative fallback when \`NEXT_PUBLIC_APP_URL\` unset, trailing-slash strip) and \`notifyActionUrl\` (empty-query handling, URL-encoded params, all four action variants).
- **\`tests/share/token.test.ts\`** — verifies \`mintShareToken\` returns 64-char hex, produces 1000 unique tokens in a row, and the test-override toggle restores real randomness when cleared.

## Risk

Worst case: a flaky uniqueness assertion on absurdly bad CSPRNG. With 32 bytes of entropy, collision probability over 1000 mints is ~1e-72. Tests are pure (no DB, no network).

## Verification

- typecheck / lint clean
- test: 2 files / 10 tests pass
- Net +94 LOC, tests-only.