### PR TITLE
chore(tests): cover lib/auth/context placeholder email + idempotency (5 tests)

### DIFF
--- a/tests/auth/context.test.ts
+++ b/tests/auth/context.test.ts
@@ -5,7 +5,11 @@
  * the success/failure shapes the route handlers depend on.
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { _setTestAuth, requireUserId } from "@/lib/auth/context";
+import { sql } from "drizzle-orm";
+import { _setTestAuth, ensureUserExists, requireUserId } from "@/lib/auth/context";
+import { makeFreshTestDb } from "@/db/test/pglite";
+import type { AppDb } from "@/lib/db/client";
+import type { PGlite } from "@electric-sql/pglite";
 
 const SAVED_ENV = { ...process.env };
 
@@ -35,5 +39,84 @@ describe("requireUserId", () => {
     _setTestAuth(() => ({ ok: false, code: "unauthenticated" }));
     const r = await requireUserId();
     expect(r).toEqual({ ok: false, code: "unauthenticated" });
+  });
+
+  it("test injection short-circuits the env check even when CLERK_SECRET_KEY is set", async () => {
+    // Pins precedence: a stubbed resolver must win over the production path so
+    // tests never accidentally hit Clerk just because an env leaked into CI.
+    process.env.CLERK_SECRET_KEY = "sk_test_should_not_be_read";
+    _setTestAuth(() => ({ ok: true, userId: "user_precedence" }));
+    const r = await requireUserId();
+    expect(r).toEqual({ ok: true, userId: "user_precedence" });
+  });
+
+  it("awaits an async resolver (Promise<AuthResult>)", async () => {
+    // The TestAuthFn signature allows sync or async; production Clerk `auth()`
+    // is async, so the async branch must work end-to-end.
+    _setTestAuth(async () => {
+      await Promise.resolve();
+      return { ok: true, userId: "user_async" };
+    });
+    const r = await requireUserId();
+    expect(r).toEqual({ ok: true, userId: "user_async" });
+  });
+
+  it("clearing the test resolver with null restores the env-gated path", async () => {
+    _setTestAuth(() => ({ ok: true, userId: "user_will_be_cleared" }));
+    _setTestAuth(null);
+    delete process.env.CLERK_SECRET_KEY;
+    const r = await requireUserId();
+    expect(r).toEqual({ ok: false, code: "config_missing" });
+  });
+});
+
+describe("ensureUserExists", () => {
+  let db: AppDb;
+  let pglite: PGlite;
+
+  beforeEach(async () => {
+    ({ db, pglite } = await makeFreshTestDb());
+  });
+  afterEach(async () => {
+    await pglite.close();
+  });
+
+  it("inserts a row with the <userId>@pending.invalid placeholder email", async () => {
+    // The placeholder shape is load-bearing: the dispatcher special-cases
+    // `@pending.invalid` to skip with `no_recipient_pending`. Pin the contract
+    // here so a refactor of the placeholder format trips this test before it
+    // silently breaks notification gating.
+    await ensureUserExists(db, "user_2abcJIT");
+    const result = (await db.execute(
+      sql`SELECT id, email FROM users WHERE id = 'user_2abcJIT'`,
+    )) as unknown as { rows?: Array<{ id: string; email: string }> };
+    const rows = (result.rows ??
+      (result as unknown as Array<{ id: string; email: string }>)) as Array<{
+      id: string;
+      email: string;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].email).toBe("user_2abcJIT@pending.invalid");
+  });
+
+  it("is idempotent and does not overwrite an existing email on conflict", async () => {
+    // Webhook-then-JIT ordering: if `user.created` lands first with a real
+    // email, a follow-up authed request must not stomp it back to placeholder.
+    await db.execute(
+      sql`INSERT INTO users (id, email) VALUES ('user_existing', 'real@example.com')`,
+    );
+    await ensureUserExists(db, "user_existing");
+    await ensureUserExists(db, "user_existing");
+    const result = (await db.execute(
+      sql`SELECT email, count(*)::int AS c FROM users WHERE id = 'user_existing' GROUP BY email`,
+    )) as unknown as { rows?: Array<{ email: string; c: number }> };
+    const rows = (result.rows ??
+      (result as unknown as Array<{ email: string; c: number }>)) as Array<{
+      email: string;
+      c: number;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].email).toBe("real@example.com");
+    expect(rows[0].c).toBe(1);
   });
 });


### PR DESCRIPTION
agent: scout

Test-only coverage pass on \`lib/auth/context.ts\` — pins gaps the Stage 5 reviewer flagged that have so far only been inferred from dispatcher tests.

## What changed (5 new tests in existing file)

- **Placeholder email shape via \`ensureUserExists\`** — previously only verified by the dispatcher's \`no_recipient_pending\` skip path; now pinned directly.
- **Idempotency semantics**: a follow-up \`ensureUserExists\` after the Clerk webhook lands a real email **must not stomp it back to placeholder**.
- **Async \`TestAuthFn\` branch** (production \`auth()\` is async).
- **\`_setTestAuth\` precedence**: short-circuits even when \`CLERK_SECRET_KEY\` is set (CI safety).
- **\`_setTestAuth(null)\` restoration** — env-gated path resumes.

## What I deliberately didn't test

Brief mentioned \"concurrent calls caching.\" But \`requireUserId\` doesn't cache — each call re-runs \`auth()\`. That's a **Clerk SDK contract**, not ours. Testing it would be fabricating behavior.

## Risk

Tests-only. Worst case: a test is wrong and passes anyway, giving false confidence on placeholder handling. Mitigation: each test asserts a literal that would visibly diverge if production flips.

## Verification

- typecheck / lint clean
- test: 8/8 in \`tests/auth/context.test.ts\` pass
- Net +84/-1.