### PR TITLE
fix(firms): redact MAP_KEY from upstream error messages

### DIFF
--- a/lib/firms/client.ts
+++ b/lib/firms/client.ts
@@ -211,11 +211,12 @@ export async function fetchAreaCsv(
     }
     if (!response.ok) {
       const text = await safeText(response);
+      const safeBody = redactKey(text, key).slice(0, 200);
       return {
         ok: false,
         code: "upstream_error",
         status: response.status,
-        message: `FIRMS responded ${response.status}: ${text.slice(0, 200)}`,
+        message: `FIRMS responded ${response.status}: ${safeBody}`,
       };
     }
     const csv = await safeText(response);
@@ -226,6 +227,14 @@ export async function fetchAreaCsv(
     code: "upstream_error",
     message: "FIRMS request failed after 3 attempts",
   };
+}
+
+function redactKey(body: string, key: string): string {
+  if (!key) return body;
+  const encoded = encodeURIComponent(key);
+  let out = body.split(key).join("[REDACTED]");
+  if (encoded !== key) out = out.split(encoded).join("[REDACTED]");
+  return out;
 }
 
 async function safeText(res: Response): Promise<string> {

--- a/tests/firms-client.test.ts
+++ b/tests/firms-client.test.ts
@@ -172,6 +172,22 @@ describe("fetchAreaCsv", () => {
     expect(r.code).toBe("rate_limited");
   });
 
+  it("redacts FIRMS_MAP_KEY from 4xx error messages", async () => {
+    const key = "super-secret-map-key-abc123";
+    process.env.FIRMS_MAP_KEY = key;
+    const stubFetch = async (url: string): Promise<Response> =>
+      new Response(`Forbidden for url ${String(url)}`, { status: 403 });
+    const r = await fetchAreaCsv({
+      source: "VIIRS_NOAA20_NRT",
+      bbox: SONOMA_BBOX,
+      fetchImpl: stubFetch as unknown as typeof fetch,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.message).not.toContain(key);
+    expect(r.message).toContain("[REDACTED]");
+  });
+
   it("throttles locally when the token bucket is exhausted", async () => {
     const stubFetch = async (): Promise<Response> =>
       new Response("", { status: 200 });


### PR DESCRIPTION
agent: scout

Redact \`FIRMS_MAP_KEY\` from upstream error messages so the secret cannot leak into logs if FIRMS ever echoes the request URL inside a 4xx response body.

## What changed

- **\`lib/firms/client.ts\`**: new \`redactKey(body, key)\` helper that strips both the raw key AND \`encodeURIComponent(key)\` from the body before it's spliced into the \`upstream_error\` message. (URL-encoded variant matters because the request URL on line 167 carries the URL-encoded key.)
- **\`tests/firms-client.test.ts\`**: regression test — stub fetch returns 403 with body containing the literal MAP_KEY; asserts the resulting \`r.message\` contains \`[REDACTED]\` and does NOT contain the key.

## Risk

Worst case: a 4xx error message becomes slightly less informative when the response body happens to contain the literal \`[REDACTED]\` substring already. No control flow changes, no new failure modes.

Surfaced by PR #462 reviewer.

## Verification

- typecheck / lint clean
- test: 309 passed / 5 skipped (no regressions; new test passes)
- Diff: +26 / -1.