### PR TITLE
chore(tests): close 4 coverage gaps in firms freshness + prune

### DIFF
--- a/tests/firms-prune.test.ts
+++ b/tests/firms-prune.test.ts
@@ -78,6 +78,40 @@ describe("pruneOldDetections — PGlite", () => {
     expect(removed).toBe(0);
   });
 
+  it("honours custom retentionDays override", async () => {
+    // Pins the retentionDays knob: if a future caller wants a tighter window
+    // (e.g. for a free-tier emergency squeeze) the parameter must work, not
+    // be silently ignored in favour of the 14-day default.
+    const now = new Date("2026-04-21T00:00:00Z");
+    await insertDetection(db, {
+      detectedAt: new Date(now.getTime() - 10 * 86400_000).toISOString(),
+      lat: 1, lon: 1,
+    });
+    await insertDetection(db, {
+      detectedAt: new Date(now.getTime() - 3 * 86400_000).toISOString(),
+      lat: 2, lon: 2,
+    });
+    expect(await countDetections(db)).toBe(2);
+    const removed = await pruneOldDetections(db, { now, retentionDays: 7 });
+    expect(removed).toBe(1);
+    expect(await countDetections(db)).toBe(1);
+  });
+
+  it("uses strict `<` cutoff: a row exactly at the boundary is kept", async () => {
+    // Pins the boundary behaviour. The SQL says `detected_at < cutoff`, so a
+    // row whose detected_at equals (now - 14d) to the millisecond must NOT be
+    // deleted. If anyone flips this to `<=` they'll fail this test.
+    const now = new Date("2026-04-21T00:00:00Z");
+    const exactCutoff = new Date(now.getTime() - 14 * 86400_000);
+    await insertDetection(db, {
+      detectedAt: exactCutoff.toISOString(),
+      lat: 1, lon: 1,
+    });
+    const removed = await pruneOldDetections(db, { now });
+    expect(removed).toBe(0);
+    expect(await countDetections(db)).toBe(1);
+  });
+
   it("does not touch aoi_events or aoi_briefs", async () => {
     const userId = "u-prune";
     await db.execute(sql`INSERT INTO "users" (id, email) VALUES (${userId}, 'x@x')`);

--- a/tests/firms/freshness.test.ts
+++ b/tests/firms/freshness.test.ts
@@ -54,4 +54,33 @@ describe("runStatusToOutcome", () => {
       retryPending: true,
     });
   });
+  it("status=error with null/undefined/empty error → network_error, retry (defensive default)", () => {
+    // The matcher writes `error: null` when status='error' came from a path that
+    // didn't capture an Error.message (e.g. a thrown non-Error object). The
+    // banner must still show *something* actionable rather than crashing.
+    expect(runStatusToOutcome({ status: "error", error: null })).toEqual({
+      outcome: "network_error",
+      retryPending: true,
+    });
+    expect(runStatusToOutcome({ status: "error", error: undefined })).toEqual({
+      outcome: "network_error",
+      retryPending: true,
+    });
+    expect(runStatusToOutcome({ status: "error" })).toEqual({
+      outcome: "network_error",
+      retryPending: true,
+    });
+    expect(runStatusToOutcome({ status: "error", error: "" })).toEqual({
+      outcome: "network_error",
+      retryPending: true,
+    });
+  });
+  it("status=error with case-variant timeout strings → timeout (regex /i flag)", () => {
+    // Documents that the AbortError|timeout match is case-insensitive — the
+    // matcher captures `error.name + ': ' + error.message`, and casing varies
+    // across runtime polyfills (Node vs undici vs Vercel edge).
+    expect(runStatusToOutcome({ status: "error", error: "aborterror" }).outcome).toBe("timeout");
+    expect(runStatusToOutcome({ status: "error", error: "Request TIMEOUT after 30s" }).outcome).toBe("timeout");
+    expect(runStatusToOutcome({ status: "error", error: "fetch timeout" }).outcome).toBe("timeout");
+  });
 });


### PR DESCRIPTION
agent: scout

Close 4 coverage gaps in \`lib/firms/freshness.ts\` and \`lib/firms/prune.ts\` so contract-shaped behavior stops being implicit.

## What changed

**\`tests/firms/freshness.test.ts\` (+29 LOC, 2 new blocks):**
- \`runStatusToOutcome\` with null/undefined/missing/empty \`error\` field pinned to \`network_error + retry\` (defensive default — matcher writes null when status='error' lacks \`Error.message\`).
- Case-insensitive regex match for \`AbortError|timeout\` exercised across three case variants (the \`/i\` flag is load-bearing across runtime polyfills — Node vs undici vs Vercel edge).

**\`tests/firms-prune.test.ts\` (+34 LOC, 2 new):**
- Custom \`retentionDays\` parameter actually honored (was an unverified knob).
- Strict \`<\` cutoff semantics — a row at exactly \`(now - 14d)\` is kept. Locks contract against accidental flip to \`<=\`.

## Risk

Tests-only. Worst case: a new assertion is wrong (asserts current behavior instead of intended behavior). Each new assertion was reviewed against existing implementation; inline rationale documents intent.

## Verification

- typecheck / lint clean
- test: 14/14 pass (was 10)
- Net +63 LOC.