### PR TITLE
test(notify): relax h3 fallthrough assertion to toContain

### DIFF
--- a/tests/notify/markdown.test.ts
+++ b/tests/notify/markdown.test.ts
@@ -46,11 +46,12 @@ describe("renderMarkdownToHtml — structure", () => {
     expect(out).toBe("<p>This is <em>emphasised</em> inline.</p>");
   });
 
-  it("treats ### h3 as a paragraph (renderer only knows h1/h2)", () => {
+  it("doesn't crash on out-of-spec ### h3 input and preserves the text", () => {
     // `lib/ai/render.ts` only emits `#` and `## `, so deeper headings are
-    // out-of-spec input. Pin current behavior: `### foo` becomes a paragraph
-    // containing the literal `### foo` text.
+    // out-of-spec input. Assert the heading text survives the render without
+    // pinning the specific fallthrough markup — a future contributor adding
+    // real h3 support shouldn't have to delete this test.
     const out = renderMarkdownToHtml("### Subsection");
-    expect(out).toBe("<p>### Subsection</p>");
+    expect(out).toContain("Subsection");
   });
 });


### PR DESCRIPTION
agent: scout

Follow-up to PR #455 reviewer flag. The \`### h3\` fallthrough test was asserting \`toBe(\"<p>### Subsection</p>\")\`, which silently locks out any future legitimate h3 rendering — a contributor adding h3 support would have to delete the assertion rather than update it.

Switched to \`expect(out).toContain(\"Subsection\")\` and rewrote the inline comment to frame the test as \"doesn't crash on out-of-spec headings, text preserved\" rather than \"specifically renders as paragraph.\"

XSS-significant guarantees (text survives, no raw HTML injected) are still covered by the three tests in the \"XSS surface\" describe block above.

## Risk

Worst case: stops detecting a regression where the renderer drops out-of-spec h3 input entirely (returns empty string). Today's paragraph fallthrough would no longer be pinned — but that's the point. Prior assertion conflated \"must not crash\" with \"must render exactly this way\"; the latter was never a real contract.

## Verification

- test: 7/7 in `tests/notify/markdown.test.ts` pass
- +5/-4 LOC