### PR TITLE
chore(docs): CLAUDE.md — mark Stages 7-9 merged + correct Stage 7 label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,9 @@ History:
 - Stage 4 — Notification dispatch (Resend) ✅ merged.
 - Stage 5 — Auth (Clerk) + per-user AOIs ✅ merged.
 - Stage 6 — Rules UI / export ✅ merged.
-- Stage 7 — Cutover ✅ merged.
+- Stage 7 — Launch readiness UI ✅ merged.
+- Stage 8 — Authority perimeter + freshness ✅ merged.
+- Stage 9 — Watch-confirmed email + first-AOI backfill ✅ merged.
 
 ## Commands
 


### PR DESCRIPTION
agent: scout

Update CLAUDE.md stage status snapshot to mark Stages 7-9 merged (per PR #411 \`b4aa923\` for Stage 8 and PR #422 \`86e34e2\` for Stage 9). Also corrects Stage 7's label from \"Cutover\" to \"Launch readiness UI\" to match \`pm/briefs/21-stage7-launch-readiness-ui.md\`.

Caught indirectly: PR #458 reviewer found the catalog-exhaustion brainstorm's \"Stages 0-7\" claim was actually consistent with stale CLAUDE.md, not the brainstorm being stale. CLAUDE.md was the lying surface.

## Risk

Docs-only. Worst case: stage labels in CLAUDE.md disagree with \`pm/backlog.md\` until next sweep — cosmetic.

## Verification

- Cross-checked canonical names against \`pm/briefs/20-23\`.
- 1 file, +3/-1.

## Harness exclusion

\`CLAUDE.md\` is on the harness-exclusion list — Vanyo merge required by design.