### PR TITLE
chore(tests): schema-driven JIT-INSERT NOT-NULL constraint test

### DIFF
--- a/tests/auth/context.test.ts
+++ b/tests/auth/context.test.ts
@@ -5,7 +5,9 @@
  * the success/failure shapes the route handlers depend on.
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { _setTestAuth, requireUserId } from "@/lib/auth/context";
+import { sql } from "drizzle-orm";
+import { _setTestAuth, ensureUserExists, requireUserId } from "@/lib/auth/context";
+import { makeFreshTestDb } from "@/db/test/pglite";
 
 const SAVED_ENV = { ...process.env };
 
@@ -35,5 +37,31 @@ describe("requireUserId", () => {
     _setTestAuth(() => ({ ok: false, code: "unauthenticated" }));
     const r = await requireUserId();
     expect(r).toEqual({ ok: false, code: "unauthenticated" });
+  });
+});
+
+describe("ensureUserExists JIT INSERT satisfies users NOT-NULL constraints", () => {
+  it("populates every NOT-NULL column without a DB default", async () => {
+    const { db, pglite } = await makeFreshTestDb();
+    try {
+      await ensureUserExists(db, "user_2abcSchemaDriven");
+      const colsRes = (await db.execute(sql`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'users' AND is_nullable = 'NO' AND column_default IS NULL
+      `)) as unknown as { rows?: Array<{ column_name: string }> };
+      const required = (colsRes.rows ?? (colsRes as unknown as Array<{ column_name: string }>))
+        .map((r) => r.column_name);
+      expect(required.length).toBeGreaterThan(0);
+      const rowRes = (await db.execute(
+        sql`SELECT * FROM users WHERE id = 'user_2abcSchemaDriven'`,
+      )) as unknown as { rows?: Array<Record<string, unknown>> };
+      const row = (rowRes.rows ?? (rowRes as unknown as Array<Record<string, unknown>>))[0];
+      expect(row).toBeDefined();
+      for (const col of required) {
+        expect(row[col], `JIT INSERT did not populate NOT-NULL column "${col}"`).not.toBeNull();
+      }
+    } finally {
+      await pglite.close();
+    }
   });
 });


### PR DESCRIPTION
agent: scout

## Summary

Adds a schema-driven test asserting \`ensureUserExists\` JIT INSERT populates every NOT-NULL column on \`users\` that lacks a DB default. Closes the reviewer gap on PR #451: the prior don't-stomp test only checked \`email\`, so a future migration adding a NOT-NULL-without-default column would silently break the JIT path at runtime.

The test queries \`information_schema.columns\` for the NOT-NULL-without-default set, runs \`ensureUserExists\`, and asserts each such column is non-null on the resulting row. **No hardcoded column list — the assertion grows with the schema.**

## Risk

Worst case: the new test is wrong about what counts as \"required\" and fails spuriously when an unrelated migration lands. Mitigated by the explicit \`information_schema\` filter (\`is_nullable='NO' AND column_default IS NULL\`), which is exactly the set the JIT path must cover.

## Verification

- typecheck clean
- test: 4/4 in \`tests/auth/context.test.ts\`; 20 pass + 1 skipped in \`tests/auth/\` overall, no regressions
- Net +29 LOC.